### PR TITLE
Variable トークンのフォーマット処理を実装

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { parse } from "./index.js";
+import { parse } from './index.js';
 
 const inputText = process.argv[2];
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -28,10 +28,12 @@ export function format(errorMessageCst: CstNode): Word[] {
     ...(sentenceNode?.children?.StaticMethodName ?? []),
   ];
   const docTags = sentenceNode?.children?.DocTag;
+  const variables = sentenceNode?.children?.Variable;
   const comma = sentenceNode?.children?.comma;
   const nodeLists = [
     { tokenType: 'function_name', nodes: functionNames },
     { tokenType: 'method_name', nodes: methodNames },
+    { tokenType: 'variable_name', nodes: variables },
     { tokenType: 'common_word', nodes: commonWords },
     { tokenType: 'doc_tag', nodes: docTags },
     { tokenType: 'comma', nodes: comma },

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -282,6 +282,97 @@ describe('test formatted results', () => {
     expect(result).toStrictEqual(expected);
   });
 
+  it('parse variable', () => {
+    const message =
+      'Parameter $a of anonymous function has unresolvable native type.';
+    const result = parse(message);
+
+    const expected = [
+      {
+        type: 'common_word',
+        value: 'Parameter',
+        location: {
+          startColumn: 0,
+          endColumn: 9,
+        },
+      },
+      {
+        type: 'variable_name',
+        value: '$a',
+        location: {
+          startColumn: 10,
+          endColumn: 12,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'of',
+        location: {
+          startColumn: 13,
+          endColumn: 15,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'anonymous',
+        location: {
+          startColumn: 16,
+          endColumn: 25,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'function',
+        location: {
+          startColumn: 26,
+          endColumn: 34,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'has',
+        location: {
+          startColumn: 35,
+          endColumn: 38,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'unresolvable',
+        location: {
+          startColumn: 39,
+          endColumn: 51,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'native',
+        location: {
+          startColumn: 52,
+          endColumn: 58,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'type',
+        location: {
+          startColumn: 59,
+          endColumn: 63,
+        },
+      },
+      {
+        type: 'period',
+        value: '.',
+        location: {
+          startColumn: 63,
+          endColumn: 64,
+        },
+      },
+    ];
+
+    expect(result).toStrictEqual(expected);
+  });
+
   it('parse static method', () => {
     const message =
       'Call to static method PHPStan\\Tests\\AssertionClass::assertInt() with int will always evaluate to true.';

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -6,10 +6,6 @@
     "declaration": false,
     "declarationMap": false
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "**/node_modules/**"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/node_modules/**"]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -6,13 +6,6 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": [
-    "src/index.ts",
-    "src/format.ts",
-    "src/parser.ts"
-  ],
-  "exclude": [
-    "src/cli.ts",
-    "**/node_modules/**"
-  ]
+  "include": ["src/index.ts", "src/format.ts", "src/parser.ts"],
+  "exclude": ["src/cli.ts", "**/node_modules/**"]
 }


### PR DESCRIPTION
## 概要

- `Variable` トークン (`$variable`) がパーサーで定義・消費されていたが、フォーマッターで処理されておらず出力から欠落していた問題を修正
- `format.ts` に `variable_name` 型としての処理を追加
- 変数を含むエラーメッセージのフォーマットテストを追加

## 変更内容

- **`src/format.ts`**: `Variable` ノードを CST から取得し、`variable_name` 型として `nodeLists` に追加
- **`test/format.spec.ts`**: `$a` を含む PHPStan エラーメッセージのフォーマットテストを追加
- **`src/cli.ts`, `tsconfig.*.json`**: フォーマッターによるコード整形

## テスト計画

- [x] 既存テスト含む全24テストが通過することを確認
- [x] `$a` を含むエラーメッセージが `variable_name` 型として正しくフォーマットされることを確認

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A