### PR TITLE
Add Number token for numeric values in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This is a JavaScript/TypeScript library that parses PHPStan error messages and e
   - Function names (including namespaced functions)
   - Method names (both static and instance methods)
   - Variable names
+  - Parameter numbers (`#1`, `#2`, ...)
+  - Numeric values (integers, negatives, decimals)
   - PHPDoc tags
   - Common words
 - Get location information (start/end columns) for each token
@@ -21,11 +23,12 @@ This is a JavaScript/TypeScript library that parses PHPStan error messages and e
 ## Tasks
 
 - [x] comma
+- [x] variable name (`$a`, `$foo`)
+- [x] error including parameter number (`#1`, `#2`, ...)
+- [x] number as a word (`-123`, `8.5`)
 - [ ] `->` ("Using nullsafe method call on non-nullable type Exception. Use -> instead.")
-- [ ] number as a word (`-123`, `8.5`)
 - [ ] number as a type (`array{1, 3}`)
-- [ ] error including parameter number(#1, #2, ...)
-- [ ] static keyword(`static::`)
+- [ ] static keyword (`static::`)
 - [ ] types
   - [ ] array types (`int[]`, `string[][]`)
   - [ ] array shapes (`array{key: value, ...}`, `array{0}`, `array{}`)
@@ -76,7 +79,7 @@ Parses a PHPStan error message and returns an array of structured word tokens.
 
 ```typescript
 type Word = {
-  type: "function_name" | "method_name" | "variable_name" | "doc_tag" | "common_word" | "period";
+  type: "function_name" | "method_name" | "variable_name" | "parameter_number" | "number" | "doc_tag" | "common_word" | "comma" | "period";
   value: string;
   location: {
     startColumn: number;
@@ -92,9 +95,11 @@ The parser can identify:
 - **Function names**: `Function format`, `Function abc\format` (with namespaces)
 - **Method names**: `Method formatString()`, `method getData`
 - **Variables**: `$variable`, `$user_name`
+- **Parameter numbers**: `#1`, `#2`, `#3`
+- **Numbers**: `1`, `-123`, `8.5`
 - **Doc tags**: `@param`, `@return`, `@var`
 - **Common words**: Regular words in the error message
-- **Punctuation**: Periods marking sentence endings
+- **Punctuation**: Commas and periods
 
 ## Development
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -7,6 +7,7 @@ export type Word = {
     | 'variable_name'
     | 'doc_tag'
     | 'parameter_number'
+    | 'number'
     | 'common_word'
     | 'comma'
     | 'period';
@@ -31,12 +32,14 @@ export function format(errorMessageCst: CstNode): Word[] {
   const docTags = sentenceNode?.children?.DocTag;
   const variables = sentenceNode?.children?.Variable;
   const parameterNumbers = sentenceNode?.children?.ParameterNumber;
+  const numbers = sentenceNode?.children?.Number;
   const comma = sentenceNode?.children?.comma;
   const nodeLists = [
     { tokenType: 'function_name', nodes: functionNames },
     { tokenType: 'method_name', nodes: methodNames },
     { tokenType: 'variable_name', nodes: variables },
     { tokenType: 'parameter_number', nodes: parameterNumbers },
+    { tokenType: 'number', nodes: numbers },
     { tokenType: 'common_word', nodes: commonWords },
     { tokenType: 'doc_tag', nodes: docTags },
     { tokenType: 'comma', nodes: comma },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -43,6 +43,11 @@ const tokens = {
     pattern: /#\d+/,
     line_breaks: false,
   }),
+  NUMBER: createToken({
+    name: 'Number',
+    pattern: /-?\d+(\.\d+)?/,
+    line_breaks: false,
+  }),
 };
 
 export const lexer = new Lexer(Object.values(tokens), {
@@ -65,6 +70,7 @@ export class Parser extends CstParser {
         { ALT: () => this.CONSUME(tokens.DOC_TAG) },
         { ALT: () => this.CONSUME(tokens.VARIABLE) },
         { ALT: () => this.CONSUME(tokens.PARAMETER_NUMBER) },
+        { ALT: () => this.CONSUME(tokens.NUMBER) },
         { ALT: () => this.CONSUME(tokens.COMMA) },
       ]);
     });

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -579,6 +579,137 @@ describe('test formatted results', () => {
     expect(result).toStrictEqual(expected);
   });
 
+  it('parse decimal number', () => {
+    const message =
+      'Attribute class Deprecated can be used with traits only on PHP 8.5 and later.';
+    const result = parse(message);
+
+    const expected = [
+      {
+        type: 'common_word',
+        value: 'Attribute',
+        location: {
+          startColumn: 0,
+          endColumn: 9,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'class',
+        location: {
+          startColumn: 10,
+          endColumn: 15,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'Deprecated',
+        location: {
+          startColumn: 16,
+          endColumn: 26,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'can',
+        location: {
+          startColumn: 27,
+          endColumn: 30,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'be',
+        location: {
+          startColumn: 31,
+          endColumn: 33,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'used',
+        location: {
+          startColumn: 34,
+          endColumn: 38,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'with',
+        location: {
+          startColumn: 39,
+          endColumn: 43,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'traits',
+        location: {
+          startColumn: 44,
+          endColumn: 50,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'only',
+        location: {
+          startColumn: 51,
+          endColumn: 55,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'on',
+        location: {
+          startColumn: 56,
+          endColumn: 58,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'PHP',
+        location: {
+          startColumn: 59,
+          endColumn: 62,
+        },
+      },
+      {
+        type: 'number',
+        value: '8.5',
+        location: {
+          startColumn: 63,
+          endColumn: 66,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'and',
+        location: {
+          startColumn: 67,
+          endColumn: 70,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'later',
+        location: {
+          startColumn: 71,
+          endColumn: 76,
+        },
+      },
+      {
+        type: 'period',
+        value: '.',
+        location: {
+          startColumn: 76,
+          endColumn: 77,
+        },
+      },
+    ];
+
+    expect(result).toStrictEqual(expected);
+  });
+
   it('parse static method', () => {
     const message =
       'Call to static method PHPStan\\Tests\\AssertionClass::assertInt() with int will always evaluate to true.';

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -488,6 +488,97 @@ describe('test formatted results', () => {
     expect(result).toStrictEqual(expected);
   });
 
+  it('parse number', () => {
+    const message =
+      'Method Test\\Foo::foo() invoked with 1 parameter, 0 required.';
+    const result = parse(message);
+
+    const expected = [
+      {
+        type: 'common_word',
+        value: 'Method',
+        location: {
+          startColumn: 0,
+          endColumn: 6,
+        },
+      },
+      {
+        type: 'method_name',
+        value: 'Test\\Foo::foo()',
+        location: {
+          startColumn: 7,
+          endColumn: 22,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'invoked',
+        location: {
+          startColumn: 23,
+          endColumn: 30,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'with',
+        location: {
+          startColumn: 31,
+          endColumn: 35,
+        },
+      },
+      {
+        type: 'number',
+        value: '1',
+        location: {
+          startColumn: 36,
+          endColumn: 37,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'parameter',
+        location: {
+          startColumn: 38,
+          endColumn: 47,
+        },
+      },
+      {
+        type: 'comma',
+        value: ',',
+        location: {
+          startColumn: 47,
+          endColumn: 48,
+        },
+      },
+      {
+        type: 'number',
+        value: '0',
+        location: {
+          startColumn: 49,
+          endColumn: 50,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'required',
+        location: {
+          startColumn: 51,
+          endColumn: 59,
+        },
+      },
+      {
+        type: 'period',
+        value: '.',
+        location: {
+          startColumn: 59,
+          endColumn: 60,
+        },
+      },
+    ];
+
+    expect(result).toStrictEqual(expected);
+  });
+
   it('parse static method', () => {
     const message =
       'Call to static method PHPStan\\Tests\\AssertionClass::assertInt() with int will always evaluate to true.';

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -85,6 +85,22 @@ describe('sample test', () => {
         ['Variable:$bar', true],
       ],
     },
+    {
+      name: 'parse number',
+      m: 'Method Test\\Foo::foo() invoked with 1 parameter, 0 required.',
+      assertions: [
+        ['Number:1', true],
+        ['Number:0', true],
+      ],
+    },
+    {
+      name: 'parse negative number',
+      m: 'Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (-1).',
+      assertions: [
+        ['Number:0', true],
+        ['Number:-1', true],
+      ],
+    },
   ] satisfies DataSet[];
 
   test.each(dataSet)('$name', ({ m, assertions }) => {

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -101,6 +101,13 @@ describe('sample test', () => {
         ['Number:-1', true],
       ],
     },
+    {
+      name: 'parse decimal number',
+      m: 'Attribute class Deprecated can be used with traits only on PHP 8.5 and later.',
+      assertions: [
+        ['Number:8.5', true],
+      ],
+    },
   ] satisfies DataSet[];
 
   test.each(dataSet)('$name', ({ m, assertions }) => {

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -104,9 +104,7 @@ describe('sample test', () => {
     {
       name: 'parse decimal number',
       m: 'Attribute class Deprecated can be used with traits only on PHP 8.5 and later.',
-      assertions: [
-        ['Number:8.5', true],
-      ],
+      assertions: [['Number:8.5', true]],
     },
   ] satisfies DataSet[];
 


### PR DESCRIPTION
## Summary

- Add `Number` token to parse numeric values in PHPStan error messages (integers, negative numbers, decimals)
- Pattern: `-?\d+(\.\d+)?` — matches `1`, `0`, `-1`, `8.5`, `-41`, `1.0`, etc.
- Add lexer, parser, and formatter support with the `number` type

## Test plan

- [x] All 29 tests pass
- [x] Parser test: `Method Test\Foo::foo() invoked with 1 parameter, 0 required.` — verifies `1` and `0` are parsed as `Number`
- [x] Parser test: `Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (-1).` — verifies `0` and `-1` are parsed as `Number`
- [x] Format test: verifies numeric tokens are output as `number` type with correct locations

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A