### PR TITLE
Add parentheses as tokens (lparen, rparen)

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -10,6 +10,8 @@ export type Word = {
     | 'number'
     | 'common_word'
     | 'comma'
+    | 'lparen'
+    | 'rparen'
     | 'period';
   value: string;
   location: {
@@ -43,6 +45,8 @@ export function format(errorMessageCst: CstNode): Word[] {
     { tokenType: 'common_word', nodes: commonWords },
     { tokenType: 'doc_tag', nodes: docTags },
     { tokenType: 'comma', nodes: comma },
+    { tokenType: 'lparen', nodes: sentenceNode?.children?.lparen },
+    { tokenType: 'rparen', nodes: sentenceNode?.children?.rparen },
     { tokenType: 'period', nodes: sentenceNode?.children?.period },
   ] as const;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -33,6 +33,8 @@ const tokens = {
   }),
   PERIOD: createToken({ name: 'period', pattern: '.', line_breaks: false }),
   COMMA: createToken({ name: 'comma', pattern: ',', line_breaks: false }),
+  LPAREN: createToken({ name: 'lparen', pattern: '(', line_breaks: false }),
+  RPAREN: createToken({ name: 'rparen', pattern: ')', line_breaks: false }),
   VARIABLE: createToken({
     name: 'Variable',
     pattern: /\$[a-z][\w]*/,
@@ -72,6 +74,8 @@ export class Parser extends CstParser {
         { ALT: () => this.CONSUME(tokens.PARAMETER_NUMBER) },
         { ALT: () => this.CONSUME(tokens.NUMBER) },
         { ALT: () => this.CONSUME(tokens.COMMA) },
+        { ALT: () => this.CONSUME(tokens.LPAREN) },
+        { ALT: () => this.CONSUME(tokens.RPAREN) },
       ]);
     });
     this.CONSUME(tokens.PERIOD);

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -710,6 +710,121 @@ describe('test formatted results', () => {
     expect(result).toStrictEqual(expected);
   });
 
+  it('parse parentheses with type annotation', () => {
+    const message =
+      'Parameter #1 (stdClass) of echo cannot be converted to string.';
+    const result = parse(message);
+
+    const expected = [
+      {
+        type: 'common_word',
+        value: 'Parameter',
+        location: {
+          startColumn: 0,
+          endColumn: 9,
+        },
+      },
+      {
+        type: 'parameter_number',
+        value: '#1',
+        location: {
+          startColumn: 10,
+          endColumn: 12,
+        },
+      },
+      {
+        type: 'lparen',
+        value: '(',
+        location: {
+          startColumn: 13,
+          endColumn: 14,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'stdClass',
+        location: {
+          startColumn: 14,
+          endColumn: 22,
+        },
+      },
+      {
+        type: 'rparen',
+        value: ')',
+        location: {
+          startColumn: 22,
+          endColumn: 23,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'of',
+        location: {
+          startColumn: 24,
+          endColumn: 26,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'echo',
+        location: {
+          startColumn: 27,
+          endColumn: 31,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'cannot',
+        location: {
+          startColumn: 32,
+          endColumn: 38,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'be',
+        location: {
+          startColumn: 39,
+          endColumn: 41,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'converted',
+        location: {
+          startColumn: 42,
+          endColumn: 51,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'to',
+        location: {
+          startColumn: 52,
+          endColumn: 54,
+        },
+      },
+      {
+        type: 'common_word',
+        value: 'string',
+        location: {
+          startColumn: 55,
+          endColumn: 61,
+        },
+      },
+      {
+        type: 'period',
+        value: '.',
+        location: {
+          startColumn: 61,
+          endColumn: 62,
+        },
+      },
+    ];
+
+    expect(result).toStrictEqual(expected);
+  });
+
   it('parse static method', () => {
     const message =
       'Call to static method PHPStan\\Tests\\AssertionClass::assertInt() with int will always evaluate to true.';

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -106,6 +106,39 @@ describe('sample test', () => {
       m: 'Attribute class Deprecated can be used with traits only on PHP 8.5 and later.',
       assertions: [['Number:8.5', true]],
     },
+    {
+      name: 'parse parentheses',
+      m: 'Parameter #1 (stdClass) of echo cannot be converted to string.',
+      assertions: [
+        ['lparen:(', true],
+        ['rparen:)', true],
+        ['CommonWord:stdClass', true],
+      ],
+    },
+    {
+      name: 'parentheses with type annotation are not structured - content is flat tokens',
+      m: 'Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (-1).',
+      assertions: [
+        ['lparen:(', true],
+        ['rparen:)', true],
+        ['Variable:$min', true],
+        ['Number:0', true],
+        ['Number:-1', true],
+        // type annotation inside parentheses is not grouped as a single structured node
+        ['ParameterNumber:#1', true],
+      ],
+    },
+    {
+      name: 'parentheses with complex type are not deeply parsed',
+      m: 'Parameter #1 (Closure(): void) of echo cannot be converted to string.',
+      assertions: [
+        ['lparen:(', true],
+        ['rparen:)', true],
+        // Closure(): void is split into flat tokens, not parsed as a callable type
+        ['CommonWord:Closure', true],
+        ['CommonWord:void', true],
+      ],
+    },
   ] satisfies DataSet[];
 
   test.each(dataSet)('$name', ({ m, assertions }) => {


### PR DESCRIPTION
## Summary

- Add `(` and `)` as `lparen` / `rparen` tokens so they appear in the output instead of being silently skipped
- This preserves location info for the VSCode extension to use when highlighting

## Design note

Content inside parentheses is currently flat-tokenized, not structurally parsed as type annotations. For example, `Parameter #1 (Closure(): void)` produces separate tokens for `Closure`, `()`, and `void` rather than a single callable type node. Structured parsing of type expressions inside parentheses is planned as a future improvement alongside the type parser.

Test cases are included to document this current limitation.

## Test plan

- [x] All 35 tests pass
- [x] Parser tests: parentheses are tokenized in `Parameter #1 (stdClass) of echo`
- [x] Parser tests: `$min (0)` content is flat tokens, not grouped
- [x] Parser tests: `(Closure(): void)` is not deeply parsed as a callable type
- [x] Format test: `lparen`/`rparen` tokens have correct location info
- [x] Biome check passes

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A