### PR TITLE
Add PHPStan error message collector and snapshot tests

### DIFF
--- a/.github/workflows/collect-errors.yml
+++ b/.github/workflows/collect-errors.yml
@@ -1,0 +1,94 @@
+name: Collect PHPStan Errors
+
+on:
+  workflow_dispatch:
+    inputs:
+      phpstan_branches:
+        description: 'PHPStan branches to collect from (comma-separated)'
+        required: true
+        default: '2.2.x'
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.34.1
+        with:
+          php-version: '8.3'
+          extensions: uopz
+          tools: composer
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Collect error messages
+        run: |
+          IFS=',' read -ra BRANCHES <<< "${{ inputs.phpstan_branches }}"
+          for BRANCH in "${BRANCHES[@]}"; do
+            BRANCH="$(echo "${BRANCH}" | xargs)"
+            echo "=========================================="
+            echo "  Collecting from branch: ${BRANCH}"
+            echo "=========================================="
+
+            SANITIZED_BRANCH="${BRANCH//\//-}"
+            PHPSTAN_DIR="/tmp/phpstan-src-${SANITIZED_BRANCH}"
+            OUTPUT_FILE="/tmp/phpstan-errors-${SANITIZED_BRANCH}.txt"
+
+            git clone --depth 1 --branch "${BRANCH}" \
+              https://github.com/phpstan/phpstan-src.git "${PHPSTAN_DIR}"
+
+            cd "${PHPSTAN_DIR}"
+            composer install --no-interaction --quiet
+
+            COLLECTOR_OUTPUT_FILE="${OUTPUT_FILE}" \
+            vendor/bin/phpunit \
+              --bootstrap "${{ github.workspace }}/collector/bootstrap-ci.php" \
+              --no-coverage \
+              --testsuite PHPStan \
+              2>/dev/null || true
+
+            cd "${{ github.workspace }}"
+
+            if [ -f "${OUTPUT_FILE}" ]; then
+              TOTAL=$(wc -l < "${OUTPUT_FILE}")
+              sort -u "${OUTPUT_FILE}" -o "${OUTPUT_FILE}"
+              UNIQUE=$(wc -l < "${OUTPUT_FILE}")
+              echo "Collected ${TOTAL} messages (${UNIQUE} unique) from ${BRANCH}"
+              cp "${OUTPUT_FILE}" "test/fixtures/phpstan-errors-${SANITIZED_BRANCH}.txt"
+            else
+              echo "ERROR: No error messages collected from ${BRANCH}"
+              exit 1
+            fi
+          done
+
+      - name: Update snapshots
+        run: npx vitest run --update
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add test/fixtures/phpstan-errors-*.txt test/__snapshots__/
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update PHPStan error messages and snapshots
+
+          Branches: ${{ inputs.phpstan_branches }}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -148,6 +148,27 @@ Function format  not  found.
 npm unlink -g phpstan-error-parser
 ```
 
+### Updating PHPStan Error Snapshots
+
+Snapshot tests parse real PHPStan error messages and track the results, so you can see exactly what changes when new tokens are added.
+
+**Via GitHub Actions (recommended):**
+
+1. Go to the **Actions** tab → **Collect PHPStan Errors**
+2. Click **Run workflow**
+3. Enter PHPStan branches (e.g., `2.2.x` or `2.0.x, 2.1.x, 2.2.x`)
+4. The workflow collects error messages, updates snapshots, and commits the results
+
+**Locally with Docker:**
+
+```bash
+# Collect error messages from phpstan-src
+cd collector && ./run.sh 2.2.x
+
+# Update snapshots
+npx vitest run --update
+```
+
 ## Project Structure
 
 ```
@@ -157,7 +178,10 @@ npm unlink -g phpstan-error-parser
 │   └── index.ts     # Main export
 ├── test/
 │   ├── parser.spec.ts
-│   └── format.spec.ts
+│   ├── format.spec.ts
+│   ├── snapshot.spec.ts # Snapshot tests for PHPStan error messages
+│   └── fixtures/        # Collected error messages (auto-generated)
+├── collector/           # PHPStan error message collector (Docker + uopz)
 └── package.json
 ```
 

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.3-cli
+
+RUN apt-get update && apt-get install -y git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pecl install uopz && docker-php-ext-enable uopz
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app

--- a/collector/bootstrap-ci.php
+++ b/collector/bootstrap-ci.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Bootstrap file for collecting PHPStan error messages in CI.
+ *
+ * Uses uopz to hook into RuleTestCase::analyse() and capture the expected
+ * error message strings without actually running PHPStan analysis.
+ *
+ * Unlike bootstrap.php (for Docker), this resolves phpstan-src path
+ * from the PHPSTAN_DIR environment variable or the current working directory.
+ */
+
+declare(strict_types=1);
+
+// Load the original bootstrap from phpstan-src (cwd is phpstan-src during phpunit run)
+require_once getcwd() . '/tests/bootstrap.php';
+
+$outputFile = getenv('COLLECTOR_OUTPUT_FILE') ?: '/tmp/phpstan-error-messages.txt';
+
+// Clear the output file
+file_put_contents($outputFile, '');
+
+// Hook into RuleTestCase::analyse() to capture expected error messages
+uopz_set_hook(
+    \PHPStan\Testing\RuleTestCase::class,
+    'analyse',
+    function (array $files, array $expectedErrors) use ($outputFile): void {
+        $messages = array_map(
+            fn(array $error): string => $error[0],
+            $expectedErrors,
+        );
+
+        if (count($messages) > 0) {
+            file_put_contents(
+                $outputFile,
+                implode("\n", $messages) . "\n",
+                FILE_APPEND,
+            );
+        }
+    },
+);
+
+// Skip the actual analysis by returning immediately
+uopz_set_return(
+    \PHPStan\Testing\RuleTestCase::class,
+    'analyse',
+    null,
+);

--- a/collector/bootstrap.php
+++ b/collector/bootstrap.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Bootstrap file for collecting PHPStan error messages from test suite.
+ *
+ * Uses uopz to hook into RuleTestCase::analyse() and capture the expected
+ * error message strings without actually running PHPStan analysis.
+ *
+ * Usage: Include this file via PHPUnit's --bootstrap option or phpunit.xml.
+ */
+
+declare(strict_types=1);
+
+// Load the original bootstrap first
+require_once __DIR__ . '/../phpstan-src/tests/bootstrap.php';
+
+$outputFile = getenv('COLLECTOR_OUTPUT_FILE') ?: '/tmp/phpstan-error-messages.txt';
+
+// Clear the output file
+file_put_contents($outputFile, '');
+
+// Hook into RuleTestCase::analyse() to capture expected error messages
+uopz_set_hook(
+    \PHPStan\Testing\RuleTestCase::class,
+    'analyse',
+    function (array $files, array $expectedErrors) use ($outputFile): void {
+        $messages = array_map(
+            fn(array $error): string => $error[0],
+            $expectedErrors,
+        );
+
+        if (count($messages) > 0) {
+            file_put_contents(
+                $outputFile,
+                implode("\n", $messages) . "\n",
+                FILE_APPEND,
+            );
+        }
+    },
+);
+
+// Skip the actual analysis by returning immediately
+uopz_set_return(
+    \PHPStan\Testing\RuleTestCase::class,
+    'analyse',
+    null,
+);

--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect PHPStan error messages from test suite using uopz.
+#
+# Usage:
+#   ./collect.sh [branch]
+#
+# Arguments:
+#   branch  - phpstan-src branch to collect from (default: 2.2.x)
+#
+# Output:
+#   ../test/fixtures/phpstan-errors-{branch}.txt
+
+BRANCH="${1:-2.2.x}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKDIR="/app"
+PHPSTAN_DIR="${WORKDIR}/phpstan-src"
+OUTPUT_FILE="/tmp/phpstan-error-messages.txt"
+SANITIZED_BRANCH="${BRANCH//\//-}"
+
+echo "==> Collecting error messages from phpstan-src branch: ${BRANCH}"
+
+# Clone or update phpstan-src
+if [ -d "${PHPSTAN_DIR}" ]; then
+    echo "==> Updating phpstan-src..."
+    cd "${PHPSTAN_DIR}"
+    git fetch origin "${BRANCH}"
+    git checkout "${BRANCH}"
+    git reset --hard "origin/${BRANCH}"
+else
+    echo "==> Cloning phpstan-src..."
+    git clone --depth 1 --branch "${BRANCH}" \
+        https://github.com/phpstan/phpstan-src.git "${PHPSTAN_DIR}"
+fi
+
+cd "${PHPSTAN_DIR}"
+
+echo "==> Installing dependencies..."
+composer install --no-interaction --quiet
+
+echo "==> Collecting error messages..."
+vendor/bin/phpunit \
+    --bootstrap "${WORKDIR}/collector/bootstrap.php" \
+    --no-coverage \
+    --testsuite PHPStan \
+    2>/dev/null || true
+
+# Sort and deduplicate
+if [ -f "${OUTPUT_FILE}" ]; then
+    TOTAL=$(wc -l < "${OUTPUT_FILE}")
+    sort -u "${OUTPUT_FILE}" -o "${OUTPUT_FILE}"
+    UNIQUE=$(wc -l < "${OUTPUT_FILE}")
+    echo "==> Collected ${TOTAL} messages (${UNIQUE} unique)"
+
+    DEST="${WORKDIR}/test/fixtures/phpstan-errors-${SANITIZED_BRANCH}.txt"
+    mkdir -p "$(dirname "${DEST}")"
+    cp "${OUTPUT_FILE}" "${DEST}"
+    echo "==> Output: ${DEST}"
+else
+    echo "==> ERROR: No error messages collected"
+    exit 1
+fi

--- a/collector/run.sh
+++ b/collector/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the error message collector in Docker.
+#
+# Usage:
+#   ./run.sh [branch...]
+#
+# Examples:
+#   ./run.sh                  # Collect from 2.2.x (default)
+#   ./run.sh 2.1.x 2.2.x     # Collect from multiple branches
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "${SCRIPT_DIR}")"
+
+BRANCHES=("${@:-2.2.x}")
+
+echo "==> Building Docker image..."
+docker build -t phpstan-error-collector "${SCRIPT_DIR}"
+
+for BRANCH in "${BRANCHES[@]}"; do
+    echo ""
+    echo "=========================================="
+    echo "  Collecting from branch: ${BRANCH}"
+    echo "=========================================="
+
+    docker run --rm \
+        -v "${PROJECT_DIR}:/app" \
+        phpstan-error-collector \
+        bash /app/collector/collect.sh "${BRANCH}"
+done
+
+echo ""
+echo "==> Done. Collected error messages:"
+ls -la "${PROJECT_DIR}/test/fixtures/phpstan-errors-"*.txt 2>/dev/null || echo "No files found"

--- a/test/fixtures/LICENSE-NOTICE
+++ b/test/fixtures/LICENSE-NOTICE
@@ -1,0 +1,25 @@
+The phpstan-errors-*.txt files in this directory contain error message strings
+extracted from the PHPStan test suite (https://github.com/phpstan/phpstan-src).
+
+PHPStan is licensed under the MIT License:
+
+  Copyright (c) 2016 Ondřej Mirtes
+  Copyright (c) 2025 PHPStan s.r.o.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.

--- a/test/snapshot.spec.ts
+++ b/test/snapshot.spec.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from '../src/index';
+
+const fixturesDir = join(__dirname, 'fixtures');
+
+function getErrorFiles(): string[] {
+  try {
+    return readdirSync(fixturesDir).filter((f) =>
+      f.startsWith('phpstan-errors-'),
+    );
+  } catch {
+    return [];
+  }
+}
+
+const errorFiles = getErrorFiles();
+
+describe.skipIf(errorFiles.length === 0)(
+  'snapshot: PHPStan error messages',
+  () => {
+    for (const file of errorFiles) {
+      describe(file, () => {
+        const filePath = join(fixturesDir, file);
+        const messages = readFileSync(filePath, 'utf-8')
+          .split('\n')
+          .filter((line) => line.length > 0);
+
+        it(`parses ${messages.length} messages and matches snapshot`, () => {
+          const results = messages.map((message) => ({
+            input: message,
+            tokens: parse(message),
+          }));
+
+          expect(results).toMatchSnapshot();
+        });
+      });
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Add tooling to collect error messages from phpstan-src test suite using Docker + uopz
- Add vitest snapshot tests to track parse results across token implementation changes

## How it works

### Collector (`collector/`)

Uses uopz PHP extension to hook into `RuleTestCase::analyse()` and capture expected error message strings without running actual PHPStan analysis:

- `Dockerfile`: PHP 8.3 + uopz + Composer
- `bootstrap.php`: `uopz_set_hook()` captures `$expectedErrors` argument, `uopz_set_return()` skips the analysis body for speed
- `collect.sh`: Clones phpstan-src, runs PHPUnit with custom bootstrap, deduplicates output
- `run.sh`: Docker wrapper supporting multiple branches

### Snapshot tests (`test/snapshot.spec.ts`)

- Parses all collected error messages and stores results as vitest snapshots
- When new tokens are added, snapshot diffs show exactly what changed
- Automatically skipped when no fixture files are present

## Usage

```bash
# Collect from one or more branches
cd collector && ./run.sh 2.2.x
cd collector && ./run.sh 2.0.x 2.1.x 2.2.x

# Generate/update snapshots
npx vitest run --update
```

## License

Error messages are extracted from phpstan-src (MIT License). Attribution is included in `test/fixtures/LICENSE-NOTICE`.

## Test plan

- [x] Existing 35 tests pass
- [x] Snapshot test skips gracefully when no fixture files exist
- [x] Biome check passes
- [ ] Verify Docker collector runs successfully (requires local Docker)

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A