### PR TITLE
Add PHPStan error message collector and snapshot tests

### DIFF
--- a/.github/workflows/collect-errors.yml
+++ b/.github/workflows/collect-errors.yml
@@ -50,6 +50,7 @@ jobs:
             OUTPUT_FILE="/tmp/phpstan-errors-${SANITIZED_BRANCH}.txt"
 
             git clone --depth 1 --branch "${BRANCH}" \
+              --filter=blob:none \
               https://github.com/phpstan/phpstan-src.git "${PHPSTAN_DIR}"
 
             cd "${PHPSTAN_DIR}"
@@ -59,7 +60,8 @@ jobs:
             vendor/bin/phpunit \
               --bootstrap "${{ github.workspace }}/collector/bootstrap-ci.php" \
               --no-coverage \
-              --testsuite PHPStan \
+              --dont-report-useless-tests \
+              tests/PHPStan/Rules/ \
               2>/dev/null || true
 
             cd "${{ github.workspace }}"

--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -31,6 +31,7 @@ if [ -d "${PHPSTAN_DIR}" ]; then
 else
     echo "==> Cloning phpstan-src..."
     git clone --depth 1 --branch "${BRANCH}" \
+        --filter=blob:none \
         https://github.com/phpstan/phpstan-src.git "${PHPSTAN_DIR}"
 fi
 
@@ -43,7 +44,8 @@ echo "==> Collecting error messages..."
 vendor/bin/phpunit \
     --bootstrap "${WORKDIR}/collector/bootstrap.php" \
     --no-coverage \
-    --testsuite PHPStan \
+    --dont-report-useless-tests \
+    tests/PHPStan/Rules/ \
     2>/dev/null || true
 
 # Sort and deduplicate


### PR DESCRIPTION
## Summary

Add tooling to collect error messages from phpstan-src test suite and snapshot tests to track parse results across token implementation changes.

### Collector (`collector/`)

Uses Docker + uopz PHP extension to hook into `RuleTestCase::analyse()` and capture expected error message strings without running actual PHPStan analysis.

- `bootstrap.php` / `bootstrap-ci.php`: `uopz_set_hook()` captures `$expectedErrors`, `uopz_set_return()` skips analysis for speed
- `collect.sh` + `run.sh`: Clone phpstan-src, run PHPUnit, deduplicate output (Docker)
- Only targets `tests/PHPStan/Rules/` where `analyse()` calls are concentrated

### CI Workflow (`.github/workflows/collect-errors.yml`)

Manual `workflow_dispatch` workflow:
1. Sets up PHP 8.3 + uopz via `shivammathur/setup-php`
2. Clones phpstan-src for specified branches (comma-separated, e.g., `2.0.x, 2.1.x, 2.2.x`)
3. Collects error messages (per-branch output: `phpstan-errors-{branch}.txt`)
4. Updates vitest snapshots
5. Commits and pushes results

### Snapshot tests (`test/snapshot.spec.ts`)

- Parses all collected error messages and stores results as vitest snapshots
- Snapshot diffs show exactly what changes when new tokens are added
- Automatically skipped when no fixture files are present

## License

Error messages are extracted from phpstan-src (MIT License). Attribution included in `test/fixtures/LICENSE-NOTICE`.

## Test plan

- [x] Existing 35 tests pass
- [x] Snapshot test skips gracefully when no fixture files exist
- [x] Biome check passes
- [ ] Verify CI workflow collects errors successfully (requires merge to main first)

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A