### PR TITLE
Allow collect-errors workflow to run on PRs via label

### DIFF
--- a/.github/workflows/collect-errors.yml
+++ b/.github/workflows/collect-errors.yml
@@ -7,18 +7,26 @@ on:
         description: 'PHPStan branches to collect from (comma-separated)'
         required: true
         default: '2.2.x'
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   collect:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'collect-errors')
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.34.1
@@ -38,7 +46,8 @@ jobs:
 
       - name: Collect error messages
         run: |
-          IFS=',' read -ra BRANCHES <<< "${{ inputs.phpstan_branches }}"
+          PHPSTAN_BRANCHES="${{ inputs.phpstan_branches || '2.2.x' }}"
+          IFS=',' read -ra BRANCHES <<< "${PHPSTAN_BRANCHES}"
           for BRANCH in "${BRANCHES[@]}"; do
             BRANCH="$(echo "${BRANCH}" | xargs)"
             echo "=========================================="
@@ -89,8 +98,9 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
+            PHPSTAN_BRANCHES="${{ inputs.phpstan_branches || '2.2.x' }}"
             git commit -m "chore: update PHPStan error messages and snapshots
 
-          Branches: ${{ inputs.phpstan_branches }}"
+          Branches: ${PHPSTAN_BRANCHES}"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -155,9 +155,14 @@ Snapshot tests parse real PHPStan error messages and track the results, so you c
 **Via GitHub Actions (recommended):**
 
 1. Go to the **Actions** tab → **Collect PHPStan Errors**
-2. Click **Run workflow**
-3. Enter PHPStan branches (e.g., `2.2.x` or `2.0.x, 2.1.x, 2.2.x`)
-4. The workflow collects error messages, updates snapshots, and commits the results
+2. Click **Run workflow**, select the target branch, and enter PHPStan branches
+3. The workflow collects error messages, updates snapshots, and commits the results
+
+**From a Pull Request:**
+
+1. Add the `collect-errors` label to the PR
+2. The workflow runs automatically, collecting errors and committing to the PR branch
+3. Defaults to PHPStan branch `2.2.x`
 
 **Locally with Docker:**
 

--- a/test/fixtures/phpstan-errors-2.2.x.txt
+++ b/test/fixtures/phpstan-errors-2.2.x.txt
@@ -1,0 +1,4587 @@
+$a (Yes): int
+$b (Yes): int
+$c (Maybe): 1
+$debug (Yes): bool
+$result (Yes): 'no matches!'
+- duplicate-class.php:10
+- duplicate-class.php:15
+- duplicate-class.php:20
+- duplicate-function.php:10
+- duplicate-function.php:15
+- duplicate-function.php:20
+2× doFoo, 2× doBar
+@readonly property Bug7361\Example::$foo is assigned outside of the constructor.
+@readonly property Feature11775\FooImmutable::$i is assigned outside of the constructor.
+@readonly property Feature11775\FooReadonly::$i is assigned outside of the constructor.
+@readonly property MissingReadOnlyPropertyAssignPhpDoc\C::$c is already assigned.
+@readonly property MissingReadOnlyPropertyAssignPhpDoc\Foo::$doubleAssigned is already assigned.
+@readonly property MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass::$doubleAssigned is already assigned.
+@readonly property MissingReadOnlyPropertyAssignPhpDoc\Immutable::$doubleAssigned is already assigned.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\A::$a is assigned by reference.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\B::$b is assigned by reference.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\C::$c is assigned by reference.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\Foo::$bar is assigned by reference.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\Foo::$foo is assigned by reference.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\Immutable::$bar is assigned by reference.
+@readonly property ReadOnlyPropertyAssignRefPhpDoc\Immutable::$foo is assigned by reference.
+@readonly property ReadonlyPropertyAssignPhpDoc\A::$a is assigned outside of its declaring class.
+@readonly property ReadonlyPropertyAssignPhpDoc\ArrayAccessPropertyFetch::$storage is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\B::$b is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\C::$c is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$bar is assigned outside of its declaring class.
+@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.
+@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$foo is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$phan is assigned outside of its declaring class.
+@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$phan is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$psalm is assigned outside of its declaring class.
+@readonly property ReadonlyPropertyAssignPhpDoc\FooArrays::$details is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\Immutable::$foo is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\ListAssign::$foo is assigned outside of the constructor.
+@readonly property ReadonlyPropertyAssignPhpDoc\NotThis::$foo is not assigned on $this.
+@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.
+@readonly property cannot have a default value.
+A class constant must not be called 'class'; it is reserved for class name fetching.
+Abstract class NonClassAttributeClass\Lorem cannot be an Attribute class.
+Access to an offset on an unknown class NonexistentOffset\Bar.
+Access to an undefined property AccessPropertiesAfterIsNull\Foo::$barProperty.
+Access to an undefined property AccessPropertiesDateIntervalChild\DateIntervalChild::$nonexistent.
+Access to an undefined property Bug11424\Bar|Bug11424\Foo::$i.
+Access to an undefined property Bug6385\ActualUnitEnum::$value.
+Access to an undefined property DynamicProperties\Bar::$dynamicProperty.
+Access to an undefined property DynamicProperties\Baz::$dynamicProperty.
+Access to an undefined property DynamicProperties\FinalBar::$dynamicProperty.
+Access to an undefined property DynamicProperties\FinalFoo::$dynamicProperty.
+Access to an undefined property DynamicProperties\Foo::$dynamicProperty.
+Access to an undefined property MixinProperties\GenericFoo<ReflectionClass>::$namee.
+Access to an undefined property NullCoalesceIsAlwaysFinal\Foo::$bar.
+Access to an undefined property NullsafePropertyFetch\Foo::$baz.
+Access to an undefined property Php82DynamicPropertiesAllow\HelloWorld::$world.
+Access to an undefined property Php82DynamicProperties\ClassA::$properties.
+Access to an undefined property Php82DynamicProperties\FinalHelloWorld::$world.
+Access to an undefined property Php82DynamicProperties\HelloWorld::$world.
+Access to an undefined property Php82DynamicProperties\ReadonlyWithMagic::$foo.
+Access to an undefined property PropertiesFromArrayIntoObject\Foo::$noop.
+Access to an undefined property PropertiesFromVariableIntoObject\Foo::$noop.
+Access to an undefined property RequireExtends\MyInterface::$bar.
+Access to an undefined property TestAccessPropertiesAssign\AccessPropertyWithDimFetch::$foo.
+Access to an undefined property TestAccessProperties\AssignOpNonexistentProperty::$flags.
+Access to an undefined property TestAccessProperties\BarAccessProperties::$loremipsum.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$anotherEmptyNonexistent.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$anotherNonexistent.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$baz.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$dolor.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$emptyBaz.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$emptyNonexistent.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$lorem.
+Access to an undefined property TestAccessProperties\FooAccessProperties::$nonexistent.
+Access to an undefined property TestAccessProperties\SomeInterface&TestAccessProperties\WithFooProperty::$bar.
+Access to an undefined property TestAccessProperties\WithFooAndBarProperty|TestAccessProperties\WithFooProperty::$bar.
+Access to an undefined property UnitEnum::$value.
+Access to an undefined property class@anonymous/tests/PHPStan/Rules/Properties/data/access-properties.php:297::$barProperty.
+Access to an undefined property object::$baz.
+Access to an undefined property object{foo: int, bar?: string}::$bar.
+Access to an undefined property object{foo: int, bar?: string}::$baz.
+Access to an undefined property object{hello?: string}::$hello.
+Access to an undefined static property AccessInIsset::$foo.
+Access to an undefined static property AccessStaticProperties\AssignOpNonexistentProperty::$flags.
+Access to an undefined static property AllowsDynamicProperties::$foo.
+Access to an undefined static property BarAccessStaticProperties::$bar.
+Access to an undefined static property ClassOrString|string::$unknownProperty.
+Access to an undefined static property DoesNotAllowDynamicProperties::$foo.
+Access to an undefined static property FooAccessStaticProperties&SomeInterface::$nonexistent.
+Access to an undefined static property FooAccessStaticProperties::$bar.
+Access to an undefined static property FooAccessStaticProperties::$nonexistent.
+Access to an undefined static property FooAccessStaticProperties::$unknownProperties.
+Access to an undefined static property ParentClassWithInstanceProperty::$j.
+Access to an undefined static property PropertiesFromArrayIntoStaticObject\Foo::$noop.
+Access to an undefined static property TestAccessStaticPropertiesAssign\AccessStaticPropertyWithDimFetch::$foo.
+Access to an undefined static property static(AccessWithStatic)::$nonexistent.
+Access to an undefined static property static(Bug6809\HelloWorld)::$coolClass.
+Access to an undefined static property static(Bug8333\BarAccessProperties)::$loremipsum.
+Access to an undefined static property static(IpsumAccessStaticProperties)::$anotherEmptyNonexistent.
+Access to an undefined static property static(IpsumAccessStaticProperties)::$anotherNonexistent.
+Access to an undefined static property static(IpsumAccessStaticProperties)::$baz.
+Access to an undefined static property static(IpsumAccessStaticProperties)::$emptyBaz.
+Access to an undefined static property static(IpsumAccessStaticProperties)::$emptyNonexistent.
+Access to an undefined static property static(IpsumAccessStaticProperties)::$nonexistent.
+Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\AssignOp::$bar.
+Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\AssignOp::$foo.
+Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\B::$b.
+Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\Foo::$readBeforeAssigned.
+Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass::$readBeforeAssigned.
+Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\Immutable::$readBeforeAssigned.
+Access to an uninitialized property Bug9619\AdminPresenter3::$user.
+Access to an uninitialized property Bug9831\Foo::$bar.
+Access to an uninitialized property RedeclareReadonlyProperty\B19::$prop2.
+Access to an uninitialized property UninitializedProperty\Bar::$foo.
+Access to an uninitialized property UninitializedProperty\SometimesInitializedInPrivateSetter::$foo.
+Access to an uninitialized readonly property Bug6402\SomeModel2::$views.
+Access to an uninitialized readonly property Bug9863\ReadonlyParentWithIsset::$foo.
+Access to an uninitialized readonly property MissingReadOnlyPropertyAssign\AssignOp::$bar.
+Access to an uninitialized readonly property MissingReadOnlyPropertyAssign\AssignOp::$foo.
+Access to an uninitialized readonly property MissingReadOnlyPropertyAssign\Foo::$readBeforeAssigned.
+Access to an uninitialized readonly property MissingReadOnlyPropertyAssign\FooTraitClass::$readBeforeAssigned.
+Access to constant BAR of internal class ClassConstantAccessOnInternalSubclassOne\Bar from outside its root namespace ClassConstantAccessOnInternalSubclassOne.
+Access to constant FOO of internal class ClassConstantInternalTagOne\FooInternal from outside its root namespace ClassConstantInternalTagOne.
+Access to constant FOO of internal class FooInternalWithClassConstantWithoutNamespace.
+Access to constant FOO on an unknown class ClassConstantNamespace\UnknownClass.
+Access to constant FOO on an unknown class ClassConstantVisibility\UnknownClassFirst.
+Access to constant FOO on an unknown class ClassConstantVisibility\UnknownClassSecond.
+Access to constant NUMERIC_COLLATION of internal class Bug12951Polyfill\NumberFormatter from outside its root namespace Bug12951Polyfill.
+Access to internal constant ClassConstantInternalTagOne\Foo::INTERNAL from outside its root namespace ClassConstantInternalTagOne.
+Access to internal constant ClassInternal::INTERNAL_CONSTANT.
+Access to internal constant FooWithInternalClassConstantWithoutNamespace::INTERNAL.
+Access to internal property FooWithInternalPropertyWithoutNamespace::$internal.
+Access to internal property PropertyInternalTagOne\Foo::$internal from outside its root namespace PropertyInternalTagOne.
+Access to internal static property FooWithInternalStaticPropertyWithoutNamespace::$internal.
+Access to internal static property StaticPropertyInternalTagOne\Foo::$internal from outside its root namespace StaticPropertyInternalTagOne.
+Access to offset '%customer…' on an unknown class Bug5669\arr.
+Access to offset 'bar' on an unknown class NonexistentOffset\Bar.
+Access to parent::BAZ but ClassConstantVisibility\Foo does not extend any class.
+Access to private constant FOO of class ClassConstantAttribute\Foo.
+Access to private constant PRIVATE_BAR of class ClassConstantVisibility\Bar.
+Access to private constant PRIVATE_FOO of class ClassConstantVisibility\Foo.
+Access to private property $foo of parent class TestAccessProperties\FooAccessProperties.
+Access to private property Bug12645\Foo::$id.
+Access to private property ConflictingAnnotationProperty\PropertyWithAnnotation::$test.
+Access to private property TestAccessProperties\FooAccessProperties::$foo.
+Access to private static property $foo of parent class Bug8333\FooAccessProperties.
+Access to property $foo of internal class FooInternalWithPropertyWithoutNamespace.
+Access to property $foo of internal class PropertyInternalTagOne\FooInternal from outside its root namespace PropertyInternalTagOne.
+Access to property $foo on an unknown class TestAccessProperties\UnknownClass.
+Access to property $lorem on an unknown class AccessPropertiesClassExists\Bar.
+Access to property $lorem on an unknown class AccessPropertiesClassExists\Baz.
+Access to property $test on an unknown class TestAccessProperties\FirstUnknownClass.
+Access to property $test on an unknown class TestAccessProperties\SecondUnknownClass.
+Access to protected constant PROTECTED_FOO of class ClassConstantVisibility\Foo.
+Access to protected property $foo of class FooAccessStaticProperties.
+Access to protected property Bug13537\Bar::$test.
+Access to protected property TestAccessProperties\FooAccessProperties::$bar.
+Access to static property $bar of internal class StaticPropertyAccessOnInternalSubclassOne\Bar from outside its root namespace StaticPropertyAccessOnInternalSubclassOne.
+Access to static property $foo of internal class FooInternalWithStaticPropertyWithoutNamespace.
+Access to static property $foo of internal class StaticPropertyInternalTagOne\FooInternal from outside its root namespace StaticPropertyInternalTagOne.
+Access to static property $foo on an unknown class TraitWithStaticProperty.
+Access to static property $prop of internal class Bug12951Polyfill\NumberFormatter from outside its root namespace Bug12951Polyfill.
+Access to static property $test on an unknown class NonexistentClass.
+Access to static property $test on an unknown class UnknownStaticProperties.
+Access to undefined constant ClassConstFetchDefined\Foo::TEST.
+Access to undefined constant ClassConstantAttribute\Foo::BAR.
+Access to undefined constant ClassConstantDynamicAccess\Foo::BUZ.
+Access to undefined constant ClassConstantDynamicAccess\Foo::FOO.
+Access to undefined constant ClassConstantDynamicAccess\Foo::QUX.
+Access to undefined constant ClassConstantNamespace\Foo::DOLOR.
+Access to undefined constant ClassConstantNamespace\Foo|string::DOLOR.
+Access to undefined constant ClassConstantVisibility\Bar::PRIVATE_FOO.
+Access to undefined constant ClassConstantVisibility\WithFooAndBarConstant&ClassConstantVisibility\WithFooConstant::BAZ.
+Access to undefined constant ClassConstantVisibility\WithFooAndBarConstant|ClassConstantVisibility\WithFooConstant::BAR.
+Access to undefined constant Foo::TEST.
+Access to undefined constant static(Bug8034\HelloWorld)::FIELDS.
+Access to undefined constant static(ClassConstantVisibility\AccessWithStatic)::BAR.
+Accessing ::class constant on a dynamic string is not supported in PHP.
+Accessing ::class constant on an expression is supported only on PHP 8.0 and later.
+Accessing PHPStan\Analyser\NodeScopeResolver::FOO is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Accessing PHPStan\Command\AnalyseCommand::class is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Accessing parent::$staticFooProperty outside of class scope.
+Accessing self::$staticFooProperty outside of class scope.
+Accessing static::$staticFooProperty outside of class scope.
+Although PHPStan\Reflection\ClassReflection is covered by backward compatibility promise, this instanceof assumption might break because it's not guaranteed to always stay the same.
+Anonymous class extends enum ClassExtendsEnum\FooEnum.
+Anonymous class extends trait ExtendsError\DolorTrait.
+Anonymous class implements enum ClassImplementsEnum\FooEnum.
+Anonymous class implements trait ImplementsError\DolorTrait.
+Anonymous class uses enum TraitUseEnum\FooEnum.
+Anonymous class uses interface TraitUseError\Baz.
+Anonymous class uses unknown trait TraitUseError\FooTrait.
+Anonymous function has an unused use $anotherUnused.
+Anonymous function has an unused use $unused.
+Anonymous function has an unused use $usedInClosureUse.
+Anonymous function has invalid return type ArrowFunctionExistingClassesInTypehints\Baz.
+Anonymous function has invalid return type TestClosureFunctionTypehintsPhp71\NonexistentClass.
+Anonymous function has invalid return type TestClosureFunctionTypehints\NonexistentClass.
+Anonymous function has invalid return type TestClosureFunctionTypehints\SomeTrait.
+Anonymous function has unresolvable native return type.
+Anonymous function never returns null so it can be removed from the return type.
+Anonymous function should never return but return statement found.
+Anonymous function should return ClosureReturnTypes\Bar&ClosureReturnTypes\Foo but returns ClosureReturnTypes\Bar.
+Anonymous function should return ClosureReturnTypes\Foo&SomeOtherNamespace\Baz but returns ClosureReturnTypes\Foo.
+Anonymous function should return ClosureReturnTypes\Foo&SomeOtherNamespace\Foo but returns ClosureReturnTypes\Foo.
+Anonymous function should return array{}|null but empty return statement found.
+Anonymous function should return int but empty return statement found.
+Anonymous function should return int but return statement is missing.
+Anonymous function should return int but returns string.
+Anonymous function should return int|null but returns string.
+Anonymous function should return iterable but returns string.
+Anonymous function should return string but empty return statement found.
+Anonymous function should return string but returns int.
+Anonymous function uses native union types but they're supported only on PHP 8.0 and later.
+Anonymous non-readonly class extends readonly class ExtendsReadOnlyClass\ReadonlyClass.
+Anonymous readonly class extends non-readonly class ExtendsReadOnlyClass\Nonreadonly.
+Another unreachable
+Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported.
+Argument for parameter $b has already been passed.
+Argument for parameter $i has already been passed.
+Argument of an invalid type T of mixed supplied for foreach, only iterables are supported.
+Argument of an invalid type array<int>|null supplied for foreach, only iterables are supported.
+Argument of an invalid type int passed to yield from, only iterables are supported.
+Argument of an invalid type list<int>|false supplied for foreach, only iterables are supported.
+Argument of an invalid type mixed supplied for foreach, only iterables are supported.
+Argument of an invalid type string supplied for foreach, only iterables are supported.
+Array has 2 duplicate keys with value '' (null, NULL).
+Array has 2 duplicate keys with value '=' (self::EQ, self::IS).
+Array has 2 duplicate keys with value 'bar' ($key, 'bar').
+Array has 2 duplicate keys with value 'bar' ('bar', $key).
+Array has 2 duplicate keys with value 'baz' ($key, 'baz').
+Array has 2 duplicate keys with value 'foo' ('foo', $key).
+Array has 2 duplicate keys with value 'key' ('key', $key2).
+Array has 2 duplicate keys with value -41 (-41, -41).
+Array has 2 duplicate keys with value 0 (0, 0).
+Array has 2 duplicate keys with value 101 (101, 101).
+Array has 2 duplicate keys with value 102 (102, 102).
+Array has 2 duplicate keys with value 2 ($idx, $idx).
+Array has 3 duplicate keys with value 0 (false, 0, PHPSTAN_DUPLICATE_KEY).
+Array has 4 duplicate keys with value 1 (1, 1, 1.0, true).
+Array has 5 duplicate keys with value 1 (1, '1', true, 1.0, 1.1).
+ArrayAccess<int, int> does not accept array<int, string>.
+ArrayAccess<int, int> does not accept float.
+ArrayAccess<int, int> does not accept int|null.
+ArrayAccess<int, int> does not accept string.
+ArrayAccess<int, string> does not accept int.
+Asking about instanceof PHPStan\Reflection\BetterReflection\SourceLocator\AutoloadSourceLocator is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Assert references unknown $this->barProp.
+Assert references unknown parameter $j.
+Assert references unknown parameter $this.
+Asserted negated type int for $i with type int can never happen.
+Asserted negated type string for $i with type int does not narrow down the type.
+Asserted type int for $i with type int does not narrow down the type.
+Asserted type int|string for $i with type int does not narrow down the type.
+Asserted type non-empty-list<static(IncompatibleAssertTypeWithMethodReturnType\Foo)> for $this->getValues() with type list<int> can never happen.
+Asserted type string for $i with type int can never happen.
+Assign to $item overwrites the last element from array.
+Asymmetric visibility for static properties is supported only on PHP 8.5 and later.
+Attribute NoDiscard cannot be used on never anonymous function.
+Attribute NoDiscard cannot be used on never function TestFunctionTypehints\returnNever().
+Attribute NoDiscard cannot be used on never method TestMethodTypehints\Demo::returnNever().
+Attribute NoDiscard cannot be used on void anonymous function.
+Attribute NoDiscard cannot be used on void function TestFunctionTypehints\nothing().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::__clone().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::__construct().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::__destruct().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::__unset().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::__wakeup().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::alsoNothing().
+Attribute NoDiscard cannot be used on void method TestMethodTypehints\Demo::nothing().
+Attribute class AllowDynamicProperties cannot be used with enum.
+Attribute class AllowDynamicProperties cannot be used with interface.
+Attribute class AllowDynamicProperties cannot be used with readonly class.
+Attribute class AllowDynamicProperties cannot be used with trait.
+Attribute class ArrowFunctionAttributes\Foo does not have the function target.
+Attribute class ClassAttributes\AbstractAttribute is abstract.
+Attribute class ClassAttributes\AttributeWithConstructor constructor invoked with 0 parameters, 2 required.
+Attribute class ClassAttributes\AttributeWithConstructor constructor invoked with 1 parameter, 2 required.
+Attribute class ClassAttributes\Bar does not have a constructor and must be instantiated without any parameters.
+Attribute class ClassAttributes\Bar is not repeatable but is already present above the class.
+Attribute class ClassAttributes\Baz does not have the class target.
+Attribute class ClassAttributes\FlagsAttributeWithPropertyTarget does not have the class target.
+Attribute class ClassAttributes\Nonexistent does not exist.
+Attribute class ClassConstantAttributes\Foo does not have the class constant target.
+Attribute class ClosureAttributes\Foo does not have the function target.
+Attribute class Deprecated can be used with traits only on PHP 8.5 and later.
+Attribute class Deprecated cannot be used with class DeprecatedAttrOnClass\Foo.
+Attribute class Deprecated cannot be used with enum DeprecatedAttrOnClass\Baz.
+Attribute class Deprecated cannot be used with interface DeprecatedAttrOnClass\Bar.
+Attribute class DeprecatedPropertyAttribute\DoSomethingTheOldWay is deprecated.
+Attribute class DeprecatedPropertyAttribute\DoSomethingTheOldWayWithDescription is deprecated: Use something else please
+Attribute class EnumAttributes\AttributeWithPropertyTarget does not have the class target.
+Attribute class EnumCaseAttributes\AttributeWithPropertyTarget does not have the class constant target.
+Attribute class FunctionAttributes\Foo does not have the function target.
+Attribute class MethodAttributes\Foo does not have the method target.
+Attribute class NonClassAttributeClass\Ipsum constructor must be public.
+Attribute class Override can be used with properties only on PHP 8.5 and later.
+Attribute class ParamAttributes\Foo does not have the parameter or property target.
+Attribute class ParamAttributes\Foo does not have the parameter target.
+Attribute class ParamAttributes\Qux does not have the parameter target.
+Attribute class PropertyAttributes\Foo does not have the property target.
+Attribute class TraitAttributes\AbstractAttribute is abstract.
+Attribute class TraitAttributes\MyTargettedAttribute does not have the class target.
+Attribute class self does not exist.
+Attributes on global constants are supported only on PHP 8.5 and later.
+Backed enum EnumSanity\BackedEnumWithBoolType can have only "int" or "string" type.
+Backed enum EnumSanity\BackedEnumWithFloatType can have only "int" or "string" type.
+Binary operation "%" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "%" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "%" between 3 and array results in an error.
+Binary operation "%" between 3 and object results in an error.
+Binary operation "%" between 5 and 0 results in an error.
+Binary operation "%" between T and 2 results in an error.
+Binary operation "%" between array and 3 results in an error.
+Binary operation "%" between array{} and array{''} results in an error.
+Binary operation "%" between mixed and 2 results in an error.
+Binary operation "%" between object and 3 results in an error.
+Binary operation "%" between stdClass and stdClass results in an error.
+Binary operation "%=" between 5 and T results in an error.
+Binary operation "%=" between 5 and mixed results in an error.
+Binary operation "%=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "%=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "&" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "&" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "&" between T and 2 results in an error.
+Binary operation "&" between mixed and 2 results in an error.
+Binary operation "&" between string and 5 results in an error.
+Binary operation "&=" between 5 and T results in an error.
+Binary operation "&=" between 5 and mixed results in an error.
+Binary operation "&=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "&=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "*" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "*" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "*" between 10 and class-string results in an error.
+Binary operation "*" between 10 and literal-string results in an error.
+Binary operation "*" between 10 and non-empty-string results in an error.
+Binary operation "*" between 10 and string results in an error.
+Binary operation "*" between T and 2 results in an error.
+Binary operation "*" between class-string and 10 results in an error.
+Binary operation "*" between literal-string and 10 results in an error.
+Binary operation "*" between mixed and 2 results in an error.
+Binary operation "*" between non-empty-string and 10 results in an error.
+Binary operation "*" between string and 10 results in an error.
+Binary operation "**" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "**" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "**" between T and 2 results in an error.
+Binary operation "**" between mixed and 2 results in an error.
+Binary operation "**=" between 5 and T results in an error.
+Binary operation "**=" between 5 and mixed results in an error.
+Binary operation "**=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "**=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "*=" between 5 and T results in an error.
+Binary operation "*=" between 5 and mixed results in an error.
+Binary operation "*=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "*=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "+" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "+" between (array<string>|string) and 1 results in an error.
+Binary operation "+" between 1 and 'blabla' results in an error.
+Binary operation "+" between 1 and string results in an error.
+Binary operation "+" between 10 and class-string results in an error.
+Binary operation "+" between 10 and literal-string results in an error.
+Binary operation "+" between 10 and non-empty-string results in an error.
+Binary operation "+" between 10 and string results in an error.
+Binary operation "+" between T and 2 results in an error.
+Binary operation "+" between array|null and '2' results in an error.
+Binary operation "+" between class-string and 10 results in an error.
+Binary operation "+" between int and array{} results in an error.
+Binary operation "+" between literal-string and 10 results in an error.
+Binary operation "+" between mixed and 2 results in an error.
+Binary operation "+" between mixed and array results in an error.
+Binary operation "+" between non-empty-string and 10 results in an error.
+Binary operation "+" between stdClass and int results in an error.
+Binary operation "+" between string and 10 results in an error.
+Binary operation "+=" between 5 and T results in an error.
+Binary operation "+=" between 5 and mixed results in an error.
+Binary operation "+=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "+=" between array and 'foo' results in an error.
+Binary operation "-" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "-" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "-" between 10 and class-string results in an error.
+Binary operation "-" between 10 and literal-string results in an error.
+Binary operation "-" between 10 and non-empty-string results in an error.
+Binary operation "-" between 10 and string results in an error.
+Binary operation "-" between T and 2 results in an error.
+Binary operation "-" between array and array results in an error.
+Binary operation "-" between class-string and 10 results in an error.
+Binary operation "-" between literal-string and 10 results in an error.
+Binary operation "-" between mixed and 2 results in an error.
+Binary operation "-" between non-empty-string and 10 results in an error.
+Binary operation "-" between string and 10 results in an error.
+Binary operation "-=" between 5 and T results in an error.
+Binary operation "-=" between 5 and mixed results in an error.
+Binary operation "-=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "-=" between array and array results in an error.
+Binary operation "-=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "." between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "." between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "." between T and 'a' results in an error.
+Binary operation "." between array<string> and 'xyz' results in an error.
+Binary operation "." between array{}|non-falsy-string and 'xyz' results in an error.
+Binary operation "." between mixed and 'a' results in an error.
+Binary operation "." between string and stdClass results in an error.
+Binary operation ".=" between 'a' and T results in an error.
+Binary operation ".=" between 'a' and mixed results in an error.
+Binary operation ".=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation ".=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation ".=" between string and stdClass results in an error.
+Binary operation "/" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "/" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "/" between 10 and class-string results in an error.
+Binary operation "/" between 10 and literal-string results in an error.
+Binary operation "/" between 10 and non-empty-string results in an error.
+Binary operation "/" between 10 and string results in an error.
+Binary operation "/" between 5 and 0 results in an error.
+Binary operation "/" between 5 and 0|1 results in an error.
+Binary operation "/" between T and 2 results in an error.
+Binary operation "/" between class-string and 10 results in an error.
+Binary operation "/" between int and 0.0 results in an error.
+Binary operation "/" between literal-string and 10 results in an error.
+Binary operation "/" between mixed and 2 results in an error.
+Binary operation "/" between non-empty-string and 10 results in an error.
+Binary operation "/" between string and 10 results in an error.
+Binary operation "/=" between 5 and T results in an error.
+Binary operation "/=" between 5 and mixed results in an error.
+Binary operation "/=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "/=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "<<" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "<<" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "<<" between T and 2 results in an error.
+Binary operation "<<" between mixed and 2 results in an error.
+Binary operation "<<" between string and string results in an error.
+Binary operation "<<=" between 5 and T results in an error.
+Binary operation "<<=" between 5 and mixed results in an error.
+Binary operation "<<=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "<<=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "<<=" between string and string results in an error.
+Binary operation ">>" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation ">>" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation ">>" between T and 2 results in an error.
+Binary operation ">>" between mixed and 2 results in an error.
+Binary operation ">>" between string and string results in an error.
+Binary operation ">>=" between 5 and T results in an error.
+Binary operation ">>=" between 5 and mixed results in an error.
+Binary operation ">>=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation ">>=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation ">>=" between string and string results in an error.
+Binary operation "^" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "^" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "^" between string and 5 results in an error.
+Binary operation "^=" between 5 and T results in an error.
+Binary operation "^=" between 5 and mixed results in an error.
+Binary operation "^=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "^=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "|" between (array<string, string>|bool|int|object|resource) and BinaryOpBenevolentUnion\Foo results in an error.
+Binary operation "|" between (array<string, string>|bool|int|object|resource) and array{} results in an error.
+Binary operation "|" between T and 2 results in an error.
+Binary operation "|" between mixed and 2 results in an error.
+Binary operation "|" between string and 5 results in an error.
+Binary operation "|=" between 5 and T results in an error.
+Binary operation "|=" between 5 and mixed results in an error.
+Binary operation "|=" between BinaryOpBenevolentUnion\Foo and (array<string, string>|bool|int|object|resource) results in an error.
+Binary operation "|=" between array{} and (array<string, string>|bool|int|object|resource) results in an error.
+Call to Bug7434\Contract::method() uses named argument for parameter $val, but Bug7434\ImplementationWithDifferentName renames it to $wrong.
+Call to CallToStaticMethodWithoutImpurePoints\SubSubY::mySubSubFunc() on a separate line has no effect.
+Call to CallToStaticMethodWithoutImpurePoints\X::myFunc() on a separate line has no effect.
+Call to CallToStaticMethodWithoutImpurePoints\y::myFunc() on a separate line has no effect.
+Call to ConstructorStatementNoSideEffects\ConstructorWithPure::__construct() on a separate line has no effect.
+Call to ConstructorStatementNoSideEffects\ConstructorWithPureAndThrowsVoid::__construct() on a separate line has no effect.
+Call to Exception::__construct() on a separate line has no effect.
+Call to NamedArgumentRenamedParameter\Foo::doFoo() uses named argument for parameter $a, but NamedArgumentRenamedParameter\Bar renames it to $b.
+Call to PHPStan\Type\ObjectType::getTemplateType() references unknown template type TSendd on class Generator.
+Call to PHPStan\Type\Type::getTemplateType() references unknown template type TSendd on class Generator.
+Call to an undefined method ArrayObject<int, stdClass>::doFoo().
+Call to an undefined method Bug14150Method\HelloWorld::y().
+Call to an undefined method BugTemplateMixedUnionIntersect\FooInterface&T of mixed::bar().
+Call to an undefined method BugTemplateMixedUnionIntersect\FooInterface::bar().
+Call to an undefined method CallArrowFunctionBind\Bar::barMethod().
+Call to an undefined method CallArrowFunctionBind\Foo::nonexistentMethod().
+Call to an undefined method CallClosureBind\Bar::barMethod().
+Call to an undefined method CallClosureBind\Foo::nonexistentMethod().
+Call to an undefined method CallMethodInEnum\Bar::doNonexistent().
+Call to an undefined method CallMethodInEnum\Foo::doNonexistent().
+Call to an undefined method CallTraitMethods\Baz::unexistentMethod().
+Call to an undefined method InterfaceMethods\Baz::barMethod().
+Call to an undefined method MethodCallable\Foo::doNonexistent().
+Call to an undefined method MethodsDynamicCall\Foo::bar().
+Call to an undefined method MethodsDynamicCall\Foo::doBar().
+Call to an undefined method MethodsDynamicCall\Foo::doBuz().
+Call to an undefined method MixinMethods\GenericFoo<Exception>::getMessagee().
+Call to an undefined method NamedArgumentsMethod\Bar::doBaz().
+Call to an undefined method ReflectionType::getName().
+Call to an undefined method RequireExtends\MyInterface::doesNotExist().
+Call to an undefined method RequireImplements\MyBaseClass::doesNotExist().
+Call to an undefined method Test\ArraySliceWithNonEmptyArray::doesNotExist().
+Call to an undefined method Test\AssertInFor::doBar().
+Call to an undefined method Test\Bar::loremipsum().
+Call to an undefined method Test\CallAfterPropertyEmpty::doBar().
+Call to an undefined method Test\Foo::lorem().
+Call to an undefined method Test\Foo::protectedMethodFromChild().
+Call to an undefined method Test\SomeInterface&Test\WithFooMethod::bar().
+Call to an undefined method Test\WithFooAndBarMethod|Test\WithFooMethod::bar().
+Call to an undefined static method Bug14150MethodStatic\HelloWorld::y().
+Call to an undefined static method CallStaticMethods\Bar::bar().
+Call to an undefined static method CallStaticMethods\CallWithStatic::nonexistent().
+Call to an undefined static method CallStaticMethods\Foo::__construct().
+Call to an undefined static method CallStaticMethods\Foo::bar().
+Call to an undefined static method CallStaticMethods\Foo::nonexistent().
+Call to an undefined static method CallStaticMethods\Foo::nonexistentMethod().
+Call to an undefined static method CallStaticMethods\Foo::unknownMethod().
+Call to an undefined static method CallStaticMethods\InterfaceWithStaticMethod::doBar().
+Call to an undefined static method InterfaceMethods\Baz::barStaticMethod().
+Call to an undefined static method MethodsDynamicCall\Foo::bar().
+Call to an undefined static method MethodsDynamicCall\Foo::doBar().
+Call to an undefined static method MethodsDynamicCall\Foo::doBuz().
+Call to an undefined static method RequireExtends\MyInterface::doesNotExistStatic().
+Call to an undefined static method RequireImplements\MyBaseClass::doesNotExistStatic().
+Call to an undefined static method ReturnStaticStaticMethod\Bar::doBaz().
+Call to an undefined static method StaticCallOnExpression\Foo::doBar().
+Call to an undefined static method StaticHasMethodCall\rex_var::doesNotExist().
+Call to an undefined static method StaticMethodCallable\Foo::nonexistent().
+Call to an undefined static method T of CallStaticMethods\Foo::nonexistentMethod().
+Call to an undefined static method T of mixed&UnitEnum::from().
+Call to an undefined static method T of object&UnitEnum::from().
+Call to an undefined static method UnitEnum::from().
+Call to fscanf contains 2 placeholders, 1 value given.
+Call to function CallToFunctionWithoutImpurePoints\myFunc() on a separate line has no effect.
+Call to function FirstClassCallableFunctionWithoutSideEffect\bar() on a separate line has no effect.
+Call to function FirstClassCallableFunctionWithoutSideEffect\foo() on a separate line has no effect.
+Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure1() on a separate line has no effect.
+Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure2() on a separate line has no effect.
+Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure3() on a separate line has no effect.
+Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure4() on a separate line has no effect.
+Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure5() on a separate line has no effect.
+Call to function FunctionCallStatementNoSideEffectsPhpDoc\pureAndThrowsVoid() on a separate line has no effect.
+Call to function IncorrectFunctionCase\fooBar() with incorrect case: IncorrectFunctionCase\foobar
+Call to function IncorrectFunctionCase\fooBar() with incorrect case: foobar
+Call to function MongoDB\Driver\Monitoring\addSubscriber() with incorrect case: MONGODB\Driver\Monitoring\addSubscriber
+Call to function MongoDB\Driver\Monitoring\addSubscriber() with incorrect case: mongodb\driver\monitoring\addsubscriber
+Call to function array_is_list() with array<string, int> will always evaluate to false.
+Call to function array_is_list() with array{0: 'foo', foo: 'bar', bar: 'baz'} will always evaluate to false.
+Call to function array_is_list() with array{foo: 'bar', bar: 'baz'} will always evaluate to false.
+Call to function array_key_exists() with 'a' and array{a: 1, b?: 2} will always evaluate to true.
+Call to function array_key_exists() with 'c' and array{a: 1, b?: 2} will always evaluate to false.
+Call to function assert() with false will always evaluate to false.
+Call to function assert() with true will always evaluate to true.
+Call to function assertIsInt() with int will always evaluate to true.
+Call to function compact() contains possibly undefined variable $baz.
+Call to function compact() contains undefined variable $bar.
+Call to function compact() contains undefined variable $foo.
+Call to function highlight_string() on a separate line has no effect.
+Call to function htmlspecialchars() with incorrect case: htmlSpecialChars
+Call to function in_array() with 'A' and array{LooseComparisonAgainstEnums\FooBackedEnum} will always evaluate to false.
+Call to function in_array() with 'A' and array{LooseComparisonAgainstEnums\FooUnitEnum} will always evaluate to false.
+Call to function in_array() with 'NotAnEnumCase' and array<Bug9662Enums\StringBackedSuit> will always evaluate to false.
+Call to function in_array() with 'NotAnEnumCase' and array<Bug9662Enums\Suit> will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooBackedEnum and array{'A'} will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooBackedEnum and array{bool} will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum and array<string> will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum and array{'A'} will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum and array{bool} will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum and array{null} will always evaluate to false.
+Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum::A and non-empty-array<LooseComparisonAgainstEnums\FooUnitEnum::A> will always evaluate to true.
+Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum::B and non-empty-array<LooseComparisonAgainstEnums\FooUnitEnum::A> will always evaluate to false.
+Call to function in_array() with arguments 'A', array{LooseComparisonAgainstEnums\FooBackedEnum|LooseComparisonAgainstEnums\FooUnitEnum} and false will always evaluate to false.
+Call to function in_array() with arguments 'A', array{LooseComparisonAgainstEnums\FooBackedEnum} and false will always evaluate to false.
+Call to function in_array() with arguments 'A', array{LooseComparisonAgainstEnums\FooUnitEnum} and false will always evaluate to false.
+Call to function in_array() with arguments 'a', non-empty-array<int, 'a'> and true will always evaluate to true.
+Call to function in_array() with arguments 'b', non-empty-array<int, 'a'> and true will always evaluate to false.
+Call to function in_array() with arguments 'bar', array{}|array{'foo'} and true will always evaluate to false.
+Call to function in_array() with arguments 'bar'|'foo', array{'baz', 'lorem'} and true will always evaluate to false.
+Call to function in_array() with arguments 'baz', array{0: 'bar', 1?: 'foo'} and true will always evaluate to false.
+Call to function in_array() with arguments 'c', list<'a'|'b'> and true will always evaluate to false.
+Call to function in_array() with arguments 'foo', array{'foo', 'bar'} and true will always evaluate to true.
+Call to function in_array() with arguments 'foo', array{'foo'} and true will always evaluate to true.
+Call to function in_array() with arguments 'foo', array{} and true will always evaluate to false.
+Call to function in_array() with arguments 1, array<string> and true will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooBackedEnum, array{'A'} and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooBackedEnum, array{bool} and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooBackedEnum|LooseComparisonAgainstEnums\FooUnitEnum, array{'A'} and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooBackedEnum|LooseComparisonAgainstEnums\FooUnitEnum, array{bool} and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum, array<string> and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum, array<string> and true will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum, array{'A'} and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum, array{bool} and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum::A, non-empty-array<LooseComparisonAgainstEnums\FooUnitEnum::A> and false will always evaluate to true.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum::A, non-empty-array<LooseComparisonAgainstEnums\FooUnitEnum::A> and true will always evaluate to true.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum::B, non-empty-array<LooseComparisonAgainstEnums\FooUnitEnum::A> and false will always evaluate to false.
+Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum::B, non-empty-array<LooseComparisonAgainstEnums\FooUnitEnum::A> and true will always evaluate to false.
+Call to function in_array() with arguments bool, array{LooseComparisonAgainstEnums\FooBackedEnum|LooseComparisonAgainstEnums\FooUnitEnum} and false will always evaluate to false.
+Call to function in_array() with arguments bool, array{LooseComparisonAgainstEnums\FooBackedEnum} and false will always evaluate to false.
+Call to function in_array() with arguments bool, array{LooseComparisonAgainstEnums\FooUnitEnum} and false will always evaluate to false.
+Call to function in_array() with arguments int, array<int, string> and true will always evaluate to false.
+Call to function in_array() with arguments int, array<string> and true will always evaluate to false.
+Call to function in_array() with arguments int, array{'foo', 'bar'} and true will always evaluate to false.
+Call to function in_array() with arguments int, array{} and true will always evaluate to false.
+Call to function in_array() with arguments null, array{key1: bool|null, key2: null} and true will always evaluate to true.
+Call to function in_array() with arguments string, array<LooseComparisonAgainstEnums\FooUnitEnum> and false will always evaluate to false.
+Call to function in_array() with arguments string, array<LooseComparisonAgainstEnums\FooUnitEnum> and true will always evaluate to false.
+Call to function in_array() with bool and array{LooseComparisonAgainstEnums\FooBackedEnum} will always evaluate to false.
+Call to function in_array() with bool and array{LooseComparisonAgainstEnums\FooUnitEnum} will always evaluate to false.
+Call to function in_array() with int and array<Bug9662Enums\StringBackedSuit> will always evaluate to false.
+Call to function in_array() with null and array{LooseComparisonAgainstEnums\FooBackedEnum} will always evaluate to false.
+Call to function in_array() with string and array<Bug9662Enums\StringBackedSuit> will always evaluate to false.
+Call to function in_array() with string and array<LooseComparisonAgainstEnums\FooUnitEnum> will always evaluate to false.
+Call to function isAnInteger() with int will always evaluate to true.
+Call to function is_a() with arguments BugPR3404\Location, 'BugPR3404\\Location' and true will always evaluate to true.
+Call to function is_bool() with bool will always evaluate to true.
+Call to function is_callable() with 'date' will always evaluate to true.
+Call to function is_callable() with 'nonexistentFunction' will always evaluate to false.
+Call to function is_callable() with array<int> will always evaluate to false.
+Call to function is_callable() with array{1: 'count', 0: ArrayObject<int, int>} will always evaluate to true.
+Call to function is_callable() with array{ArrayObject<int, int>, 'count'} will always evaluate to true.
+Call to function is_callable() with mixed will always evaluate to false.
+Call to function is_int() with int will always evaluate to true.
+Call to function is_int() with string will always evaluate to false.
+Call to function is_null() with 10 will always evaluate to false.
+Call to function is_null() with null will always evaluate to true.
+Call to function is_numeric() with '123' will always evaluate to true.
+Call to function is_numeric() with 'blabla' will always evaluate to false.
+Call to function is_numeric() with 123 will always evaluate to true.
+Call to function is_numeric() with 123|float will always evaluate to true.
+Call to function is_object() with int will always evaluate to false.
+Call to function is_string() with int will always evaluate to false.
+Call to function is_string() with mixed will always evaluate to false.
+Call to function is_string() with string will always evaluate to true.
+Call to function is_subclass_of() with Bug6305\B and 'Bug6305\\A' will always evaluate to true.
+Call to function is_subclass_of() with Bug6305\B and 'Bug6305\\B' will always evaluate to false.
+Call to function is_subclass_of() with arguments Bug13713\test, 'stdClass' and false will always evaluate to true.
+Call to function is_subclass_of() with arguments class-string<Bug13713\test>, 'stdClass' and true will always evaluate to true.
+Call to function method_exists() with $this(CheckTypeFunctionCall\FinalClassWithMethodExists) and 'doBar' will always evaluate to false.
+Call to function method_exists() with $this(CheckTypeFunctionCall\FinalClassWithMethodExists) and 'doFoo' will always evaluate to true.
+Call to function method_exists() with $this(CheckTypeFunctionCall\MethodExistsWithTrait) and 'method' will always evaluate to true.
+Call to function method_exists() with $this(CheckTypeFunctionCall\MethodExistsWithTrait) and 'someAnother' will always evaluate to true.
+Call to function method_exists() with $this(CheckTypeFunctionCall\MethodExistsWithTrait) and 'unknown' will always evaluate to false.
+Call to function method_exists() with 'CheckTypeFunctionCall\\MethodExists' and 'testWithStringFirst…' will always evaluate to true.
+Call to function method_exists() with 'CheckTypeFunctionCall\\MethodExistsWithTrait' and 'method' will always evaluate to true.
+Call to function method_exists() with 'CheckTypeFunctionCall\\MethodExistsWithTrait' and 'someAnother' will always evaluate to true.
+Call to function method_exists() with 'CheckTypeFunctionCall\\MethodExistsWithTrait' and 'unknown' will always evaluate to false.
+Call to function method_exists() with 'UndefinedClass' and 'test' will always evaluate to false.
+Call to function method_exists() with 'UndefinedClass' and string will always evaluate to false.
+Call to function method_exists() with CheckTypeFunctionCall\Foo and 'doFoo' will always evaluate to true.
+Call to function method_exists() with CheckTypeFunctionCall\Foo and 'test' will always evaluate to false.
+Call to function method_exists() with CheckTypeFunctionCall\MethodExists and 'testWithNewObjectIn…' will always evaluate to true.
+Call to function method_exists() with CheckTypeFunctionCall\MethodExists and 'undefinedMethod' will always evaluate to false.
+Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>&literal-string and 'nonExistent' will always evaluate to false.
+Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>&literal-string and 'nonStaticAbc' will always evaluate to true.
+Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>&literal-string and 'staticAbc' will always evaluate to true.
+Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\S>&literal-string and 'nonStaticAbc' will always evaluate to true.
+Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\S>&literal-string and 'staticAbc' will always evaluate to true.
+Call to function mkdir() on a separate line has no effect.
+Call to function print_r() on a separate line has no effect.
+Call to function property_exists() with $this(CheckTypeFunctionCall\FinalClassWithPropertyExists) and 'fooProperty' will always evaluate to true.
+Call to function property_exists() with CheckTypeFunctionCall\Bug2221 and 'foo' will always evaluate to true.
+Call to function property_exists() with object{foo: int, bar?: string} and 'baz' will always evaluate to false.
+Call to function sprintf() on a separate line has no effect.
+Call to function strlen() on a separate line has no effect.
+Call to function strlen() with incorrect case: StrLen
+Call to function testIsInt() with int will always evaluate to true.
+Call to function testIsInt() with string will always evaluate to false.
+Call to function testIsNotInt() with int will always evaluate to false.
+Call to function testIsNotInt() with string will always evaluate to true.
+Call to function unset() contains undefined variable $notSetVariable.
+Call to function var_export() on a separate line has no effect.
+Call to internal function FunctionInternalTagOne\doInternal() from outside its root namespace FunctionInternalTagOne.
+Call to internal function doInternalWithoutNamespace().
+Call to internal method ClassInternal::internalMethod().
+Call to internal method FooWithInternalMethodWithoutNamespace::doInternal().
+Call to internal method InternalConstructorDefinition\Foo::__construct() from outside its root namespace InternalConstructorDefinition.
+Call to internal method MethodInternalTagOne\Foo::doInternal() from outside its root namespace MethodInternalTagOne.
+Call to internal static method ClassInternal::internalStaticMethod().
+Call to internal static method FooWithInternalStaticMethodWithoutNamespace::doInternal().
+Call to internal static method StaticMethodInternalTagOne\Foo::doInternal() from outside its root namespace StaticMethodInternalTagOne.
+Call to method Bug11011\AnotherPureImpl::doFoo() on a separate line has no effect.
+Call to method Bug12087b\MyAssert::is_null() with null will always evaluate to true.
+Call to method Bug8169\HelloWorld::assertString() with int will always evaluate to false.
+Call to method Bug8169\HelloWorld::assertString() with string will always evaluate to true.
+Call to method CallToMethodWithoutImpurePoints\AbstractFoo::myFunc() on a separate line has no effect.
+Call to method CallToMethodWithoutImpurePoints\CallsPrivateMethodWithoutImpurePoints::doBar() on a separate line has no effect.
+Call to method CallToMethodWithoutImpurePoints\finalSubSubY::mySubSubFunc() on a separate line has no effect.
+Call to method CallToMethodWithoutImpurePoints\finalX::myFunc() on a separate line has no effect.
+Call to method CallToMethodWithoutImpurePoints\foo::finalFunc() on a separate line has no effect.
+Call to method CallToMethodWithoutImpurePoints\y::myFinalBaseFunc() on a separate line has no effect.
+Call to method CallToMethodWithoutImpurePoints\y::myFunc() on a separate line has no effect.
+Call to method DateTime::format() on a separate line has no effect.
+Call to method DateTimeImmutable::add() on a separate line has no effect.
+Call to method DateTimeImmutable::modify() on a separate line has no effect.
+Call to method DateTimeImmutable::setDate() on a separate line has no effect.
+Call to method DateTimeImmutable::setISODate() on a separate line has no effect.
+Call to method DateTimeImmutable::setTime() on a separate line has no effect.
+Call to method DateTimeImmutable::setTimestamp() on a separate line has no effect.
+Call to method DateTimeImmutable::setTimezone() on a separate line has no effect.
+Call to method Exception::getCode() on a separate line has no effect.
+Call to method Exception::getMessage() on a separate line has no effect.
+Call to method FirstClassCallableMethodWithoutSideEffect\Bar::doBar() on a separate line has no effect.
+Call to method FirstClassCallableMethodWithoutSideEffect\Bar::doFoo() on a separate line has no effect.
+Call to method FirstClassCallableMethodWithoutSideEffect\Foo::doFoo() on a separate line has no effect.
+Call to method ImpossibleMethodCallInTrait\TypeChecker::isString() with int will always evaluate to false.
+Call to method ImpossibleMethodCall\ConditionalAlwaysTrue::isInt() with int will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with '' and '' will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with '1' and stdClass will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with 'foo' and 'foo' will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with 1 and 1 will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with 1 and 2 will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with 1 and stdClass will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with 2 and 2 will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with array{'a', 'b'} and array{1, 2} will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with array{1, 3} and array{1, 3} will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with array{} and array{} will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with stdClass and '1' will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isNotSame() with stdClass and stdClass will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isSame() with '' and '' will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isSame() with '1' and stdClass will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isSame() with 'foo' and 'foo' will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isSame() with 1 and 1 will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isSame() with 1 and 2 will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isSame() with 1 and stdClass will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isSame() with array{'a', 'b'} and array{1, 2} will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isSame() with array{1, 3} and array{1, 3} will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isSame() with array{} and array{} will always evaluate to true.
+Call to method ImpossibleMethodCall\Foo::isSame() with stdClass and '1' will always evaluate to false.
+Call to method ImpossibleMethodCall\Foo::isSame() with stdClass and stdClass will always evaluate to true.
+Call to method IncorrectMethodCase\Foo::fooBar() with incorrect case: foobar
+Call to method MethodCallStatementNoSideEffects\Bar::doPure() on a separate line has no effect.
+Call to method MethodCallStatementNoSideEffects\Bar::doPureWithThrowsVoid() on a separate line has no effect.
+Call to method MethodCallStatementNoSideEffects\Bzz::pure1() on a separate line has no effect.
+Call to method MethodCallStatementNoSideEffects\Bzz::pure2() on a separate line has no effect.
+Call to method MethodCallStatementNoSideEffects\Bzz::pure3() on a separate line has no effect.
+Call to method MethodCallStatementNoSideEffects\Bzz::pure4() on a separate line has no effect.
+Call to method MethodCallStatementNoSideEffects\Bzz::pure5() on a separate line has no effect.
+Call to method MethodCallable\Foo::doFoo() with incorrect case: dofoo
+Call to method PHPStan\Tests\AssertionClass::assertNotInt() with int will always evaluate to false.
+Call to method PHPStan\Tests\AssertionClass::assertNotInt() with string will always evaluate to true.
+Call to method PHPStan\Tests\AssertionClass::assertString() with int will always evaluate to false.
+Call to method PHPStan\Tests\AssertionClass::assertString() with string will always evaluate to true.
+Call to method ReflectionClass<Bug12473\PictureUser>::isSubclassOf() with 'Bug12473\\PictureProduct' will always evaluate to false.
+Call to method StaticCallsToInstanceMethods\Foo::doFoo() with incorrect case: dofoo
+Call to method __construct() of internal class Bug12951Polyfill\NumberFormatter from outside its root namespace Bug12951Polyfill.
+Call to method doFoo() of internal class FooInternalWithoutNamespace.
+Call to method doFoo() of internal class MethodInternalTagOne\FooInternal from outside its root namespace MethodInternalTagOne.
+Call to method doFoo() on an unknown class MethodCallable\Nonexistent.
+Call to method doFoo() on an unknown class Test\UnknownClass.
+Call to method test() on an unknown class Test\FirstUnknownClass.
+Call to method test() on an unknown class Test\SecondUnknownClass.
+Call to new CallToConstructorWithoutImpurePoints\Foo() on a separate line has no effect.
+Call to new ConstructorStatementNoSideEffects\NoConstructor() on a separate line has no effect.
+Call to new PDOStatement() on a separate line has no effect.
+Call to new stdClass() on a separate line has no effect.
+Call to preg_quote() is missing delimiter & to be effective.
+Call to preg_quote() is missing delimiter parameter to be effective.
+Call to preg_quote() uses invalid delimiter / while pattern uses &.
+Call to printf contains an invalid placeholder.
+Call to private method __construct() of class CallStaticMethods\ClassWithConstructor.
+Call to private method doBar() of class MethodCallable\Bar.
+Call to private method doFoo() of class MethodCallable\ParentClass.
+Call to private method doPrivateFoo() of class StaticCallsToInstanceMethods\Foo.
+Call to private method foo() of class Test\Foo.
+Call to private method privateFooMethod() of class CallCallables\Foo.
+Call to private method privateMethod() of class CallClosureBind\Foo.
+Call to private method somethingElse() of class Bug12544\Bar.
+Call to private static method doBar() of class StaticMethodCallable\Bar.
+Call to private static method dolor() of class CallStaticMethods\Foo.
+Call to protected static method baz() of class CallStaticMethods\Foo.
+Call to sprintf contains 0 placeholders, 1 value given.
+Call to sprintf contains 1 placeholder, 0 values given.
+Call to sprintf contains 1 placeholder, 2 values given.
+Call to sprintf contains 2 placeholders, 0 values given.
+Call to sprintf contains 2 placeholders, 1 value given.
+Call to sprintf contains 2 placeholders, 3 values given.
+Call to sprintf contains 4 placeholders, 0 values given.
+Call to sprintf contains 5 placeholders, 2 values given.
+Call to sprintf contains 6 placeholders, 0 values given.
+Call to sscanf contains 2 placeholders, 1 value given.
+Call to static method Bug12087b\MyAssert::static_is_null() with null will always evaluate to true.
+Call to static method CallStaticMethods\Foo::test() with incorrect case: TEST
+Call to static method FirstClassCallableStaticMethodWithoutSideEffect\Bar::doBar() on a separate line has no effect.
+Call to static method FirstClassCallableStaticMethodWithoutSideEffect\Bar::doFoo() on a separate line has no effect.
+Call to static method FirstClassCallableStaticMethodWithoutSideEffect\Foo::doFoo() on a separate line has no effect.
+Call to static method ImpossibleStaticMethodCallInTrait\TypeChecker::isString() with int will always evaluate to false.
+Call to static method ImpossibleStaticMethodCall\ConditionalAlwaysTrue::isInt() with int will always evaluate to true.
+Call to static method IncorrectStaticMethodCase\Foo::fooBar() with incorrect case: foobar
+Call to static method PHPStan\Tests\AssertionClass::assertInt() with 1 and 2 will always evaluate to true.
+Call to static method PHPStan\Tests\AssertionClass::assertInt() with arguments 1, 2 and 3 will always evaluate to true.
+Call to static method PHPStan\Tests\AssertionClass::assertInt() with int will always evaluate to true.
+Call to static method PHPStan\Tests\AssertionClass::assertInt() with string will always evaluate to false.
+Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure1() on a separate line has no effect.
+Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure2() on a separate line has no effect.
+Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure3() on a separate line has no effect.
+Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure4() on a separate line has no effect.
+Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure5() on a separate line has no effect.
+Call to static method StaticMethodCallStatementNoSideEffects\PureThrows::pureAndThrowsVoid() on a separate line has no effect.
+Call to static method StaticMethodCallable\Foo::doFoo() with incorrect case: dofoo
+Call to static method doBar() of internal class Bug12951Polyfill\NumberFormatter from outside its root namespace Bug12951Polyfill.
+Call to static method doBar() of internal class StaticMethodCallOnInternalSubclassOne\Bar from outside its root namespace StaticMethodCallOnInternalSubclassOne.
+Call to static method doFoo() of internal class FooInternalStaticWithoutNamespace.
+Call to static method doFoo() of internal class StaticMethodInternalTagOne\FooInternal from outside its root namespace StaticMethodInternalTagOne.
+Call to static method doFoo() on an unknown class CallStaticMethods\TraitWithStaticMethod.
+Call to static method doFoo() on an unknown class StaticMethodCallable\Nonexistent.
+Call to static method doFoo() on internal class StaticMethodCallOnInternalSubclassOne\Bar.
+Call to static method loremIpsum() on an unknown class CallStaticMethods\UnknownStaticMethodClass.
+Call to vprintf contains 2 placeholders, 1 value given.
+Call to vsprintf contains 0 placeholders, 1 value given.
+Call to vsprintf contains 1 placeholder, 1-2 values given.
+Call to vsprintf contains 1 placeholder, 2 values given.
+Call to vsprintf contains 2 placeholders, 0 values given.
+Call to vsprintf contains 2 placeholders, 1 value given.
+Call to vsprintf contains 4 placeholders, 0 values given.
+Call to vsprintf contains 5 placeholders, 2 values given.
+Call to vsprintf contains an invalid placeholder.
+Call-site variance annotation of covariant EnumGenericAncestors\NonGeneric in generic type EnumGenericAncestors\Generic<covariant EnumGenericAncestors\NonGeneric, int> in PHPDoc tag @implements is not allowed.
+Call-site variance annotation of covariant LogicException in generic type InterfaceAncestorsExtends\FooGeneric<int, covariant LogicException> in PHPDoc tag @extends is not allowed.
+Call-site variance annotation of covariant Throwable in generic type ClassAncestorsExtends\FooGeneric<covariant Throwable, InvalidArgumentException> in PHPDoc tag @extends is not allowed.
+Call-site variance annotation of covariant Throwable in generic type ClassAncestorsImplements\FooGeneric<covariant Throwable, InvalidArgumentException> in PHPDoc tag @implements is not allowed.
+Call-site variance annotation of covariant Throwable in generic type UsedTraits\GenericTrait<covariant Throwable> in PHPDoc tag @use is not allowed.
+Call-site variance of contravariant MixinRule\Foo in generic type MixinRule\Adipiscing<contravariant MixinRule\Foo> in PHPDoc tag @mixin is in conflict with covariant template type T of class MixinRule\Adipiscing.
+Call-site variance of contravariant int in generic type ClassTemplateType\Consecteur<contravariant int> in PHPDoc tag @template W is in conflict with covariant template type T of class ClassTemplateType\Consecteur.
+Call-site variance of contravariant int in generic type FunctionTemplateType\GenericCovariant<contravariant int> in PHPDoc tag @template W is in conflict with covariant template type T of class FunctionTemplateType\GenericCovariant.
+Call-site variance of contravariant int in generic type InterfaceTemplateType\Covariant<contravariant int> in PHPDoc tag @template W is in conflict with covariant template type T of interface InterfaceTemplateType\Covariant.
+Call-site variance of contravariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<contravariant int> in PHPDoc tag @param for parameter $foo is in conflict with covariant template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric.
+Call-site variance of contravariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<contravariant int> in PHPDoc tag @return is in conflict with covariant template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric.
+Call-site variance of contravariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<contravariant int> in PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$genericIncompatibleTypeProjection is in conflict with covariant template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric.
+Call-site variance of contravariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<contravariant int> in PHPDoc tag @var for variable $test is in conflict with covariant template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric.
+Call-site variance of contravariant int in generic type MethodTemplateType\Dolor<contravariant int> in PHPDoc tag @template W is in conflict with covariant template type T of class MethodTemplateType\Dolor.
+Call-site variance of contravariant int in generic type TraitTemplateType\Dolor<contravariant int> in PHPDoc tag @template W is in conflict with covariant template type T of class TraitTemplateType\Dolor.
+Call-site variance of covariant MixinRule\Foo in generic type MixinRule\Adipiscing<covariant MixinRule\Foo> in PHPDoc tag @mixin is redundant, template type T of class MixinRule\Adipiscing has the same variance.
+Call-site variance of covariant int in generic type ClassTemplateType\Consecteur<covariant int> in PHPDoc tag @template U is redundant, template type T of class ClassTemplateType\Consecteur has the same variance.
+Call-site variance of covariant int in generic type FunctionTemplateType\GenericCovariant<covariant int> in PHPDoc tag @template U is redundant, template type T of class FunctionTemplateType\GenericCovariant has the same variance.
+Call-site variance of covariant int in generic type InterfaceTemplateType\Covariant<covariant int> in PHPDoc tag @template U is redundant, template type T of interface InterfaceTemplateType\Covariant has the same variance.
+Call-site variance of covariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<covariant int> in PHPDoc tag @param for parameter $foo is redundant, template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric has the same variance.
+Call-site variance of covariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<covariant int> in PHPDoc tag @return is redundant, template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric has the same variance.
+Call-site variance of covariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<covariant int> in PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$genericRedundantTypeProjection is redundant, template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric has the same variance.
+Call-site variance of covariant int in generic type InvalidPhpDocDefinitions\FooCovariantGeneric<covariant int> in PHPDoc tag @var for variable $test is redundant, template type T of class InvalidPhpDocDefinitions\FooCovariantGeneric has the same variance.
+Call-site variance of covariant int in generic type MethodTemplateType\Dolor<covariant int> in PHPDoc tag @template U is redundant, template type T of class MethodTemplateType\Dolor has the same variance.
+Call-site variance of covariant int in generic type TraitTemplateType\Dolor<covariant int> in PHPDoc tag @template U is redundant, template type T of class TraitTemplateType\Dolor has the same variance.
+CallStaticMethods\Ipsum::ipsumTest() calls parent::lorem() but CallStaticMethods\Ipsum does not extend any class.
+Callable 'CallCallables\\Foo:…' invoked with 1 parameter, 0 required.
+Callable 'date' invoked with 0 parameters, 1-2 required.
+Callable array{'CallCallables\\Foo', 'doStaticBaz'} invoked with 1 parameter, 0 required.
+Callable passed to call_user_func() invoked with 0 parameters, 1 required.
+Callable passed to call_user_func() invoked with 0 parameters, 2-4 required.
+Callable passed to call_user_func() invoked with 0 parameters, at least 2 required.
+Callable passed to call_user_func() invoked with 1 parameter, 2-4 required.
+Callable passed to call_user_func() invoked with 1 parameter, at least 2 required.
+Callable passed to call_user_func() invoked with named argument $i, but it's not allowed because of @no-named-arguments.
+Callable passed to call_user_func_array() invoked with 0 parameters, 1 required.
+Callable passed to call_user_func_array() invoked with 0 parameters, 2-4 required.
+Callable passed to call_user_func_array() invoked with 0 parameters, at least 2 required.
+Callable passed to call_user_func_array() invoked with 1 parameter, 2-4 required.
+Callable passed to call_user_func_array() invoked with 1 parameter, at least 2 required.
+Calling PHPStan\Command\CommandHelper::begin() is not covered by backward compatibility promise. The method might change in a minor PHPStan version.
+Calling PHPStan\Node\InClassNode::__construct() is not covered by backward compatibility promise. The method might change in a minor PHPStan version.
+Calling PHPStan\Rules\Debug\DumpTypeRule::getNodeType() is not covered by backward compatibility promise. The method might change in a minor PHPStan version.
+Calling PHPStan\Type\Php\ArrayKeyDynamicReturnTypeExtension::isFunctionSupported() is not covered by backward compatibility promise. The method might change in a minor PHPStan version.
+Calling parent::someStaticMethod() outside of class scope.
+Calling self::someStaticMethod() outside of class scope.
+Calling static::someStaticMethod() outside of class scope.
+Cannot access $foo
+Cannot access FOO
+Cannot access an offset on callable.
+Cannot access an offset on int.
+Cannot access an offset on int<3, 4>.
+Cannot access an offset on mixed.
+Cannot access constant FOO on int|string.
+Cannot access constant LOREM on mixed.
+Cannot access constant TEST on trait ClassConstantAccessedOnTrait\Foo.
+Cannot access constant class on stdClass|null.
+Cannot access constant class on string|null.
+Cannot access offset 'a' on Closure(): void.
+Cannot access offset 'a' on array{a: 1, b: 1}|(Closure(): void).
+Cannot access offset 'a' on stdClass.
+Cannot access offset 'foo' on 4.141.
+Cannot access offset 'foo' on 42.
+Cannot access offset 'foo' on array|int.
+Cannot access offset 'foo' on bool.
+Cannot access offset 'foo' on false.
+Cannot access offset 'foo' on resource.
+Cannot access offset 'foo' on stdClass.
+Cannot access offset 'foo' on true.
+Cannot access offset 'invalidoffset' on Bug6605\X.
+Cannot access offset 'path' on Closure.
+Cannot access offset 'path' on iterable<int|string, object>.
+Cannot access offset 'permission' on mixed.
+Cannot access offset 'title' on mixed.
+Cannot access offset (int|string) on $this(Bug3782\HelloWorld)|(ArrayAccess&Bug3782\HelloWorld).
+Cannot access offset 0 on Closure(): void.
+Cannot access offset 0 on array{'test'}|(Closure(): void).
+Cannot access offset 0 on array{'test'}|stdClass.
+Cannot access offset 0 on parent.
+Cannot access offset 0 on stdClass.
+Cannot access offset 42 on bool.
+Cannot access offset 42 on float.
+Cannot access offset 42 on int.
+Cannot access offset 42 on resource.
+Cannot access offset 5 on T of mixed.
+Cannot access offset 5 on mixed.
+Cannot access offset mixed on (float|int).
+Cannot access offset string on mixed.
+Cannot access property $bar on TestAccessProperties\NullCoalesce|null.
+Cannot access property $bar on string.
+Cannot access property $bob on array<string, mixed>.
+Cannot access property $child on Bug5868PropertyFetch\Child|null.
+Cannot access property $child on Bug5868PropertyFetch\Foo|null.
+Cannot access property $existingChild on Bug5868PropertyFetch\Child|null.
+Cannot access property $foo on TestAccessProperties\NullCoalesce|null.
+Cannot access property $foo on null.
+Cannot access property $fooProperty on null.
+Cannot access property $ipsum on TestAccessProperties\FooAccessProperties|null.
+Cannot access property $prop on string.
+Cannot access property $propertyOnString on string.
+Cannot access property $selfOrNull on TestAccessProperties\RevertNonNullabilityForIsset|null.
+Cannot access static property $anotherProperty on ClassOrString|false.
+Cannot access static property $foo on int|string.
+Cannot assign new offset to OffsetAccessAssignment\ObjectWithOffsetAccess.
+Cannot assign new offset to string.
+Cannot assign offset 'foo' to array|int.
+Cannot assign offset 'foo' to array|string.
+Cannot assign offset 'foo' to string.
+Cannot assign offset 12.34 to string.
+Cannot assign offset array{1, 2, 3} to SplObjectStorage<object, mixed>.
+Cannot assign offset false to OffsetAccessAssignment\ObjectWithOffsetAccess.
+Cannot assign offset false to string.
+Cannot assign offset int|null to string.
+Cannot assign offset int|object to array|string.
+Cannot assign offset int|object to string.
+Cannot assign offset stdClass to string.
+Cannot call __toString
+Cannot call abstract method CallParentAbstractMethod\Baz::uninstall().
+Cannot call abstract method CallParentAbstractMethod\Lorem::doFoo().
+Cannot call abstract static method CallParentAbstractMethod\SitAmet::doFoo().
+Cannot call abstract static method CallStaticMethods\InterfaceWithStaticMethod::doFoo().
+Cannot call abstract static method InterfaceMethods\Foo::fooStaticMethod().
+Cannot call abstract static method StaticMethodCallable\Bar::doBaz().
+Cannot call doFoo
+Cannot call method abc() on class-string.
+Cannot call method add() on null.
+Cannot call method answer() on Bug4199\Baz|null.
+Cannot call method bar() on string.
+Cannot call method doFoo() on int.
+Cannot call method find() on Test\NullCoalesce|null.
+Cannot call method foo() on BugTemplateMixedUnionIntersect\FooInterface|T of mixed.
+Cannot call method foo() on T of mixed.
+Cannot call method foo() on class-string|object.
+Cannot call method foo() on int|string.
+Cannot call method foo() on mixed.
+Cannot call method foo() on null.
+Cannot call method ipsum() on Test\Bar|null.
+Cannot call method ipsum() on Test\Foo|null.
+Cannot call method isAllowed() on bool.
+Cannot call method method() on string.
+Cannot call method nonExistent() on class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>.
+Cannot call method nonExistent() on class-string<ImpossibleMethodExistsOnGenericClassString\S>.
+Cannot call method nonStaticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>.
+Cannot call method nonStaticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\S>.
+Cannot call method nullable1() on Bug5868\HelloWorld|null.
+Cannot call method nullable2() on Bug5868\HelloWorld|null.
+Cannot call method nullable3() on Bug5868\HelloWorld|null.
+Cannot call method staticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>.
+Cannot call method staticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\S>.
+Cannot call method test() on array<Test\UnknownClass>.
+Cannot call method test() on string.
+Cannot call static method doFoo() on int.
+Cannot call static method foo() on T of mixed.
+Cannot call static method foo() on int|string.
+Cannot call static method foo() on mixed.
+Cannot cast T to float.
+Cannot cast T to int.
+Cannot cast T to string.
+Cannot cast Test\Foo to string.
+Cannot cast array|float|int to string.
+Cannot cast mixed to float.
+Cannot cast mixed to int.
+Cannot cast mixed to string.
+Cannot cast object to string.
+Cannot cast object|string to string.
+Cannot cast stdClass to float.
+Cannot cast stdClass to int.
+Cannot cast stdClass to string.
+Cannot cast stdClass|null to string.
+Cannot clone int|string.
+Cannot clone non-object variable $bar of type string|VariableCloning\Foo.
+Cannot clone non-object variable $baz of type VariableCloning\Bar|VariableCloning\Foo|null.
+Cannot clone non-object variable $stringData of type string.
+Cannot clone stdClass|null.
+Cannot clone string.
+Cannot create callable from the new operator.
+Cannot declare class NoNamespace because the name is already in use.
+Cannot declare class SomeNamespace\SimpleUses because the name is already in use.
+Cannot declare interface SomeNamespace\GroupedUses because the name is already in use.
+Cannot declare trait FirstNamespace\MultipleNamespaces because the name is already in use.
+Cannot import type alias ImportedAliasFromNonClass: class LocalTypeAliases\int does not exist.
+Cannot import type alias ImportedAliasFromNonClass: class LocalTypeTraitAliases\int does not exist.
+Cannot import type alias ImportedAliasFromUnknownClass: class LocalTypeAliases\UnknownClass does not exist.
+Cannot import type alias ImportedAliasFromUnknownClass: class LocalTypeTraitAliases\UnknownClass does not exist.
+Cannot import type alias ImportedUnknownAlias: type alias does not exist in LocalTypeAliases\Foo.
+Cannot import type alias ImportedUnknownAlias: type alias does not exist in LocalTypeTraitAliases\Foo.
+Cannot import type alias Test: class LocalTypeAliasesEnums\NonexistentClass does not exist.
+Cannot instantiate class TestInstantiation\ClassExtendsProtectedConstructorClass via protected constructor TestInstantiation\ProtectedConstructorClass::__construct().
+Cannot instantiate class TestInstantiation\ExtendsPrivateConstructorClass via private constructor TestInstantiation\PrivateConstructorClass::__construct().
+Cannot instantiate class TestInstantiation\PrivateConstructorClass via private constructor TestInstantiation\PrivateConstructorClass::__construct().
+Cannot instantiate class TestInstantiation\ProtectedConstructorClass via protected constructor TestInstantiation\ProtectedConstructorClass::__construct().
+Cannot instantiate enum EnumInstantiation\Foo.
+Cannot instantiate interface Bug4471\Bar.
+Cannot instantiate interface TestInstantiation\IpsumInstantiation.
+Cannot instantiate trait Bug14251\InternalTrait.
+Cannot re-assign $this.
+Cannot redeclare constant Bug14250\TraitWithDuplicateConstants::CONST1.
+Cannot redeclare constant Bug14250\TraitWithDuplicateConstants::CONST2.
+Cannot redeclare constant DuplicateDeclarations\Foo::CONST1.
+Cannot redeclare constant DuplicateDeclarations\Foo::CONST2.
+Cannot redeclare constant DuplicatedEnumCase\Hoo::BAR.
+Cannot redeclare enum case DuplicatedEnumCase\Boo::BAR.
+Cannot redeclare enum case DuplicatedEnumCase\Foo::BAR.
+Cannot redeclare method Bug14250\MyTrait::doSomething().
+Cannot redeclare method Bug14250\TraitWithDuplicateMethods::Func1().
+Cannot redeclare method Bug14250\TraitWithDuplicateMethods::func1().
+Cannot redeclare method DuplicateDeclarations\Foo::Func1().
+Cannot redeclare method DuplicateDeclarations\Foo::func1().
+Cannot redeclare property Bug14250PromotedProperties\TraitWithDuplicatePromotedProperties::$bar.
+Cannot redeclare property Bug14250PromotedProperties\TraitWithDuplicatePromotedProperties::$foo.
+Cannot redeclare property Bug14250\TraitWithDuplicateProperties::$prop1.
+Cannot redeclare property Bug14250\TraitWithDuplicateProperties::$prop2.
+Cannot redeclare property DuplicateDeclarations\Foo::$prop1.
+Cannot redeclare property DuplicateDeclarations\Foo::$prop2.
+Cannot redeclare property DuplicatedPromotedProperty\Foo::$bar.
+Cannot redeclare property DuplicatedPromotedProperty\Foo::$foo.
+Cannot unset @readonly Bug12421\PhpdocImmutableClass::$y property.
+Cannot unset @readonly Bug12421\PhpdocReadonlyClass::$y property.
+Cannot unset @readonly Bug12421\PhpdocReadonlyProperty::$y property.
+Cannot unset offset 'a' on 3.
+Cannot unset offset 'b' on 1.
+Cannot unset offset 'c' on 1.
+Cannot unset offset 'limit' on array{categoryKeys: array<string>, tagNames: array<string>}.
+Cannot unset offset 'page' on array{categoryKeys: array<string>, tagNames: array<string>}.
+Cannot unset offset 'string' on iterable<int, int>.
+Cannot unset readonly Bug12421\NativeReadonlyClass::$y property.
+Cannot unset readonly Bug12421\NativeReadonlyProperty::$y property.
+Cannot use $this as global variable.
+Cannot use $this as lexical variable.
+Cannot use $this as parameter.
+Cannot use $this as static variable.
+Cannot use ++ on (array|object).
+Cannot use ++ on InvalidIncDec\ClassWithToString.
+Cannot use ++ on T of mixed.
+Cannot use ++ on a non-variable.
+Cannot use ++ on array{}.
+Cannot use ++ on array|bool|float|int|object|string|null.
+Cannot use ++ on bool.
+Cannot use ++ on mixed.
+Cannot use ++ on resource.
+Cannot use ++ on stdClass.
+Cannot use ++ on true.
+Cannot use -- on 'a'.
+Cannot use -- on (array|object).
+Cannot use -- on InvalidIncDec\ClassWithToString.
+Cannot use -- on T of mixed.
+Cannot use -- on a non-variable.
+Cannot use -- on array{}.
+Cannot use -- on array|bool|float|int|object|string|null.
+Cannot use -- on bool.
+Cannot use -- on false.
+Cannot use -- on mixed.
+Cannot use -- on null.
+Cannot use -- on resource.
+Cannot use -- on string.
+Cannot use SomeOtherNamespace\FooBar as FooBar because the name is already in use.
+Cannot use SomeOtherNamespace\UsesUnderClass as GroupedUsesUnderClass because the name is already in use.
+Cannot use SomeOtherNamespace\UsesUnderClass as SimpleUsesUnderClass because the name is already in use.
+Cannot use [] for reading.
+Cannot use array destructuring on array|null.
+Cannot use array destructuring on stdClass.
+Cannot use lexical variable $bar since a parameter with the same name already exists.
+Cannot use lexical variable $baz since a parameter with the same name already exists.
+Cannot use superglobal variable $GLOBALS as lexical variable.
+Cannot use superglobal variable $_COOKIE as lexical variable.
+Cannot use superglobal variable $_ENV as lexical variable.
+Cannot use superglobal variable $_FILES as lexical variable.
+Cannot use superglobal variable $_GET as lexical variable.
+Cannot use superglobal variable $_POST as lexical variable.
+Cannot use superglobal variable $_REQUEST as lexical variable.
+Cannot use superglobal variable $_SERVER as lexical variable.
+Cannot use superglobal variable $_SESSION as lexical variable.
+Caught class FooCatchException not found.
+Caught class TestCatch\FooCatch is not an exception.
+Circular definition detected in type alias CircularTypeAlias1.
+Circular definition detected in type alias CircularTypeAlias2.
+Circular definition detected in type alias CircularTypeAliasImport1.
+Circular definition detected in type alias CircularTypeAliasImport2.
+Circular definition detected in type alias RecursiveTypeAlias.
+Class Bug11552\SomeResult @extends tag contains unresolvable type.
+Class Bug7219\Foo has an uninitialized property $email. Give it default value or assign it in the constructor.
+Class Bug7219\Foo has an uninitialized property $id. Give it default value or assign it in the constructor.
+Class Bug7649\Foo has an uninitialized readonly property $bar. Assign it in the constructor.
+Class Bug8889\HelloWorld implements unknown interface iterable.
+Class Bug8889\HelloWorld2 implements unknown interface Iterable.
+Class Bug9577\SpecializedException2 has an uninitialized readonly property $message. Assign it in the constructor.
+Class Bug9863\ReadonlyParentWithIsset has an uninitialized readonly property $foo. Assign it in the constructor.
+Class CallStaticMethods\Foo referenced with incorrect case: CallStaticMethods\FOO.
+Class ClassAncestorsExtends\FilterIteratorChild extends generic class FilterIterator but does not specify its types: TKey, TValue, TIterator
+Class ClassAncestorsExtends\FooCollection @extends tag contains incompatible type ClassAncestorsExtends\FooCollection&iterable<int>.
+Class ClassAncestorsExtends\FooCollection extends generic class ClassAncestorsExtends\AbstractFooCollection but does not specify its types: T
+Class ClassAncestorsExtends\FooDoesNotExtendAnything has @extends tag, but does not extend any class.
+Class ClassAncestorsExtends\FooExtendsGenericClass extends generic class ClassAncestorsExtends\FooGeneric but does not specify its types: T, U
+Class ClassAncestorsExtends\FooObjectStorage @extends tag contains incompatible type ClassAncestorsExtends\FooObjectStorage.
+Class ClassAncestorsExtends\FooObjectStorage extends generic class SplObjectStorage but does not specify its types: TObject, TData
+Class ClassAncestorsExtends\FooWrongClassExtended extends generic class ClassAncestorsExtends\FooGeneric but does not specify its types: T, U
+Class ClassAncestorsExtends\FooWrongTypeInExtendsTag @extends tag contains incompatible type class-string<ClassAncestorsExtends\T>.
+Class ClassAncestorsExtends\FooWrongTypeInExtendsTag extends generic class ClassAncestorsExtends\FooGeneric but does not specify its types: T, U
+Class ClassAncestorsImplements\FooCollection @implements tag contains incompatible type ClassAncestorsImplements\FooCollection&iterable<int>.
+Class ClassAncestorsImplements\FooCollection implements generic interface ClassAncestorsImplements\AbstractFooCollection but does not specify its types: T
+Class ClassAncestorsImplements\FooDoesNotImplementAnything has @implements tag, but does not implement any interface.
+Class ClassAncestorsImplements\FooImplementsGenericInterface implements generic interface ClassAncestorsImplements\FooGeneric but does not specify its types: T, U
+Class ClassAncestorsImplements\FooIterator @implements tag contains incompatible type ClassAncestorsImplements\FooIterator&iterable<int, object>.
+Class ClassAncestorsImplements\FooIterator implements generic interface Iterator but does not specify its types: TKey, TValue
+Class ClassAncestorsImplements\FooWrongClassImplemented implements generic interface ClassAncestorsImplements\FooGeneric but does not specify its types: T, U
+Class ClassAncestorsImplements\FooWrongClassImplemented implements generic interface ClassAncestorsImplements\FooGeneric3 but does not specify its types: T, W
+Class ClassAncestorsImplements\FooWrongTypeInImplementsTag @implements tag contains incompatible type class-string<ClassAncestorsImplements\T>.
+Class ClassAncestorsImplements\FooWrongTypeInImplementsTag implements generic interface ClassAncestorsImplements\FooGeneric but does not specify its types: T, U
+Class ClassAttributes\Bar referenced with incorrect case: ClassAttributes\baR.
+Class ClassAttributes\Foo is not an Attribute class.
+Class ClassConstantNamespace\Bar not found.
+Class ClassConstantNamespace\Foo referenced with incorrect case: ClassConstantNamespace\FOO.
+Class ClassConstantVisibility\Foo referenced with incorrect case: ClassConstantVisibility\FOO.
+Class ClassExtendsEnum\Foo extends enum ClassExtendsEnum\FooEnum.
+Class ClassImplementsEnum\Foo implements enum ClassImplementsEnum\FooEnum.
+Class ClassTemplateType\Baz referenced with incorrect case: ClassTemplateType\baz.
+Class DatePeriod constructor invoked with 0 parameters, 1-4 required.
+Class DateTime referenced with incorrect case: DATETIME.
+Class DateTime referenced with incorrect case: Datetime.
+Class DateTimeImmutable referenced with incorrect case: dateTimeImmutable.
+Class DuplicateClassDeclaration\Foo declared multiple times:
+Class ExtendsError\Foo extends unknown class ExtendsError\Bar.
+Class ExtendsError\Ipsum extends trait ExtendsError\DolorTrait.
+Class ExtendsError\Lorem extends interface ExtendsError\BazInterface.
+Class ExtendsError\Sit extends final class ExtendsError\FinalFoo.
+Class ExtendsFinalByTag\Bar2 extends @final class ExtendsFinalByTag\Bar.
+Class ExtendsImplements\ExtendsFinalWithAnnotation extends @final class ExtendsImplements\FinalWithAnnotation.
+Class ExtendsImplements\Foo referenced with incorrect case: ExtendsImplements\FOO.
+Class FooAccessStaticProperties referenced with incorrect case: FOOAccessStaticPropertieS.
+Class FooFunctionTypehints referenced with incorrect case: FOOFunctionTypehints.
+Class FooFunctionTypehints referenced with incorrect case: fOOFunctionTypehintS.
+Class FooFunctionTypehints referenced with incorrect case: fOOFunctionTypehints.
+Class ImplementsError\Foo implements unknown interface ImplementsError\Bar.
+Class ImplementsError\Ipsum implements trait ImplementsError\DolorTrait.
+Class ImplementsError\Lorem implements class ImplementsError\Foo.
+Class InstanceOfNamespaceRule\Bar not found.
+Class InstanceOfNamespaceRule\Foo referenced with incorrect case: InstanceOfNamespaceRule\FOO.
+Class InvalidVarTagType\Foo referenced with incorrect case: InvalidVarTagType\foo.
+Class LocalTypeAliases\Foo referenced with incorrect case: LocalTypeAliases\fOO.
+Class LocalTypeAliases\MissingTypehints has type alias NoCallable with no signature specified for callable.
+Class LocalTypeAliases\MissingTypehints has type alias NoGenerics with generic class LocalTypeAliases\Generic but does not specify its types: T
+Class LocalTypeAliases\MissingTypehints has type alias NoIterableValue with no value type specified in iterable type array.
+Class MethodAssert\Foo referenced with incorrect case: MethodAssert\fOO.
+Class MethodTag\Foo has PHPDoc tag @method for method doMissingIterablueValue() return type with no value type specified in iterable type array.
+Class MethodTag\Foo referenced with incorrect case: MethodTag\fOO.
+Class MethodTag\MissingCallableSignature has PHPDoc tag @method for method doA() return type with no signature specified for callable.
+Class MethodTag\MissingIterableValue has PHPDoc tag @method for method doA() return type with no value type specified in iterable type array.
+Class MissingReadOnlyPropertyAssignPhpDoc\A has an uninitialized @readonly property $a. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\AssignOp has an uninitialized @readonly property $foo. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\B has an uninitialized @readonly property $b. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\BarDoubleAssignInSetter has an uninitialized @readonly property $foo. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\Foo has an uninitialized @readonly property $unassigned. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\Foo has an uninitialized @readonly property $unassigned2. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass has an uninitialized @readonly property $unassigned. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass has an uninitialized @readonly property $unassigned2. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\Immutable has an uninitialized @readonly property $unassigned. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssignPhpDoc\Immutable has an uninitialized @readonly property $unassigned2. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\AssignOp has an uninitialized readonly property $foo. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\BarDoubleAssignInSetter has an uninitialized readonly property $foo. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\Foo has an uninitialized readonly property $unassigned. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\Foo has an uninitialized readonly property $unassigned2. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\FooTraitClass has an uninitialized readonly property $unassigned. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\FooTraitClass has an uninitialized readonly property $unassigned2. Assign it in the constructor.
+Class MissingReadOnlyPropertyAssign\PropertyAssignedOnDifferentObjectUninitialized has an uninitialized readonly property $foo. Assign it in the constructor.
+Class MixinRule\Foo referenced with incorrect case: MixinRule\foo.
+Class MixinRule\NoCallableSignature has PHPDoc tag @mixin with no signature specified for callable.
+Class MixinRule\NoIterableValue has PHPDoc tag @mixin with no value type specified in iterable type array.
+Class OldStyleConstructorOnPhp8 does not have a constructor and must be instantiated without any parameters.
+Class ParamClosureThisClassesFunctions\Foo referenced with incorrect case: ParamClosureThisClassesFunctions\fOO.
+Class ParamClosureThisClasses\Foo referenced with incorrect case: ParamClosureThisClasses\fOO.
+Class ParamOutClassesMethods\Foo referenced with incorrect case: ParamOutClassesMethods\fOO.
+Class ParamOutClasses\Foo referenced with incorrect case: ParamOutClasses\fOO.
+Class PhpParser\Node\Expr\ArrayItem not found. It has been renamed to PhpParser\Node\ArrayItem in PHP-Parser v5.
+Class PromoteParameter\Foo has an uninitialized property $test. Give it default value or assign it in the constructor.
+Class PropertiesTypes\Foo referenced with incorrect case: PropertiesTypes\FOO.
+Class PropertyTag\Foo referenced with incorrect case: PropertyTag\fOO.
+Class PropertyTag\MissingCallableSignature has PHPDoc tag @property for property $a with no signature specified for callable.
+Class PropertyTag\MissingIterableValue has PHPDoc tag @property for property $a with no value type specified in iterable type array.
+Class RedeclareReadonlyProperty\B16 has an uninitialized readonly property $myProp. Assign it in the constructor.
+Class RedeclareReadonlyProperty\B18 has an uninitialized readonly property $aProp. Assign it in the constructor.
+Class RedeclareReadonlyProperty\B19 has an uninitialized property $prop2. Give it default value or assign it in the constructor.
+Class RedeclareReadonlyProperty\C17 has an uninitialized readonly property $aProp. Assign it in the constructor.
+Class SelfOutClasses\Foo referenced with incorrect case: SelfOutClasses\fOO.
+Class TestCatch\MyCatchException referenced with incorrect case: TestCatch\MyCatchEXCEPTION.
+Class TestClosureFunctionTypehints\FooFunctionTypehints referenced with incorrect case: TestClosureFunctionTypehints\FOOfUnctionTypehintS.
+Class TestClosureFunctionTypehints\FooFunctionTypehints referenced with incorrect case: TestClosureFunctionTypehints\fOOfUnctionTypehints.
+Class TestFunctionTypehints\FooFunctionTypehints referenced with incorrect case: TestFunctionTypehints\FOOFunctionTypehints.
+Class TestFunctionTypehints\FooFunctionTypehints referenced with incorrect case: TestFunctionTypehints\fOOFunctionTypehintS.
+Class TestFunctionTypehints\FooFunctionTypehints referenced with incorrect case: TestFunctionTypehints\fOOFunctionTypehints.
+Class TestInitializedProperty\TestAdditionalConstructor has an uninitialized property $one. Give it default value or assign it in the constructor.
+Class TestInitializedProperty\TestAdditionalConstructor has an uninitialized property $three. Give it default value or assign it in the constructor.
+Class TestInstantiation\AbstractClassWithFinalConstructor constructor invoked with 1 parameter, 0 required.
+Class TestInstantiation\AbstractConstructor constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\BarInstantiation constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\BarInstantiation referenced with incorrect case: TestInstantiation\BARInstantiation.
+Class TestInstantiation\ClassExtendingAbstractConstructor constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\ClassExtendsProtectedConstructorClass constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\ClassWithFinalConstructor constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\ConstructorComingFromAnInterface constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\ExtendsPrivateConstructorClass constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\FinalClass does not have a constructor and must be instantiated without any parameters.
+Class TestInstantiation\FooInstantiation does not have a constructor and must be instantiated without any parameters.
+Class TestInstantiation\FooInstantiation referenced with incorrect case: TestInstantiation\FOOInstantiation.
+Class TestInstantiation\InstantiatingClass constructor invoked with 0 parameters, 1 required.
+Class TestInstantiation\NoConstructor referenced with incorrect case: TestInstantiation\NOCONSTRUCTOR.
+Class TestMethodTypehints\FooMethodTypehints referenced with incorrect case: TestMethodTypehints\FOOMethodTypehints.
+Class TestMethodTypehints\FooMethodTypehints referenced with incorrect case: TestMethodTypehints\fOOMethodTypehintS.
+Class TestMethodTypehints\FooMethodTypehints referenced with incorrect case: TestMethodTypehints\fOOMethodTypehints.
+Class TraitUseEnum\Foo uses enum TraitUseEnum\FooEnum.
+Class TraitUseError\Foo uses unknown trait TraitUseError\FooTrait.
+Class UninitializedProperty\EarlyReturn has an uninitialized property $foo. Give it default value or assign it in the constructor.
+Class UninitializedProperty\Foo has an uninitialized property $bar. Give it default value or assign it in the constructor.
+Class UninitializedProperty\Foo has an uninitialized property $baz. Give it default value or assign it in the constructor.
+Class UninitializedProperty\FooTraitClass has an uninitialized property $bar. Give it default value or assign it in the constructor.
+Class UninitializedProperty\FooTraitClass has an uninitialized property $baz. Give it default value or assign it in the constructor.
+Class UninitializedProperty\Lorem has an uninitialized property $baz. Give it default value or assign it in the constructor.
+Class UninitializedProperty\SometimesInitializedInPrivateSetter has an uninitialized property $foo. Give it default value or assign it in the constructor.
+Class UninitializedProperty\TestExtension has an uninitialized property $uninited. Give it default value or assign it in the constructor.
+Class UnknownClass\Bar not found.
+Class UnknownClass\Foo not found.
+Class UsedTraits\Baz uses generic trait UsedTraits\GenericTrait but does not specify its types: T
+Class class@anonymous/tests/PHPStan/Rules/Classes/data/instantiation.php:137 constructor invoked with 3 parameters, 1 required.
+Class class@anonymous/tests/PHPStan/Rules/Properties/data/missing-readonly-anonymous-class-property-assign.php:10 has an uninitialized readonly property $foo. Assign it in the constructor.
+Class constant name for ClassConstantDynamicAccess\Foo must be a string, but object was given.
+Class constant name for ClassConstantDynamicStringableAccess\Bar must be a string, but mixed was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but 1111 was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but DateTime|string was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but Stringable was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but Stringable|null was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but int was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but int|null was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but mixed was given.
+Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but string|null was given.
+Class constant name for DateTime|DateTimeImmutable must be a string, but mixed was given.
+Class constant name for object must be a string, but mixed was given.
+Class constant name in dynamic fetch can only be a string, int given.
+Class constant name in dynamic fetch can only be a string, int|string given.
+Class constant name in dynamic fetch can only be a string, string|null given.
+Class finfo constructor invoked with 3 parameters, 0-2 required.
+Class stdClass referenced with incorrect case: STDClass.
+Class stdClass referenced with incorrect case: stdclass.
+Cloning object of an unknown class VariableCloning\Bar.
+Closure invoked with 0 parameters, 1-2 required.
+Closure invoked with 0 parameters, 3 required.
+Closure invoked with 0 parameters, at least 1 required.
+Closure invoked with 1 parameter, 3 required.
+Closure invoked with 2 parameters, 3 required.
+Combining constants with | is not allowed for parameter #2 $filter of function filter_var.
+Combining constants with | is not allowed for parameter #2 $flags of function array_unique.
+Comment contains PHPDoc tag but does not start with /** prefix.
+Comparison operation "!=" between array and int results in an error.
+Comparison operation "!=" between array<int|string>|null and 1 results in an error.
+Comparison operation "!=" between object|null and 1 results in an error.
+Comparison operation "!=" between stdClass and int results in an error.
+Comparison operation "<" between 0 and 0 is always false.
+Comparison operation "<" between 5 and 4 is always false.
+Comparison operation "<" between Bug7052\Foo::A and Bug7052\Foo::B is always false.
+Comparison operation "<" between array and 1 results in an error.
+Comparison operation "<" between array and array|int results in an error.
+Comparison operation "<" between array and float|int|null results in an error.
+Comparison operation "<" between array and float|null results in an error.
+Comparison operation "<" between array and int results in an error.
+Comparison operation "<" between int<1, max> and 0 is always false.
+Comparison operation "<" between int<min, 0> and int<1, max> is always true.
+Comparison operation "<" between int<min, 1> and 5 is always true.
+Comparison operation "<" between numeric-string and DateTimeImmutable results in an error.
+Comparison operation "<" between stdClass and 1 results in an error.
+Comparison operation "<" between stdClass and float|int|null results in an error.
+Comparison operation "<" between stdClass and float|null results in an error.
+Comparison operation "<" between stdClass and int results in an error.
+Comparison operation "<" between stdClass and int|stdClass results in an error.
+Comparison operation "<=" between Bug7052\Foo::A and Bug7052\Foo::B is always false.
+Comparison operation "<=" between array and int results in an error.
+Comparison operation "<=" between int<6, max> and 2 is always false.
+Comparison operation "<=" between stdClass and int results in an error.
+Comparison operation "<=>" between array and int results in an error.
+Comparison operation "<=>" between stdClass and int results in an error.
+Comparison operation "==" between array and 1 results in an error.
+Comparison operation "==" between array and array|int results in an error.
+Comparison operation "==" between array and float|int|null results in an error.
+Comparison operation "==" between array and float|null results in an error.
+Comparison operation "==" between array and int results in an error.
+Comparison operation "==" between stdClass and 1 results in an error.
+Comparison operation "==" between stdClass and float|int|null results in an error.
+Comparison operation "==" between stdClass and float|null results in an error.
+Comparison operation "==" between stdClass and int results in an error.
+Comparison operation "==" between stdClass and int|stdClass results in an error.
+Comparison operation "==" between stdClass|null and int results in an error.
+Comparison operation ">" between 1 and 0 is always true.
+Comparison operation ">" between Bug7052\Foo::A and Bug7052\Foo::B is always false.
+Comparison operation ">" between array and int results in an error.
+Comparison operation ">" between array{1} and 2147483647|9223372036854775807 results in an error.
+Comparison operation ">" between int<2, 4> and 8 is always false.
+Comparison operation ">" between stdClass and int results in an error.
+Comparison operation ">=" between Bug7052\Foo::A and Bug7052\Foo::B is always false.
+Comparison operation ">=" between array and int results in an error.
+Comparison operation ">=" between int<1, max> and 0 is always true.
+Comparison operation ">=" between stdClass and int results in an error.
+Condition "T of int is int" in conditional return type is always true.
+Condition "T of int is string" in conditional return type is always false.
+Condition "array{foo: string} is array{foo: int}" in conditional return type is always false.
+Condition "int is int" in conditional return type is always true.
+Condition "int is not int" in conditional return type is always false.
+Condition "int is not string" in conditional return type is always true.
+Condition "int is string" in conditional return type is always false.
+Conditional return type references unknown parameter $callable.
+Conditional return type references unknown parameter $j.
+Conditional return type uses subject type stdClass which is not part of PHPDoc @template tags.
+Constant Bug10212\HelloWorld::B (Bug10212\X\Foo) does not accept value Bug10212\Foo::Bar.
+Constant ClassConstantNativeTypeForMissingTypehintRule\Foo::B type has no value type specified in iterable type array.
+Constant ClassConstantNativeTypeForMissingTypehintRule\Foo::D with generic class ClassConstantNativeTypeForMissingTypehintRule\Bar does not specify its types: T
+Constant Collator::FRENCH_COLLATION is not allowed for parameter #2 $flags of method Collator::sort().
+Constant ConflictingTraitConstantsTypes\Baz::BAR_CONST (int) overriding constant ConflictingTraitConstantsTypes\Foo::BAR_CONST should not have a native type.
+Constant ConflictingTraitConstantsTypes\Baz::FOO_CONST (int) overriding constant ConflictingTraitConstantsTypes\Foo::FOO_CONST (int|string) should have the same native type int|string.
+Constant ConflictingTraitConstantsTypes\Lorem::FOO_CONST overriding constant ConflictingTraitConstantsTypes\Foo::FOO_CONST (int|string) should also have native type int|string.
+Constant ConflictingTraitConstants\Bar9::PUBLIC_CONSTANT with value 2 overriding constant ConflictingTraitConstants\Foo::PUBLIC_CONSTANT with different value 1 should have the same value.
+Constant DEFINED_CONSTANT_IF not found.
+Constant FILE_APPEND is not allowed for parameter #2 $flags of function file.
+Constant FILE_APPEND is not allowed for parameter #2 $operation of function flock.
+Constant IntlDateFormatter::GREGORIAN is not allowed for parameter #2 $dateType of class IntlDateFormatter constructor.
+Constant IntlDateFormatter::GREGORIAN is not allowed for parameter #2 $dateType of static method IntlDateFormatter::create().
+Constant JSON_BIGINT_AS_STRING is not allowed for parameter #3 $flags of function json_validate.
+Constant JSON_PRETTY_PRINT is not allowed for parameter #4 $flags of function json_decode.
+Constant JSON_THROW_ON_ERROR is not allowed for parameter #3 $depth of function json_decode.
+Constant MissingClassConstantTypehint\Foo::BAR type has no value type specified in iterable type array.
+Constant MissingClassConstantTypehint\Foo::BAZ with generic class MissingClassConstantTypehint\Bar does not specify its types: T
+Constant MissingClassConstantTypehint\Foo::LOREM type has no signature specified for callable.
+Constant NONEXISTENT_CONSTANT not found.
+Constant NumberFormatter::TYPE_INT32 is not allowed for parameter #2 $style of static method NumberFormatter::create().
+Constant OverridingConstantNativeTypes\Ipsum::B overriding constant OverridingConstantNativeTypes\Lorem::B (int) should also have native type int.
+Constant OverridingConstantNativeTypes\PharChild::BZ2 overriding constant Phar::BZ2 (int) should also have native type int.
+Constant OverridingFinalConstant\Bar::BAR overrides final constant OverridingFinalConstant\Foo::BAR.
+Constant OverridingFinalConstant\Bar::FOO overrides final constant OverridingFinalConstant\Foo::FOO.
+Constant OverridingFinalConstant\Baz::BAR overrides final constant OverridingFinalConstant\FooInterface::BAR.
+Constant PDO::ATTR_ERRMODE is not allowed for parameter #1 $mode of method PDOStatement::fetch().
+Constant REMEMBERED_FOO not found.
+Constant RecursiveIteratorIterator::CHILD_FIRST is not allowed for parameter #3 $flags of class RecursiveIteratorIterator constructor.
+Constant SORT_REGULAR is not allowed for parameter #1 $flags of class finfo constructor.
+Constant SORT_REGULAR is not allowed for parameter #2 $filter of function filter_var.
+Constant SORT_REGULAR is not allowed for parameter #2 $flags of callable passed to call_user_func().
+Constant SORT_REGULAR is not allowed for parameter #2 $flags of closure.
+Constant SORT_REGULAR is not allowed for parameter #2 $flags of function json_encode.
+Constant SORT_REGULAR is not allowed for parameter #2 $flags of method finfo::file().
+Constant SORT_REGULAR is not allowed for parameter $flags of function json_encode.
+Constant TEST not found.
+Constant UnusedPrivateConstantDynamicFetch\Baz::FOO is unused.
+Constant UnusedPrivateConstantEnum\Foo::TEST_2 is unused.
+Constant UnusedPrivateConstant\Foo::BAR_CONST is unused.
+Constant UnusedPrivateConstant\TestExtension::UNUSED is unused.
+Constant ValueAssignedToClassConstantNativeType\Bar::BAR (int<1, max>) does not accept value 0.
+Constant ValueAssignedToClassConstantNativeType\Floats::BAR (int) does not accept value 1.0.
+Constant ValueAssignedToClassConstantNativeType\Foo::BAR (int) does not accept value 'bar'.
+Constant XYZ not found.
+Constant XYZ22 not found.
+Constant XYZ33 not found.
+Constant __COMPILER_HALT_OFFSET__ not found.
+Constant is declared inside a trait but is only supported on PHP 8.2 and later.
+ConstantAttributesRule requires PHP 8.5 runtime to check the code.
+Constants ENT_HTML401, ENT_HTML5 cannot be combined for parameter #2 $flags of function htmlspecialchars.
+Constants ENT_QUOTES, ENT_NOQUOTES cannot be combined for parameter #2 $flags of function htmlspecialchars.
+Constants LOCK_EX, LOCK_SH cannot be combined for parameter #2 $operation of function flock.
+Constants LOCK_SH, LOCK_EX cannot be combined for parameter #2 $operation of function flock.
+Constants SORT_NUMERIC, SORT_STRING cannot be combined for parameter #2 $flags of function sort.
+Constructor of attribute class ClassAttributes\NonPublicConstructor is not public.
+Constructor of class ConstructorReturnType\Bar has a return type.
+Constructor of class ConstructorReturnType\UsesFooTrait has a return type.
+Constructor of class UnusedConstructorParameters\Foo has an unused parameter $anotherUnusedParameter.
+Constructor of class UnusedConstructorParameters\Foo has an unused parameter $unusedParameter.
+Creating callable from 1 but it's not a callable.
+Creating callable from 1|(callable(): mixed) but it might not be a callable.
+Creating callable from an unknown class FunctionCallable\Nonexistent.
+Creating callable from string but it might not be a callable.
+Creating new PHPStan\DependencyInjection\NeonAdapter is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Creating new PHPStan\Type\FileTypeMapper is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Creating new PHPStan\Type\StringAlwaysAcceptingObjectWithToStringType is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Creating new ReflectionClass is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionClassConstant is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionEnum is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionEnumBackedCase is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionExtension is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionFiber is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionFunction is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionGenerator is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionMethod is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionObject is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionParameter is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionProperty is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Creating new ReflectionZendExtension is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Dead catch - ArgumentCountError is never thrown in the try block.
+Dead catch - ArithmeticError is never thrown in the try block.
+Dead catch - DivisionByZeroError is never thrown in the try block.
+Dead catch - DomainException is never thrown in the try block.
+Dead catch - Error is never thrown in the try block.
+Dead catch - Exception is never thrown in the try block.
+Dead catch - InvalidArgumentException is already caught above.
+Dead catch - InvalidArgumentException is never thrown in the try block.
+Dead catch - JsonException is never thrown in the try block.
+Dead catch - LogicException is never thrown in the try block.
+Dead catch - OutOfBoundsException is never thrown in the try block.
+Dead catch - OverflowException is never thrown in the try block.
+Dead catch - RuntimeException is never thrown in the try block.
+Dead catch - Throwable is never thrown in the try block.
+Dead catch - TypeError is already caught above.
+Dead catch - TypeError is never thrown in the try block.
+Dead catch - UnhandledMatchError is never thrown in the try block.
+Declare strict_types must be the very first statement.
+Declare strict_types must have 0 or 1 as its value, 'foo' given.
+Declare strict_types must have 0 or 1 as its value, \true given.
+Declaring PHPStan namespace is not allowed in 3rd party packages.
+Default type bool in PHPDoc tag @template T for class ClassTemplateType\Venenatis is not subtype of bound type object.
+Default type bool in PHPDoc tag @template T for function FunctionTemplateType\outOfBoundsDefault() is not subtype of bound type object.
+Default type bool in PHPDoc tag @template T for interface InterfaceTemplateType\OutOfBoundsDefault is not subtype of bound type object.
+Default type bool in PHPDoc tag @template T for method MethodTemplateType\InvalidDefault::outOfBounds() is not subtype of bound type object.
+Default type bool in PHPDoc tag @template T for trait TraitTemplateType\Elit is not subtype of bound type object.
+Default value of the parameter #1 $foo (string) of method DefaultValueForPromotedProperty\Foo::__construct() is incompatible with type int.
+Default value of the parameter #1 $i (stdClass) of method MethodNewInInitializers\Foo::doFoo() is incompatible with type int.
+Default value of the parameter #1 $i (string) of anonymous function is incompatible with type int.
+Default value of the parameter #1 $string (false) of function IncompatibleDefaultParameter\takesString() is incompatible with type string.
+Default value of the parameter #2 $foo (string) of method DefaultValueForPromotedProperty\Foo::__construct() is incompatible with type int.
+Default value of the parameter #4 $intProp (null) of method DefaultValueForPromotedProperty\Foo::__construct() is incompatible with type int.
+Default value of the parameter #6 $resource (false) of method IncompatibleDefaultParameter\Foo::bar() is incompatible with type resource.
+Default value of the parameter #6 $resource (false) of method IncompatibleDefaultParameter\Foo::baz() is incompatible with type resource.
+Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.
+Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.
+Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.
+Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.
+Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.
+Do-while loop condition is always false.
+Do-while loop condition is always true.
+Doing instanceof PHPStan\Type\Generic\GenericObjectType is error-prone and deprecated.
+Doing instanceof PHPStan\Type\TypeWithClassName is error-prone and deprecated. Use Type::getObjectClassNames() or Type::getObjectClassReflections() instead.
+Doing instanceof phpstan\type\typewithclassname is error-prone and deprecated. Use Type::getObjectClassNames() or Type::getObjectClassReflections() instead.
+Dumped type: T
+Dumped type: array
+Dumped type: array<string, mixed>
+Dumped type: array{' ': 'NUL', NUL: ' '}
+Dumped type: array{'': 'SOH', SOH: ''}
+Dumped type: array{'	': 'HT', HT: '	'}
+Dumped type: array{' ': 'SP', SP: ' '}
+Dumped type: array{'': ''}
+Dumped type: array{'3.14': 3.14}
+Dumped type: array{'Let\'s go': 'Let\'s go'}
+Dumped type: array{'Shall we dance': 'yes'}
+Dumped type: array{'Shall we dance?': 'yes'}
+Dumped type: array{'foo ': 'ends with SP', ' foo': 'starts with SP', ' foo ': 'surrounded by SP', foo: 'no SP'}
+Dumped type: array{'foo?': 'foo?'}
+Dumped type: array{'shall-we-dance?': 'yes'}
+Dumped type: array{'shall_we_dance?': 'yes'}
+Dumped type: array{'shallwedance?': 'yes'}
+Dumped type: array{1: 1}
+Dumped type: array{1: true, 0: false}
+Dumped type: array{2: 2}
+Dumped type: array{Foo\Bar: 'Foo\\Bar'}
+Dumped type: array{shall-we-dance: 'yes'}
+Dumped type: array{shall_we_dance: 'yes'}
+Dumped type: array{shallwedance: 'yes'}
+Dumped type: int<4, max>
+Dumped type: non-empty-array
+Dumped type: non-empty-array<int, string>
+Dumped type: string
+Dumped: 1|null
+Elseif condition is always false.
+Elseif condition is always true.
+Empty array passed to foreach.
+Enum Bug11592\BackedTest2 cannot redeclare native method cases().
+Enum Bug11592\BackedTest2 cannot redeclare native method from().
+Enum Bug11592\BackedTest2 cannot redeclare native method tryFrom().
+Enum Bug11592\EnumWithAbstractMethod contains abstract method foo().
+Enum Bug11592\Test contains abstract method from().
+Enum Bug11592\Test contains abstract method tryFrom().
+Enum Bug11592\Test2 cannot redeclare native method cases().
+Enum Bug11592\Test2 contains abstract method from().
+Enum Bug11592\Test2 contains abstract method tryFrom().
+Enum Bug11891\test has duplicate value 42 for cases A, B.
+Enum Bug13768\Backed has duplicate value 1 for cases One, Two.
+Enum Bug13768\Order is not backed, but case A has value 1.5.
+Enum Bug13768\Order is not backed, but case B has value 2.5.
+Enum Bug13768\Order is not backed, but case C has value 3.
+Enum Bug13768\Order is not backed, but case D has value '3'.
+Enum Bug13768\Order is not backed, but case E has value false.
+Enum Bug13768\Order is not backed, but case F has value 1.
+Enum EnumAttributes\EnumAsAttribute is not an Attribute class.
+Enum EnumGenericAncestors\Foo has @implements tag, but does not implement any interface.
+Enum EnumGenericAncestors\Foo4 implements generic interface EnumGenericAncestors\Generic but does not specify its types: T, U
+Enum EnumGenericAncestors\Foo7 has @extends tag, but cannot extend anything.
+Enum EnumImplements\Foo3 implements class EnumImplements\FooClass.
+Enum EnumImplements\Foo4 implements trait EnumImplements\FooTrait.
+Enum EnumImplements\Foo5 implements enum EnumImplements\FooEnum.
+Enum EnumImplements\Foo6 implements unknown interface EnumImplements\NonexistentInterface.
+Enum EnumImplements\Foo7 implements enum EnumImplements\FooEnum.
+Enum EnumImplements\FooEnum referenced with incorrect case: EnumImplements\FOOEnum.
+Enum EnumSanity\BackedEnumCannotRedeclareMethods cannot redeclare native method cases().
+Enum EnumSanity\BackedEnumCannotRedeclareMethods cannot redeclare native method from().
+Enum EnumSanity\BackedEnumCannotRedeclareMethods cannot redeclare native method tryFrom().
+Enum EnumSanity\EnumDuplicateValue has duplicate value 1 for cases A, E.
+Enum EnumSanity\EnumDuplicateValue has duplicate value 2 for cases B, C.
+Enum EnumSanity\EnumMayNotSerializable cannot implement the Serializable interface.
+Enum EnumSanity\EnumWithConstructorAndDestructor contains constructor.
+Enum EnumSanity\EnumWithConstructorAndDestructor contains destructor.
+Enum EnumSanity\EnumWithMagicMethods contains magic method __get().
+Enum EnumSanity\EnumWithMagicMethods contains magic method __set().
+Enum EnumSanity\EnumWithSerialize contains magic method __serialize().
+Enum EnumSanity\EnumWithSerialize contains magic method __unserialize().
+Enum EnumSanity\EnumWithValueButNotBacked is not backed, but case FOO has value 1.
+Enum EnumSanity\PureEnumCannotRedeclareMethods cannot redeclare native method cases().
+Enum EnumTemplate\Bar has PHPDoc @template tags but enums cannot be generic.
+Enum EnumTemplate\Foo has PHPDoc @template tag but enums cannot be generic.
+Enum MethodInEnumWithoutBody\Foo contains abstract method doBar().
+Enum MissingMethodImplEnum\Bar contains abstract method doFoo() from interface MissingMethodImplEnum\FooInterface.
+Enum cannot be an Attribute class.
+Enum case Bug9402\Foo::Two value 'foo' does not match the "int" type.
+Enum case EnumSanity\EnumInconsistentCaseType::BAR does not have a value but the enum is backed with the "int" type.
+Enum case EnumSanity\EnumInconsistentCaseType::FOO value 'foo' does not match the "int" type.
+Enum case EnumSanity\EnumInconsistentStringCaseType::BAR does not have a value but the enum is backed with the "string" type.
+Enum case can only be used in enums.
+Expected native type false, actual: bool
+Expected native type true, actual: bool
+Expected offset 'firstName' certainty No, actual: Yes
+Expected subtype of array<string>, actual: array<int>
+Expected subtype of never, actual: false
+Expected subtype of string, actual: false
+Expected type array<string>, actual: array<int>
+Expected variable $b certainty Maybe, actual: No
+Expected variable $b certainty Yes, actual: No
+Expression "$arr" on a separate line does not do anything.
+Expression "$arr['test']" on a separate line does not do anything.
+Expression "$b()" on a separate line does not do anything.
+Expression "$foo->test" on a separate line does not do anything.
+Expression "$foo::$test" on a separate line does not do anything.
+Expression "$ref?->name" on a separate line does not do anything.
+Expression "'foo'" on a separate line does not do anything.
+Expression "(string) 1" on a separate line does not do anything.
+Expression "+1" on a separate line does not do anything.
+Expression "-1" on a separate line does not do anything.
+Expression "1" on a separate line does not do anything.
+Expression "@'foo'" on a separate line does not do anything.
+Expression "\DeadCodeNoop\Foo::TEST" on a separate line does not do anything.
+Expression "empty($test)" on a separate line does not do anything.
+Expression "isset($test)" on a separate line does not do anything.
+Expression "new class extends \Bug13698\NoConstructorClass…" on a separate line does not do anything.
+Expression "new class…" on a separate line does not do anything.
+Expression "true" on a separate line does not do anything.
+Expression in empty() is not falsy.
+Expression in isset() is not nullable.
+Expression on left side of ?? is always null.
+Expression on left side of ?? is not nullable.
+Expression on left side of assignment is not assignable.
+Extending PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Extending PHPStan\Reflection\ExtendedMethodReflection is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Extending PHPStan\Reflection\ReflectionProvider is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Extending PHPStan\Type\FileTypeMapper is not covered by backward compatibility promise. The class might change in a minor PHPStan version.
+Extending PHPStan\Type\Type is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+File begins with UTF-8 BOM character. This may cause problems when running the code in the web browser.
+File ends with a trailing whitespace. This may cause problems when running the code in the web browser. Remove the closing ?> mark or remove the whitespace.
+Final class constants are supported only on PHP 8.1 and later.
+Final constant ConflictingTraitConstants\Bar8::PUBLIC_CONSTANT overriding non-final constant ConflictingTraitConstants\Foo::PUBLIC_CONSTANT should also be non-final.
+Final promoted properties are supported only on PHP 8.5 and later.
+Final properties are supported only on PHP 8.4 and later.
+First unreachable
+Function Bug10077\mergeMediaQueries() should return list<Bug10077\CssMediaQuery>|null but returns list<Bug10077\MediaQueryMergeResult>.
+Function Bug11301\cString() should return array<string, string> but returns array<int, string>.
+Function Bug11559b\maybe_variadic_fn invoked with 5 parameters, 0 required.
+Function Bug11559b\maybe_variadic_fn4 invoked with 2 parameters, 0 required.
+Function Bug11980Function\process2() never returns void so it can be removed from the return type.
+Function Bug12274\getItemsByModifiedIndex() should return non-empty-list<int> but returns non-empty-array<int<0, max>, int>.
+Function Bug13384c\doFoo() never returns true so the return type can be changed to false.
+Function Bug13384c\doFoo2() never returns false so the return type can be changed to true.
+Function Bug13384c\doFooPhpdoc() never returns false so the return type can be changed to true.
+Function Bug13384c\doFooPhpdoc2() never returns true so the return type can be changed to false.
+Function Bug13384c\returnsTruePhpdocUnionReturn() never returns int so it can be removed from the return type.
+Function Bug13384c\returnsTrueUnionReturn() never returns int so it can be removed from the return type.
+Function Bug2723\baz() should return Bug2723\Bar<Bug2723\Foo<T4>> but returns Bug2723\BarOfFoo<string>.
+Function Bug3028\run() should return Bug3028\Format<Bug3028\Output> but returns Bug3028\Format<O of Bug3028\Output>.
+Function Bug3801\do_foo() should return array{bool, null}|array{null, bool} but returns array{false, false}.
+Function Bug3801\do_foo() should return array{bool, null}|array{null, bool} but returns array{false, true}.
+Function Bug6568\test() should return T of array but returns array<mixed, mixed>.
+Function Bug6787\f() should return T of DateTimeInterface but returns DateTime.
+Function Bug7766\problem() should return array<array{id: int, created: DateTimeInterface, updated: DateTimeInterface, valid_from: DateTimeInterface, valid_till: DateTimeInterface, string: string, other_string: string, another_string: string, ...}> but returns array{array{id: 1, created: DateTimeImmutable, updated: DateTimeImmutable, valid_from: DateTimeImmutable, valid_till: DateTimeImmutable, string: 'string', other_string: 'string', another_string: 'string', ...}}.
+Function Bug9401\foo() should return list<int<1, max>> but returns list<int<0, max>>.
+Function CallToFunctionWithOptionalParameters\foo invoked with 3 parameters, 1-2 required.
+Function DuplicateFunctionDeclaration\foo declared multiple times:
+Function FunctionIntersectionTypes\doBar() has unresolvable native return type.
+Function FunctionIntersectionTypes\doBaz() has unresolvable native return type.
+Function FunctionNever\callsNever() always terminates script execution, it should have return type "never".
+Function FunctionNever\doBar() always throws an exception, it should have return type "never".
+Function FunctionNever\doBaz() always terminates script execution, it should have return type "never".
+Function FunctionWithNullableVariadicParameters\foo invoked with 0 parameters, at least 1 required.
+Function FunctionWithVariadicParameters\bar invoked with 0 parameters, at least 1 required.
+Function FunctionWithVariadicParameters\foo invoked with 0 parameters, at least 1 required.
+Function IncorrectCallToFunction\foo invoked with 1 parameter, 2 required.
+Function IncorrectCallToFunction\foo invoked with 3 parameters, 2 required.
+Function MissingExceptionFunctionThrows\doBar2() throws checked exception LogicException but it's missing from the PHPDoc @throws tag.
+Function MissingExceptionFunctionThrows\doBar3() throws checked exception LogicException but it's missing from the PHPDoc @throws tag.
+Function MissingExceptionFunctionThrows\doBaz() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
+Function MissingExceptionFunctionThrows\doLorem() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
+Function MissingExceptionFunctionThrows\doLorem2() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
+Function MissingFunctionParameterTypehint\acceptsGenericClass() has parameter $c with generic class MissingFunctionParameterTypehint\GenericClass but does not specify its types: A, B
+Function MissingFunctionParameterTypehint\acceptsGenericInterface() has parameter $i with generic interface MissingFunctionParameterTypehint\GenericInterface but does not specify its types: T, U
+Function MissingFunctionParameterTypehint\missingArrayTypehint() has parameter $a with no value type specified in iterable type array.
+Function MissingFunctionParameterTypehint\missingCallableSignature() has parameter $cb with no signature specified for callable.
+Function MissingFunctionParameterTypehint\missingIterableTypehint() has parameter $iterable with no value type specified in iterable type iterable.
+Function MissingFunctionParameterTypehint\missingIterableTypehintPhpDoc() has parameter $iterable with no value type specified in iterable type iterable.
+Function MissingFunctionParameterTypehint\missingPhpDocIterableTypehint() has parameter $a with no value type specified in iterable type array.
+Function MissingFunctionParameterTypehint\missingTraversableTypehint() has parameter $traversable with no value type specified in iterable type Traversable.
+Function MissingFunctionParameterTypehint\missingTraversableTypehintPhpDoc() has parameter $traversable with no value type specified in iterable type Traversable.
+Function MissingFunctionParameterTypehint\namespacedFunction() has parameter $d with no type specified.
+Function MissingFunctionParameterTypehint\unionTypeWithUnknownArrayValueTypehint() has parameter $a with no value type specified in iterable type array.
+Function MissingFunctionReturnTypehint\callableNestedNoPrototype() return type has no signature specified for callable.
+Function MissingFunctionReturnTypehint\callableWithNoPrototype() return type has no signature specified for callable.
+Function MissingFunctionReturnTypehint\closureWithNoPrototype() return type has no signature specified for Closure.
+Function MissingFunctionReturnTypehint\genericGenericMissingTemplateArgs() return type with generic class MissingFunctionReturnTypehint\GenericClass does not specify its types: A, B
+Function MissingFunctionReturnTypehint\namespacedFunction1() has no return type specified.
+Function MissingFunctionReturnTypehint\returnsGeneratorOfIntegersByStringNoPrototype() return type with generic class Generator does not specify its types: TKey, TValue, TSend, TReturn
+Function MissingFunctionReturnTypehint\returnsGeneratorOfIntegersNoPrototype() return type with generic class Generator does not specify its types: TKey, TValue, TSend, TReturn
+Function MissingFunctionReturnTypehint\returnsGenericClass() return type with generic class MissingFunctionReturnTypehint\GenericClass does not specify its types: A, B
+Function MissingFunctionReturnTypehint\returnsGenericInterface() return type with generic interface MissingFunctionReturnTypehint\GenericInterface does not specify its types: T, U
+Function MissingFunctionReturnTypehint\returnsIteratorAggregateNoPrototype() return type with generic interface IteratorAggregate does not specify its types: TKey, TValue
+Function MissingFunctionReturnTypehint\returnsIteratorNoPrototype() return type with generic interface Iterator does not specify its types: TKey, TValue
+Function MissingFunctionReturnTypehint\returnsTraversableNoPrototype() return type has no value type specified in iterable type Traversable.
+Function MissingFunctionReturnTypehint\unionTypeWithUnknownArrayValueTypehint() return type has no value type specified in iterable type array.
+Function MissingParamClosureThisType\generics() has @param-closure-this PHPDoc tag for parameter $cb with generic class ReflectionClass but does not specify its types: T
+Function MissingParamOutType\generics() has @param-out PHPDoc tag for parameter $a with generic class ReflectionClass but does not specify its types: T
+Function MissingParamOutType\oneArray() has @param-out PHPDoc tag for parameter $a with no value type specified in iterable type array.
+Function MissingReturn\doFoo() should return int but return statement is missing.
+Function NativeUnionTypesSupport\bar() uses native union types but they're supported only on PHP 8.0 and later.
+Function NativeUnionTypesSupport\foo() uses native union types but they're supported only on PHP 8.0 and later.
+Function NoNamedArgumentsFunction\foo invoked with named argument $i, but it's not allowed because of @no-named-arguments.
+Function NoNamedArgumentsFunction\foo invoked with unpacked array with possibly string key, but it's not allowed because of @no-named-arguments.
+Function NoNamedArgumentsFunction\foo invoked with unpacked array with string key, but it's not allowed because of @no-named-arguments.
+Function PHPStan\Rules\Pure\data\pureWithThrowsVoid() is marked as pure but returns void.
+Function PHPStan\dumpNativeType invoked with 0 parameters, at least 1 required.
+Function PHPStan\dumpPhpDocType invoked with 0 parameters, at least 1 required.
+Function PHPStan\dumpType invoked with 0 parameters, at least 1 required.
+Function PureFunction\actuallyPure() is marked as impure but does not have any side effects.
+Function PureFunction\doFoo() is marked as pure but parameter $p is passed by reference.
+Function PureFunction\doFoo2() is marked as pure but returns void.
+Function PureFunction\emptyVoidFunction() returns void but does not have any side effects.
+Function RequiredAfterOptional\doAmet() uses native union types but they're supported only on PHP 8.0 and later.
+Function RequiredAfterOptional\doConsectetur() uses native union types but they're supported only on PHP 8.0 and later.
+Function RequiredAfterOptional\doSed() uses native union types but they're supported only on PHP 8.0 and later.
+Function ReturnListNullables\doFoo() should return array<string>|null but returns list<string|null>.
+Function ReturnTypes\Php70\returnInteger() should return int but empty return statement found.
+Function ReturnTypes\returnChild() should return ReturnTypes\Foo but returns ReturnTypes\OtherInterfaceImpl.
+Function ReturnTypes\returnFromGeneratorString() should return string but empty return statement found.
+Function ReturnTypes\returnFromGeneratorString() should return string but returns int.
+Function ReturnTypes\returnInteger() should return int but returns string.
+Function ReturnTypes\returnNever() should never return but return statement found.
+Function ReturnTypes\returnObject() should return ReturnTypes\Bar but returns ReturnTypes\Foo.
+Function ReturnTypes\returnObject() should return ReturnTypes\Bar but returns int.
+Function ReturnTypes\returnVoid() with return type void returns int but should not return anything.
+Function ReturnTypes\returnVoid() with return type void returns null but should not return anything.
+Function ReturnTypes\returnVoidFromGenerator2() with return type void returns int but should not return anything.
+Function ReturnTypes\sometimesThrows() should always throw an exception or terminate script execution but doesn't do that.
+Function TestFunctionTypehints\foo() has invalid return type TestFunctionTypehints\NonexistentClass.
+Function TestFunctionTypehints\referencesTraitsInNative() has invalid return type TestFunctionTypehints\SomeTrait.
+Function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid return type TestFunctionTypehints\SomeTrait.
+Function TestFunctionTypehints\returnParent() has invalid return type TestFunctionTypehints\parent.
+Function ThrowsVoidFunction\foo() throws exception ThrowsVoidFunction\MyException but the PHPDoc contains @throws void.
+Function TooWideFunctionParameterOut\doBar() never assigns null to &$p so it can be removed from the by-ref type.
+Function TooWideFunctionParameterOut\doBaz() never assigns null to &$p so it can be removed from the @param-out type.
+Function TooWideFunctionParameterOut\doLorem() never assigns null to &$p so it can be removed from the by-ref type.
+Function TooWideFunctionReturnType\bar() never returns string so it can be removed from the return type.
+Function TooWideFunctionReturnType\baz() never returns null so it can be removed from the return type.
+Function TooWideFunctionReturnType\conditionalType() never returns string so it can be removed from the return type.
+Function TooWideFunctionReturnType\dolor2() never returns null so it can be removed from the return type.
+Function TooWideFunctionReturnType\dolor4() never returns int so it can be removed from the return type.
+Function TooWideFunctionReturnType\dolor6() never returns null so it can be removed from the return type.
+Function TooWideFunctionReturnType\ipsum() never returns null so it can be removed from the return type.
+Function TooWideThrowsFunction\doFoo3() has InvalidArgumentException in PHPDoc @throws tag but it's not thrown.
+Function TooWideThrowsFunction\doFoo4() has DomainException in PHPDoc @throws tag but it's not thrown.
+Function TooWideThrowsFunction\doFoo7() has DomainException in PHPDoc @throws tag but it's not thrown.
+Function TooWideThrowsFunction\doFoo8() has DomainException in PHPDoc @throws tag but it's not thrown.
+Function TooWideThrowsFunction\doFoo9() has DomainException in PHPDoc @throws tag but it's not thrown.
+Function Uses\foo used with incorrect case: Uses\Foo.
+Function another_unknown_function not found.
+Function array_unique invoked with 3 parameters, 1-2 required.
+Function barNonExistentFunction not found.
+Function bug3576 not found.
+Function class_implements() is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Function class_parents() is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Function class_uses() is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Function convert_cyr_string not found.
+Function create_function not found.
+Function dolor not found.
+Function ezmlm_hash not found.
+Function fgetss not found.
+Function fooWithoutNamespace() has invalid return type NonexistentClass.
+Function foobarNonExistentFunction not found.
+Function fputcsv invoked with 1 parameter, 2-6 required.
+Function get_magic_quotes_gpc not found.
+Function globalFunction() has parameter $b with no type specified.
+Function globalFunction() has parameter $c with no type specified.
+Function globalFunction1() has no return type specified.
+Function hebrevc not found.
+Function imagepng invoked with 0 parameters, 1-4 required.
+Function imagepng invoked with 5 parameters, 1-4 required.
+Function imap_header not found.
+Function implode invoked with 0 parameters, 1-2 required.
+Function implode invoked with 3 parameters, 1-2 required.
+Function ipsum not found.
+Function is_a() is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Function is_subclass_of() is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine. Use objects retrieved from ReflectionProvider instead.
+Function ldap_control_paged_result not found.
+Function ldap_control_paged_result_response not found.
+Function locale_get_display_language invoked with 3 parameters, 1-2 required.
+Function lorem not found.
+Function mysqli_fetch_all invoked with 0 parameters, 1-2 required.
+Function mysqli_fetch_all invoked with 3 parameters, 1-2 required.
+Function nonexistent not found.
+Function openssl_open invoked with 4 parameters, 5-6 required.
+Function openssl_open invoked with 7 parameters, 5-6 required.
+Function openssl_pkcs12_export invoked with 6 parameters, 4-5 required.
+Function openssl_x509_parse invoked with 3 parameters, 1-2 required.
+Function referencesTraitsInNativeWithoutNamespace() has invalid return type SomeTraitWithoutNamespace.
+Function referencesTraitsInPhpDocWithoutNamespace() has invalid return type SomeTraitWithoutNamespace.
+Function restore_include_path not found.
+Function returnParentWithoutNamespace() has invalid return type parent.
+Function setcookie invoked with 9 parameters, 1-7 required.
+Function setrawcookie invoked with 9 parameters, 1-7 required.
+Function sit not found.
+Function strtok invoked with 0 parameters, 1-2 required.
+Function strtok invoked with 3 parameters, 1-2 required.
+Function unpack invoked with 0 parameters, 2-3 required.
+Generator expects delegated TSend type int, int|null given.
+Generator expects key type DateTimeImmutable, stdClass given.
+Generator expects key type K of int|string, (K of int)|string given.
+Generator expects key type string, int given.
+Generator expects value type array{0: DateTime, 1: DateTime, 2: stdClass, 4: DateTimeImmutable}, array{DateTime, DateTime, stdClass, DateTimeImmutable} given.
+Generator expects value type array{DateTime, DateTime, stdClass, DateTimeImmutable}, array{0: DateTime, 1: DateTime, 2: stdClass, 4: DateTimeImmutable} given.
+Generator expects value type int, null given.
+Generator expects value type int, string given.
+Generator expects value type string, int given.
+Generic type ClassAncestorsExtends\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @extends specifies 3 template types, but class ClassAncestorsExtends\FooGeneric supports only 2: T, U
+Generic type ClassAncestorsExtends\FooGeneric<int> in PHPDoc tag @extends does not specify all template types of class ClassAncestorsExtends\FooGeneric: T, U
+Generic type ClassAncestorsImplements\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @implements specifies 3 template types, but interface ClassAncestorsImplements\FooGeneric supports only 2: T, U
+Generic type ClassAncestorsImplements\FooGeneric<int> in PHPDoc tag @implements does not specify all template types of interface ClassAncestorsImplements\FooGeneric: T, U
+Generic type EnumGenericAncestors\Generic<stdClass> in PHPDoc tag @implements does not specify all template types of interface EnumGenericAncestors\Generic: T, U
+Generic type IncompatibleSelfOutType\GenericCheck2<InvalidArgumentException, int<1, max>, string> in PHPDoc tag @phpstan-self-out specifies 3 template types, but class IncompatibleSelfOutType\GenericCheck2 supports only 2: T, U
+Generic type IncompatibleSelfOutType\GenericCheck2<InvalidArgumentException> in PHPDoc tag @phpstan-self-out does not specify all template types of class IncompatibleSelfOutType\GenericCheck2: T, U
+Generic type InterfaceAncestorsExtends\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @extends specifies 3 template types, but interface InterfaceAncestorsExtends\FooGeneric supports only 2: T, U
+Generic type InterfaceAncestorsExtends\FooGeneric<int> in PHPDoc tag @extends does not specify all template types of interface InterfaceAncestorsExtends\FooGeneric: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @param for parameter $lorem specifies 3 template types, but class InvalidPhpDocDefinitions\FooGeneric supports only 2: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @return specifies 3 template types, but class InvalidPhpDocDefinitions\FooGeneric supports only 2: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$tooManyTypesGenericfoo specifies 3 template types, but class InvalidPhpDocDefinitions\FooGeneric supports only 2: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int, InvalidArgumentException, string> in PHPDoc tag @var for variable $test specifies 3 template types, but class InvalidPhpDocDefinitions\FooGeneric supports only 2: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int, InvalidArgumentException, string> in PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$tooManyTypesGenericfoo specifies 3 template types, but class InvalidPhpDocDefinitions\FooGeneric supports only 2: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int> in PHPDoc tag @param for parameter $baz does not specify all template types of class InvalidPhpDocDefinitions\FooGeneric: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int> in PHPDoc tag @return does not specify all template types of class InvalidPhpDocDefinitions\FooGeneric: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int> in PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$notEnoughTypesGenericfoo does not specify all template types of class InvalidPhpDocDefinitions\FooGeneric: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int> in PHPDoc tag @var for variable $test does not specify all template types of class InvalidPhpDocDefinitions\FooGeneric: T, U
+Generic type InvalidPhpDocDefinitions\FooGeneric<int> in PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$notEnoughTypesGenericfoo does not specify all template types of class InvalidPhpDocDefinitions\FooGeneric: T, U
+Generic type MethodAssert\FooBar<int, string, float> in PHPDoc tag @phpstan-assert for $m specifies 3 template types, but class MethodAssert\FooBar supports only 2: T, TT
+Generic type MethodAssert\FooBar<int> in PHPDoc tag @phpstan-assert for $m does not specify all template types of class MethodAssert\FooBar: T, TT
+Generic type MethodAssert\FooBar<mixed> in PHPDoc tag @phpstan-assert for $m does not specify all template types of class MethodAssert\FooBar: T, TT
+Generic type MethodTag\Generic<int, string, float> in PHPDoc tag @method for method MethodTag\TestGenerics::doC() return type specifies 3 template types, but class MethodTag\Generic supports only 2: T, U
+Generic type MethodTag\Generic<int> in PHPDoc tag @method for method MethodTag\TestGenerics::doB() return type does not specify all template types of class MethodTag\Generic: T, U
+Generic type MixinRule\Consecteur<MixinRule\Foo> in PHPDoc tag @mixin does not specify all template types of class MixinRule\Consecteur: T, U
+Generic type ParamClosureThisPhpDocRule\FooBar<int> in PHPDoc tag @param-closure-this for parameter $i does not specify all template types of class ParamClosureThisPhpDocRule\FooBar: T, TT
+Generic type ParamClosureThisPhpDocRule\FooBar<mixed> in PHPDoc tag @param-closure-this for parameter $i does not specify all template types of class ParamClosureThisPhpDocRule\FooBar: T, TT
+Generic type ParamOutPhpDocRule\FooBar<int> in PHPDoc tag @param-out for parameter $i does not specify all template types of class ParamOutPhpDocRule\FooBar: T, TT
+Generic type ParamOutPhpDocRule\FooBar<mixed> in PHPDoc tag @param-out for parameter $i does not specify all template types of class ParamOutPhpDocRule\FooBar: T, TT
+Generic type PropertyTag\Generic<int, string, float> in PHPDoc tag @property for property PropertyTag\TestGenerics::$c specifies 3 template types, but class PropertyTag\Generic supports only 2: T, U
+Generic type PropertyTag\Generic<int> in PHPDoc tag @property for property PropertyTag\TestGenerics::$b does not specify all template types of class PropertyTag\Generic: T, U
+Generic type Traversable<int, int, int> in PHPDoc tag @mixin specifies 3 template types, but interface Traversable supports only 2: TKey, TValue
+Generic type UsedTraits\GenericTrait<stdClass, Exception> in PHPDoc tag @use specifies 2 template types, but trait UsedTraits\GenericTrait supports only 1: T
+Generic type static(IncompatiblePhpDocGenericStatic\Foo<int, string>) in PHPDoc tag @return specifies 2 template types, but class IncompatiblePhpDocGenericStatic\Foo supports only 1: T
+If condition is always false.
+If condition is always true.
+Implementing PHPStan\Analyser\Scope is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Implementing PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Implementing PHPStan\Reflection\ExtendedMethodReflection is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Implementing PHPStan\Reflection\FunctionReflection is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Implementing PHPStan\Reflection\ReflectionProvider is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Implementing PHPStan\Type\Type is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
+Imported type alias ExportedTypeAlias has an invalid name: int.
+Impure access to superglobal variable in pure function PureFunction\pureButAccessSuperGlobal().
+Impure assign to superglobal variable in pure method PureMethod\ClassWithVoidMethods::purePostGetAssign().
+Impure call to a Closure with by-ref parameter in pure function Bug11361Pure\foo().
+Impure call to function FirstClassCallablePureFunction\impureFunction() in pure function FirstClassCallablePureFunction\testThese().
+Impure call to function FirstClassCallablePureFunction\voidFunction() in pure function FirstClassCallablePureFunction\testThese().
+Impure call to function PureFunction\impureFunction() in pure function PureFunction\testThese().
+Impure call to function PureFunction\voidFunction() in pure function PureFunction\testThese().
+Impure call to function array_push() in pure function PureFunction\bug13288().
+Impure call to method AllMethodsArePure\FooWithMixed::impureMethod() in pure method AllMethodsArePure\FooWithMixed::testMixed().
+Impure call to method AllMethodsArePure\FooWithMixed::impureMethod() in pure method AllMethodsArePure\FooWithMixed::testMixed2().
+Impure call to method AllMethodsArePure\Test::impure() in pure method AllMethodsArePure\SideEffectImpure::pureWithImpure().
+Impure call to method AllMethodsArePure\Test::impure() in pure method AllMethodsArePure\SideEffectPure::nothingWithImpure().
+Impure call to method FirstClassCallablePureFunction\Foo::impureFunction() in pure function FirstClassCallablePureFunction\testThese().
+Impure call to method FirstClassCallablePureFunction\Foo::voidFunction() in pure function FirstClassCallablePureFunction\testThese().
+Impure call to method PureMethod\Foo::impureReturningMethod() in pure method PureMethod\Foo::doFoo4().
+Impure call to method PureMethod\Foo::impureReturningMethod() in pure method PureMethod\Foo::doFoo5().
+Impure call to method PureMethod\Foo::impureVoidMethod() in pure method PureMethod\Foo::doFoo4().
+Impure call to method PureMethod\Foo::impureVoidMethod() in pure method PureMethod\Foo::doFoo5().
+Impure call to method PureMethod\Foo::voidMethod() in pure method PureMethod\Foo::doFoo4().
+Impure call to method PureMethod\Foo::voidMethod() in pure method PureMethod\Foo::doFoo5().
+Impure call to method PureMethod\ImpureMagicMethods::__toString() in pure method PureMethod\TestMagicMethods::doFoo().
+Impure die in pure method PureMethod\Foo::doFoo2().
+Impure echo in pure function PureFunction\doFoo().
+Impure echo in pure method PureMethod\ExtendingClass::pure().
+Impure echo in pure method PureMethod\Foo::doFoo().
+Impure exit in pure function PureFunction\bug13288b().
+Impure exit in pure function PureFunction\bug13288c().
+Impure exit in pure function PureFunction\bug13288d().
+Impure exit in pure function PureFunction\doFoo2().
+Impure global variable in pure function PureFunction\functionWithGlobal().
+Impure instantiation of class PureMethod\ImpureConstructor in pure method PureMethod\TestConstructors::doFoo().
+Impure output between PHP opening and closing tags in pure function PureFunction\justContainsInlineHtml().
+Impure property assignment in pure function PureFunction\doFoo3().
+Impure property assignment in pure method PureConstructor\AssignOtherThanThis::__construct().
+Impure property assignment in pure method PureConstructor\Foo::__construct().
+Impure property assignment in pure method PureMethod\Foo::doFoo3().
+Impure property assignment in pure method PureMethod\StaticMethodAssigningStaticProperty::getA().
+Impure static property access in pure method PureConstructor\Foo::__construct().
+Impure static property access in pure method PureMethod\StaticMethodAccessingStaticProperty::getA().
+Impure static variable in pure function PureFunction\functionWithStaticVariable().
+Inner named functions are not supported by PHPStan. Consider refactoring to an anonymous function, class method, or a top-level-defined function. See issue #165 (https://github.com/phpstan/phpstan/issues/165) for more details.
+Instanceof between *NEVER* and ImpossibleInstanceOf\Bar will always evaluate to false.
+Instanceof between *NEVER* and ImpossibleInstanceOf\Foo will always evaluate to false.
+Instanceof between *NEVER* and ImpossibleInstanceOf\Lorem will always evaluate to false.
+Instanceof between Bug13469\Foo and Stringable will always evaluate to true.
+Instanceof between Bug3632\NiceClass and Bug3632\NiceClass will always evaluate to true.
+Instanceof between Bug8042\B and Bug8042\B will always evaluate to true.
+Instanceof between DateTime and DateTime will always evaluate to true.
+Instanceof between DateTimeImmutable and DateTime will always evaluate to false.
+Instanceof between DateTimeImmutable and DateTimeImmutable will always evaluate to true.
+Instanceof between DateTimeImmutable and DateTimeInterface will always evaluate to true.
+Instanceof between DateTimeImmutable and ImpossibleInstanceofNotPhpDoc\SomeFinalClass will always evaluate to false.
+Instanceof between DateTimeInterface and 'DateTimeInterface' will always evaluate to true.
+Instanceof between DateTimeInterface and DateTimeInterface will always evaluate to true.
+Instanceof between DateTimeInterface and ImpossibleInstanceofNotPhpDoc\SomeFinalClass will always evaluate to false.
+Instanceof between Exception and Exception will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Bar and ImpossibleInstanceOf\BarChild will always evaluate to false.
+Instanceof between ImpossibleInstanceOf\Bar and ImpossibleInstanceOf\BarGrandChild will always evaluate to false.
+Instanceof between ImpossibleInstanceOf\Bar&ImpossibleInstanceOf\Foo and ImpossibleInstanceOf\Bar will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Bar&ImpossibleInstanceOf\Foo and ImpossibleInstanceOf\Foo will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\BarChild and ImpossibleInstanceOf\Bar will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Dolor and ImpossibleInstanceOf\Dolor will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Dolor and ImpossibleInstanceOf\Lorem will always evaluate to false.
+Instanceof between ImpossibleInstanceOf\Foo and ImpossibleInstanceOf\Foo will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\FooImpl and ImpossibleInstanceOf\Foo will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Ipsum and ImpossibleInstanceOf\Ipsum will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Ipsum and ImpossibleInstanceOf\Lorem will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Lorem and ImpossibleInstanceOf\Lorem will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Test and ImpossibleInstanceOf\Test will always evaluate to true.
+Instanceof between ImpossibleInstanceOf\Test|null and ImpossibleInstanceOf\Lorem will always evaluate to false.
+Instanceof between ImpossibleInstanceofInTrait\Cat and stdClass will always evaluate to false.
+Instanceof between ImpossibleInstanceofInTrait\Dog and stdClass will always evaluate to false.
+Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.
+Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar|null and ImpossibleInstanceofNewIsAlwaysFinal\Baz will always evaluate to false.
+Instanceof between ImpossibleInstanceofNewIsAlwaysFinal\Bar|null and ImpossibleInstanceofNewIsAlwaysFinal\Foo will always evaluate to false.
+Instanceof between PossiblyImpureInstanceofTip\Cat and PossiblyImpureInstanceofTip\Cat will always evaluate to true.
+Instanceof between UnreachableIfBranchesNotPhpDoc\Foo and UnreachableIfBranchesNotPhpDoc\Foo will always evaluate to true.
+Instanceof between UnreachableTernaryElseBranchNotPhpDoc\Foo and UnreachableTernaryElseBranchNotPhpDoc\Foo will always evaluate to true.
+Instanceof between callable and ImpossibleInstanceOf\FinalClassWithoutInvoke will always evaluate to false.
+Instanceof between class-string<DateTimeInterface> and 'DateTimeInterface' will always evaluate to false.
+Instanceof between class-string<DateTimeInterface> and DateTimeInterface will always evaluate to false.
+Instanceof between class-string<DateTimeInterface> and class-string<DateTimeInterface> will always evaluate to false.
+Instanceof between mixed and ImpossibleInstanceOf\InvalidTypeTest|int results in an error.
+Instanceof between mixed and int results in an error.
+Instanceof between mixed and trait Bug7720\FooBar will always evaluate to false.
+Instanceof between null and Bug3632\NiceClass will always evaluate to false.
+Instanceof between object and Exception will always evaluate to false.
+Instanceof between object and InvalidArgumentException will always evaluate to false.
+Instanceof between stdClass and Exception will always evaluate to false.
+Instanceof between stdClass and array results in an error.
+Instanceof between stdClass and stdClass will always evaluate to true.
+Instanceof between stdClass and string|null results in an error.
+Instanceof between string and 'str' will always evaluate to false.
+Instanceof between string and Bug10201\Hello will always evaluate to false.
+Instanceof between string and ImpossibleInstanceOf\Foo will always evaluate to false.
+Instantiated class Bug4471\Baz not found.
+Instantiated class Bug4471\Foo is abstract.
+Instantiated class Test not found.
+Instantiated class TestInstantiation\FooBarInstantiation not found.
+Instantiated class TestInstantiation\LoremInstantiation is abstract.
+Instantiated class UndefinedClass1 not found.
+Instantiated class UndefinedClass2 not found.
+Instantiated class UndefinedClass3 not found.
+Instantiating DateTime with 2020.11.17 produces an error: Double time specification
+Instantiating DateTimeImmutable with 2020.11.17 produces an error: Double time specification
+Instantiating DateTimeImmutable with 2020.11.18 produces an error: Double time specification
+Instantiating DateTimeImmutable with asdfasdf produces an error: The timezone could not be found in the database
+Instantiation of internal class Bug12951Polyfill\NumberFormatter.
+Interface AbstractMethod\Baz contains abstract method doBar().
+Interface Bug10302ExtendedInterface\BatchAware requires implementing class to extend Bug10302ExtendedInterface\Model, but Bug10302ExtendedInterface\AnotherModel does not.
+Interface ClassAttributes\InterfaceAsAttribute is not an Attribute class.
+Interface EnumImplements\FooInterface referenced with incorrect case: EnumImplements\FOOInterface.
+Interface ExtendsImplements\FooInterface referenced with incorrect case: ExtendsImplements\FOOInterface.
+Interface IncompatibleRequireExtends\RequireNonExisstentUnionClassinterface requires implementing class to extend IncompatibleRequireExtends\NonExistentClass|IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\RequireNonExisstentUnionClassinterface@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-extends.php:185 does not.
+Interface IncompatibleRequireExtends\RequireNonExisstentUnionClassinterface requires implementing class to extend IncompatibleRequireExtends\NonExistentClass|IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\SomeClass@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-extends.php:187 does not.
+Interface IncompatibleRequireExtends\ValidInterface requires implementing class to extend IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\InvalidInterfaceUse does not.
+Interface IncompatibleRequireExtends\ValidInterface requires implementing class to extend IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\InvalidInterfaceUse2 does not.
+Interface InterfaceAncestorsExtends\ExtendsGenericInterface extends generic interface InterfaceAncestorsExtends\FooGeneric but does not specify its types: T, U
+Interface InterfaceAncestorsExtends\FooDoesNotImplementAnything has @extends tag, but does not extend any interface.
+Interface InterfaceAncestorsExtends\FooWrongClassImplemented extends generic interface InterfaceAncestorsExtends\FooGeneric but does not specify its types: T, U
+Interface InterfaceAncestorsExtends\FooWrongClassImplemented extends generic interface InterfaceAncestorsExtends\FooGeneric3 but does not specify its types: T, W
+Interface InterfaceAncestorsExtends\FooWrongTypeInImplementsTag @extends tag contains incompatible type class-string<InterfaceAncestorsExtends\T>.
+Interface InterfaceAncestorsExtends\FooWrongTypeInImplementsTag extends generic interface InterfaceAncestorsExtends\FooGeneric but does not specify its types: T, U
+Interface InterfaceAncestorsImplements\FooAlsoNotSubtype has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooCorrect has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooDoesNotImplementAnything has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooExtraTypes has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric2 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric3 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric4 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric5 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric6 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric7 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooGenericGeneric8 has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooInvalidImplementsTags has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooNotEnough has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooNotSubtype has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooTypeProjection has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooUnknownClass has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooWrongClassImplemented has @implements tag, but can not implement any interface, must extend from it.
+Interface InterfaceAncestorsImplements\FooWrongTypeInImplementsTag @implements tag contains incompatible type class-string<InterfaceAncestorsImplements\T>.
+Interface InterfaceExtendsEnum\Foo extends enum InterfaceExtendsEnum\FooEnum.
+Interface InterfaceExtendsError\Foo extends unknown interface InterfaceExtendsError\Bar.
+Interface InterfaceExtendsError\Ipsum extends trait InterfaceExtendsError\DolorTrait.
+Interface InterfaceExtendsError\Lorem extends class InterfaceExtendsError\BazClass.
+Interface IteratorAggregate specifies template type TValue of interface Traversable as string but it's already specified as CrossCheckInterfacesEnums\Item.
+Interface IteratorAggregate specifies template type TValue of interface Traversable as string but it's already specified as CrossCheckInterfacesInInterfaces\Item.
+Interface IteratorAggregate specifies template type TValue of interface Traversable as string but it's already specified as CrossCheckInterfaces\Item.
+Interface TraitUseError\Baz uses trait TraitUseError\BarTrait.
+Interface Uses\Lorem referenced with incorrect case: Uses\LOREM.
+Interface cannot be an Attribute class.
+Interfaces can include properties only on PHP 8.4 and later.
+Invalid array key type Bug6315\FooEnum::A.
+Invalid array key type Bug6315\FooEnum::B.
+Invalid array key type DateTimeImmutable.
+Invalid array key type InvalidKeyArrayItemEnum\FooEnum::A.
+Invalid array key type array.
+Invalid array key type array<int, int|string>.
+Invalid array key type false.
+Invalid array key type float.
+Invalid array key type null.
+Invalid array key type stdClass.
+Invalid type Exception|null to throw.
+Invalid type ThrowExprValues\InvalidException to throw.
+Invalid type ThrowExprValues\InvalidInterfaceException to throw.
+Invalid type definition detected in type alias InvalidTypeAlias.
+Invalid type int to throw.
+Invoking callable on an unknown class CallCallables\Bar.
+IpsumAccessStaticProperties::ipsum() accesses parent::$lorem but IpsumAccessStaticProperties does not extend any class.
+Iterating over an object of an unknown class IterablesInForeach\Bar.
+Key '1' (string) will be cast to 1 (int) in the array access.
+Key '1' (string) will be cast to 1 (int) in the array.
+Key '10' (string) will be cast to 10 (int) in the array access.
+Key '10' (string) will be cast to 10 (int) in the array.
+Key 2.5 (float) will be cast to 2 (int) in the array access.
+Key 2.5 (float) will be cast to 2 (int) in the array.
+Key false (bool) will be cast to 0 (int) in the array access.
+Key false (bool) will be cast to 0 (int) in the array.
+Key null (null) will be cast to '' (string) in the array access.
+Key null (null) will be cast to '' (string) in the array.
+Key true (bool) will be cast to 1 (int) in the array access.
+Key true (bool) will be cast to 1 (int) in the array.
+Keyword break used outside of a loop or a switch statement.
+Keyword continue used outside of a loop or a switch statement.
+Left side of && is always false.
+Left side of && is always true.
+Left side of and is always false.
+Left side of and is always true.
+Left side of or is always false.
+Left side of or is always true.
+Left side of xor is always false.
+Left side of xor is always true.
+Left side of || is always false.
+Left side of || is always true.
+Loose comparison using != between 3 and 3 will always evaluate to false.
+Loose comparison using == between ' 23' and int<10, 20> will always evaluate to false.
+Loose comparison using == between ' 3' and int<10, 20> will always evaluate to false.
+Loose comparison using == between '13foo' and int<10, 20> will always evaluate to false.
+Loose comparison using == between 0 and '0' will always evaluate to true.
+Loose comparison using == between 0 and '1' will always evaluate to false.
+Loose comparison using == between 0|1|false and 2 will always evaluate to false.
+Loose comparison using == between 1 and 1 will always evaluate to true.
+Loose comparison using == between 1 and null will always evaluate to false.
+Loose comparison using == between 23 and int<10, 20> will always evaluate to false.
+Loose comparison using == between 3 and 3 will always evaluate to true.
+Loose comparison using == between 3 and int<10, 20> will always evaluate to false.
+Loose comparison using == between Bug8485\E::c and Bug8485\E::c will always evaluate to true.
+Loose comparison using == between Bug8485\F and Bug8485\E will always evaluate to false.
+Loose comparison using == between Bug8485\F and Bug8485\E::c will always evaluate to false.
+Loose comparison using == between Bug8485\F::c and Bug8485\E::c will always evaluate to false.
+Loose comparison using == between false and int<10, 20> will always evaluate to false.
+Loose comparison using == between int<10, 20> and ' 23' will always evaluate to false.
+Loose comparison using == between int<10, 20> and ' 3' will always evaluate to false.
+Loose comparison using == between int<10, 20> and '13foo' will always evaluate to false.
+Loose comparison using == between int<10, 20> and 23 will always evaluate to false.
+Loose comparison using == between int<10, 20> and 3 will always evaluate to false.
+Loose comparison using == between int<10, 20> and false will always evaluate to false.
+Loose comparison using == between int<10, 20> and null will always evaluate to false.
+Loose comparison using == between int<10, 20> and true will always evaluate to true.
+Loose comparison using == between null and int<10, 20> will always evaluate to false.
+Loose comparison using == between true and int<10, 20> will always evaluate to true.
+Magic constant __CLASS__ is always empty outside a class.
+Magic constant __FUNCTION__ is always empty outside a function.
+Magic constant __METHOD__ is always empty outside a function.
+Magic constant __NAMESPACE__ is always empty in global namespace.
+Magic constant __TRAIT__ is always empty outside a trait.
+Match arm comparison between $this(LastMatchArmAlwaysTrue\Bar)&LastMatchArmAlwaysTrue\Bar::ONE and LastMatchArmAlwaysTrue\Bar::ONE is always true.
+Match arm comparison between $this(LastMatchArmAlwaysTrue\Foo)&LastMatchArmAlwaysTrue\Foo::TWO and LastMatchArmAlwaysTrue\Foo::TWO is always true.
+Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.
+Match arm comparison between 1 and 0 is always false.
+Match arm comparison between 1 and 1 is always true.
+Match arm comparison between 1|2 and 3 is always false.
+Match arm comparison between 1|2|3 and 'foo' is always false.
+Match arm comparison between 1|2|3 and 0 is always false.
+Match arm comparison between 1|2|3|4|5|6 and 0 is always false.
+Match arm comparison between 3 and 3 is always true.
+Match arm comparison between Bug8240\Foo2::BAZ and Bug8240\Foo2::BAZ is always true.
+Match arm comparison between Bug8240\Foo::BAR and Bug8240\Foo::BAR is always true.
+Match arm comparison between MatchEnums\Foo and MatchEnums\Foo::ONE is always false.
+Match arm comparison between MatchEnums\Foo::THREE and MatchEnums\Foo::THREE is always true.
+Match arm comparison between MatchEnums\Foo::THREE|MatchEnums\Foo::TWO and MatchEnums\DifferentEnum::ONE is always false.
+Match arm comparison between int<1, 6>|int<8, 14> and 0 is always false.
+Match arm comparison between int<1, max> and 0 is always false.
+Match arm comparison between true and false is always false.
+Match expression does not handle remaining value: 1
+Match expression does not handle remaining value: 3
+Match expression does not handle remaining value: MatchEnums\Foo::THREE
+Match expression does not handle remaining value: class-string<Bug9534\Bike|Bug9534\Boat|Bug9534\Car>
+Match expression does not handle remaining value: class-string<Bug9534\Bike|Bug9534\Car>
+Match expression does not handle remaining value: class-string<Bug9534\FinalBike|Bug9534\FinalBoat>
+Match expression does not handle remaining value: class-string<T of Bug12998\C|Bug12998\D>
+Match expression does not handle remaining value: true
+Match expression does not handle remaining values: 1|2|3
+Match expression does not handle remaining values: MatchEnums\Foo::THREE|MatchEnums\Foo::TWO
+Match expression does not handle remaining values: int<min, 0>|int<2, max>
+MatchCallbackScopeRegression\Suit
+MatchEnumPartialArmRegression\MyEnum::A
+Method AllMethodsArePure\Bar::impure() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\Bar::impureVoid() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\Bar::pureVoid() is marked as pure but returns void.
+Method AllMethodsArePure\Bar::test() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\Bar::testVoid() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\Foo::impure() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\Foo::impureVoid() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\Foo::pureVoid() is marked as pure but returns void.
+Method AllMethodsArePure\SideEffectImpure::nothingWithPure() is marked as impure but does not have any side effects.
+Method AllMethodsArePure\SideEffectPure::impureWithPure() is marked as impure but does not have any side effects.
+Method Bug10043\C::foo() overrides final method Bug10043\B::foo().
+Method Bug10149\StdSat::__get() has #[\Override] attribute but does not override any method.
+Method Bug10580\FooA::fooThisClass() should return $this(Bug10580\FooA) but returns Bug10580\FooA.
+Method Bug10580\FooA::fooThisInterface() should return $this(Bug10580\FooA) but returns Bug10580\FooA.
+Method Bug10580\FooA::fooThisSelf() should return $this(Bug10580\FooA) but returns Bug10580\FooA.
+Method Bug10580\FooA::fooThisStatic() should return $this(Bug10580\FooA) but returns Bug10580\FooA.
+Method Bug10580\FooB::fooThis() should return $this(Bug10580\FooB) but returns Bug10580\FooB.
+Method Bug10580\FooB::fooThisClass() should return $this(Bug10580\FooB) but returns Bug10580\FooB.
+Method Bug10580\FooB::fooThisInterface() should return $this(Bug10580\FooB) but returns Bug10580\FooB.
+Method Bug10580\FooB::fooThisSelf() should return $this(Bug10580\FooB) but returns Bug10580\FooB.
+Method Bug10580\FooB::fooThisStatic() should return $this(Bug10580\FooB) but returns Bug10580\FooB.
+Method Bug11067\BooleanBuilder2::__construct() overrides final method Bug11067\BaseBuilder2::__construct().
+Method Bug11802b\HelloWorld::doBar() is unused.
+Method Bug11980\Demo::process2() never returns void so it can be removed from the return type.
+Method Bug12382\FinalHelloWorld1::dummy() is marked as impure but does not have any side effects.
+Method Bug12382\FinalHelloWorld2::dummy() is marked as impure but does not have any side effects.
+Method Bug12382\FinalHelloWorld3::dummy() is marked as impure but does not have any side effects.
+Method Bug12382\FinalHelloWorld4::dummy() is marked as impure but does not have any side effects.
+Method Bug12928\FooBarBaz::render() should return non-empty-string but returns string.
+Method Bug13384c\Bug13384Static::doBar() never returns true so the return type can be changed to false.
+Method Bug13384c\Bug13384Static::doBar2() never returns false so the return type can be changed to true.
+Method Bug13384c\Bug13384Static::doBarPhpdoc() never returns false so the return type can be changed to true.
+Method Bug13384c\Bug13384c::doBar() never returns true so the return type can be changed to false.
+Method Bug13384c\Bug13384c::doBar2() never returns false so the return type can be changed to true.
+Method Bug13384c\Bug13384c::doBarPhpdoc() never returns false so the return type can be changed to true.
+Method Bug13642\HelloWorld::sayHello2() throws exception ValueError but the PHPDoc contains @throws void.
+Method Bug13792\Foo::dynamicName() throws checked exception DOMException but it's missing from the PHPDoc @throws tag.
+Method Bug13792\Foo::invalidConstantName() throws checked exception DOMException but it's missing from the PHPDoc @throws tag.
+Method Bug13792\Foo::unions() throws checked exception DOMException but it's missing from the PHPDoc @throws tag.
+Method Bug1903\Test::doFoo() should return array but returns int.
+Method Bug2600\Foo::doBar() invoked with 3 parameters, 0-1 required.
+Method Bug3117\SimpleTemporal::adjustInto() should return T of Bug3117\Temporal but returns $this(Bug3117\SimpleTemporal).
+Method Bug3118\CustomEnum2::all() should return Bug3118\EnumSet<static(Bug3118\CustomEnum2)> but returns Bug3118\CustomEnumSet.
+Method Bug3481\Foo::doSomething() invoked with 2 parameters, 3 required.
+Method Bug3488\C::invalidCase() should return int but return statement is missing.
+Method Bug3523\Bar::deserialize() should return static(Bug3523\Bar) but returns Bug3523\Bar.
+Method Bug3997\Bar::count() should return int<0, max> but returns 'foo'.
+Method Bug3997\Baz::count() should return int but returns string.
+Method Bug3997\Dolor::count() should return int<0, max> but returns -1.
+Method Bug3997\Foo::count() should return int<0, max> but returns 'foo'.
+Method Bug3997\Lorem::count() should return int but returns string.
+Method Bug4163\HelloWorld::lall() should return array<string, string> but returns array<int|string, string>.
+Method Bug4443\HelloWorld::getArray() should return array<mixed> but returns array<mixed>|null.
+Method Bug4590\Controller::test1() should return Bug4590\OkResponse<array<string, string>> but returns Bug4590\OkResponse<array{ok: string}>.
+Method Bug4590\Controller::test2() should return Bug4590\OkResponse<array<int, string>> but returns Bug4590\OkResponse<array{string}>.
+Method Bug4590\Controller::test3() should return Bug4590\OkResponse<array<string>> but returns Bug4590\OkResponse<array{string}>.
+Method Bug4590\OkResponse::testGenericStatic() should return static(Bug4590\OkResponse<array<string, string>>) but returns static(Bug4590\OkResponse<array{ok: string}>).
+Method Bug5065\Collection::emptyWorkaround2() should return Bug5065\Collection<NewTKey of (int|string), NewT> but returns Bug5065\Collection<(int|string), mixed>.
+Method Bug5218\IA::getIterator() should return Traversable<string, int> but returns ArrayIterator<string, mixed>.
+Method Bug5946\Model::getModel() should return $this(Bug5946\Model) but returns static(Bug5946\Model).
+Method Bug6358\HelloWorld::sayHello() should return list<stdClass> but returns array{1: stdClass}.
+Method Bug6589\HelloWorldSimple::getField() should return Bug6589\Field2 but returns Bug6589\Field.
+Method Bug6589\HelloWorldTemplated::getField() should return TField of Bug6589\Field2 but returns Bug6589\Field.
+Method Bug7389\HelloWorld::getTest() is unused.
+Method Bug7389\HelloWorld::getTest1() is unused.
+Method Bug7662\Foo::__construct() has parameter $bar with no value type specified in iterable type array.
+Method Bug7859\ExtendingClassImplementingSomeInterface::getList() overrides method Bug7859\ImplementingSomeInterface::getList() but misses parameter #2 $b.
+Method Bug7859\ExtendingClassNotImplementingSomeInterface::getList() overrides method Bug7859\NotImplementingSomeInterface::getList() but misses parameter #2 $b.
+Method Bug8071\Inheritance::inherit() should return array<TKey of (int|string), TValues of bool|float|int|string|null> but returns array<string>.
+Method Bug8146bError\LocationFixtures::getData() should return array<non-empty-string, array<non-empty-string, array{constituencies: non-empty-list<non-empty-string>, coordinates: array{lat: float, lng: float}}>> but returns array{Bács-Kiskun: array{Ágasegyháza: array{constituencies: array{'Bács-Kiskun 4.', true, false, Bug8146bError\X, null}, coordinates: array{lat: 46.8386043, lng: 19.4502899}}, Akasztó: array{constituencies: array{'Bács-Kiskun 3.'}, coordinates: array{lat: 46.6898175, lng: 19.205086}}, Apostag: array{constituencies: array{'Bács-Kiskun 3.'}, coordinates: array{lat: 46.8812652, lng: 18.9648478}}, Bácsalmás: array{constituencies: array{'Bács-Kiskun 5.'}, coordinates: array{lat: 46.1250396, lng: 19.3357509}}, Bácsbokod: array{constituencies: array{'Bács-Kiskun 6.'}, coordinates: array{lat: 46.1234737, lng: 19.155708}}, Bácsborsód: array{constituencies: array{'Bács-Kiskun 6.'}, coordinates: array{lat: 46.0989373, lng: 19.1566725}}, Bácsszentgyörgy: array{constituencies: array{'Bács-Kiskun 6.'}, coordinates: array{lat: 45.9746039, lng: 19.0398066}}, Bácsszőlős: array{constituencies: array{'Bács-Kiskun 5.'}, coordinates: array{lat: 46.1352003, lng: 19.4215997}}, ...}, Baranya: non-empty-array<literal-string&non-falsy-string, non-empty-array<literal-string&non-falsy-string, non-empty-array<int<0, max>|(literal-string&non-falsy-string), float|(literal-string&non-falsy-string)>>>, Békés: array{Almáskamarás: array{constituencies: array{'Békés 4.'}, coordinates: array{lat: 46.4617785, lng: 21.092448}}, Battonya: array{constituencies: array{'Békés 4.'}, coordinates: array{lat: 46.2902462, lng: 21.0199215}}, Békés: array{constituencies: array{'Békés 2.'}, coordinates: array{lat: 46.6704899, lng: 21.0434996}}, Békéscsaba: array{constituencies: array{'Békés 1.'}, coordinates: array{lat: 46.6735939, lng: 21.0877309}}, Békéssámson: array{constituencies: array{'Békés 4.'}, coordinates: array{lat: 46.4208677, lng: 20.6176498}}, Békésszentandrás: array{constituencies: array{'Békés 2.'}, coordinates: array{lat: 46.8715996, lng: 20.48336}}, Bélmegyer: array{constituencies: array{'Békés 3.'}, coordinates: array{lat: 46.8726019, lng: 21.1832832}}, Biharugra: array{constituencies: array{'Békés 3.'}, coordinates: array{lat: 46.9691009, lng: 21.5987651}}, ...}, Borsod-Abaúj-Zemplén: non-empty-array<literal-string&non-falsy-string, non-empty-array<literal-string&non-falsy-string, non-empty-array<int<0, max>|(literal-string&non-falsy-string), float|(literal-string&non-falsy-string)>>>, Budapest: array{'Budapest I. ker.': array{constituencies: array{'Budapest 01.'}, coordinates: array{lat: 47.4968219, lng: 19.037458}}, 'Budapest II. ker.': array{constituencies: array{'Budapest 03.', 'Budapest 04.'}, coordinates: array{lat: 47.5393329, lng: 18.986934}}, 'Budapest III. ker.': array{constituencies: array{'Budapest 04.', 'Budapest 10.'}, coordinates: array{lat: 47.5671768, lng: 19.0368517}}, 'Budapest IV. ker.': array{constituencies: array{'Budapest 11.', 'Budapest 12.'}, coordinates: array{lat: 47.5648915, lng: 19.0913149}}, 'Budapest V. ker.': array{constituencies: array{'Budapest 01.'}, coordinates: array{lat: 47.5002319, lng: 19.0520181}}, 'Budapest VI. ker.': array{constituencies: array{'Budapest 05.'}, coordinates: array{lat: 47.509863, lng: 19.0625813}}, 'Budapest VII. ker.': array{constituencies: array{'Budapest 05.'}, coordinates: array{lat: 47.5027289, lng: 19.073376}}, 'Budapest VIII. ker.': array{constituencies: array{'Budapest 01.', 'Budapest 06.'}, coordinates: array{lat: 47.4894184, lng: 19.070668}}, ...}, Csongrád-Csanád: array{Algyő: array{constituencies: array{'Csongrád-Csanád 4.'}, coordinates: array{lat: 46.3329625, lng: 20.207889}}, Ambrózfalva: array{constituencies: array{'Csongrád-Csanád 4.'}, coordinates: array{lat: 46.3501417, lng: 20.7313995}}, Apátfalva: array{constituencies: array{'Csongrád-Csanád 4.'}, coordinates: array{lat: 46.173317, lng: 20.5800472}}, Árpádhalom: array{constituencies: array{'Csongrád-Csanád 3.'}, coordinates: array{lat: 46.6158286, lng: 20.547733}}, Ásotthalom: array{constituencies: array{'Csongrád-Csanád 2.'}, coordinates: array{lat: 46.1995983, lng: 19.7833756}}, Baks: array{constituencies: array{'Csongrád-Csanád 3.'}, coordinates: array{lat: 46.5518708, lng: 20.1064166}}, Balástya: array{constituencies: array{'Csongrád-Csanád 3.'}, coordinates: array{lat: 46.4261828, lng: 20.004933}}, Bordány: array{constituencies: array{'Csongrád-Csanád 2.'}, coordinates: array{lat: 46.3194213, lng: 19.9227063}}, ...}, Fejér: array{Aba: array{constituencies: array{'Fejér 5.'}, coordinates: array{lat: 47.0328193, lng: 18.522359}}, Adony: array{constituencies: array{'Fejér 4.'}, coordinates: array{lat: 47.119831, lng: 18.8612469}}, Alap: array{constituencies: array{'Fejér 5.'}, coordinates: array{lat: 46.8075763, lng: 18.684028}}, Alcsútdoboz: array{constituencies: array{'Fejér 3.'}, coordinates: array{lat: 47.4277067, lng: 18.6030325}}, Alsószentiván: array{constituencies: array{'Fejér 5.'}, coordinates: array{lat: 46.7910573, lng: 18.732161}}, Bakonycsernye: array{constituencies: array{'Fejér 2.'}, coordinates: array{lat: 47.321719, lng: 18.0907379}}, Bakonykúti: array{constituencies: array{'Fejér 2.'}, coordinates: array{lat: 47.2458464, lng: 18.195769}}, Balinka: array{constituencies: array{'Fejér 2.'}, coordinates: array{lat: 47.3135736, lng: 18.1907168}}, ...}, Győr-Moson-Sopron: array{Abda: array{constituencies: array{'Győr-Moson-Sopron 5.'}, coordinates: array{lat: 47.6962149, lng: 17.5445786}}, Acsalag: array{constituencies: array{'Győr-Moson-Sopron 3.'}, coordinates: array{lat: 47.676095, lng: 17.1977771}}, Ágfalva: array{constituencies: array{'Győr-Moson-Sopron 4.'}, coordinates: array{lat: 47.688862, lng: 16.5110233}}, Agyagosszergény: array{constituencies: array{'Győr-Moson-Sopron 3.'}, coordinates: array{lat: 47.608545, lng: 16.9409912}}, Árpás: array{constituencies: array{'Győr-Moson-Sopron 3.'}, coordinates: array{lat: 47.5134127, lng: 17.3931579}}, Ásványráró: array{constituencies: array{'Győr-Moson-Sopron 5.'}, coordinates: array{lat: 47.8287695, lng: 17.499195}}, Babót: array{constituencies: array{'Győr-Moson-Sopron 3.'}, coordinates: array{lat: 47.5752269, lng: 17.0758604}}, Bágyogszovát: array{constituencies: array{'Győr-Moson-Sopron 3.'}, coordinates: array{lat: 47.5866036, lng: 17.3617273}}, ...}, ...}.
+Method Bug8174\HelloWorld::filterList() should return list<string> but returns array<int<0, max>, '23423'>.
+Method Bug9014\Bar::test() overrides method Bug9014\Foo::test() but misses parameter #2 $test.
+Method Bug9135\Sub::sayHello() overrides @final method Bug9135\HelloWorld::sayHello().
+Method Bug9820\HelloWorld::x() invoked with 1 parameter, 0 required.
+Method BugArrayOffset\Foo2::__construct() throws checked exception BugArrayOffset\ParameterNotFoundException but it's missing from the PHPDoc @throws tag.
+Method BugArrayOffset\Foo3::__construct() throws checked exception BugArrayOffset\ParameterNotFoundException but it's missing from the PHPDoc @throws tag.
+Method BugArrayOffset\Foo4::__construct() throws checked exception BugArrayOffset\ParameterNotFoundException but it's missing from the PHPDoc @throws tag.
+Method BugArrayOffset\Foo::__construct() throws checked exception BugArrayOffset\ParameterNotFoundException but it's missing from the PHPDoc @throws tag.
+Method CallMethodsWithoutUnionTypes\Foo::doFoo() invoked with 3 parameters, 0 required.
+Method CallStaticMethods\ClassWithConstructor::__construct() invoked with 0 parameters, 1 required.
+Method CallVariadicMethods\Foo::baz() invoked with 0 parameters, at least 1 required.
+Method CallVariadicMethods\Foo::doIntegerParameters() invoked with 3 parameters, 2 required.
+Method CallVariadicMethods\Foo::lorem() invoked with 0 parameters, at least 2 required.
+Method CheckMissingOverrideAttr\Bar::doFoo() overrides method CheckMissingOverrideAttr\Foo::doFoo() but is missing the #[\Override] attribute.
+Method CheckMissingOverrideAttr\ChildOfParentWithAbstractConstructor::__construct() overrides method CheckMissingOverrideAttr\ParentWithAbstractConstructor::__construct() but is missing the #[\Override] attribute.
+Method CheckPhpDocMissingReturn\Bar::doFoo() should return int|string but return statement is missing.
+Method CheckPhpDocMissingReturn\Bar::doFoo2() should return string|null but return statement is missing.
+Method CheckPhpDocMissingReturn\Bar::doFoo3() should return int|string but return statement is missing.
+Method CheckPhpDocMissingReturn\Bar::doFoo4() should return string|null but return statement is missing.
+Method CheckPhpDocMissingReturn\Bar::doFoo5() should return mixed but return statement is missing.
+Method CheckPhpDocMissingReturn\Foo::doFoo() should return int|string but return statement is missing.
+Method CheckPhpDocMissingReturn\Foo::doFoo2() should return string|null but return statement is missing.
+Method CheckPhpDocMissingReturn\Foo::doFoo3() should return int|string but return statement is missing.
+Method CheckPhpDocMissingReturn\Foo::doFoo4() should return string|null but return statement is missing.
+Method CheckPhpDocMissingReturn\Foo::doFoo5() should return mixed but return statement is missing.
+Method Closure::call() invoked with 0 parameters, 2 required.
+Method Closure::call() invoked with 1 parameter, 2 required.
+Method Closure::call() invoked with 3 parameters, 2 required.
+Method ConsistentConstructor\FakeConnection::__construct() overrides method ConsistentConstructor\Connection::__construct() but misses parameter #1 $i.
+Method ConsistentConstructor\Foo2::__construct() overrides method ConsistentConstructor\Foo1::__construct() but misses parameter #1 $a.
+Method Couchbase\BucketManager::flush() invoked with 0 parameters, 1 required.
+Method Couchbase\BucketManager::flush() invoked with 2 parameters, 1 required.
+Method DateTimeZone::getTransitions() invoked with 3 parameters, 0-2 required.
+Method DeepInspectTypes\Foo::doBar() has parameter $bars with generic class DeepInspectTypes\Bar but does not specify its types: T
+Method DeepInspectTypes\Foo::doFoo() has parameter $foo with no value type specified in iterable type iterable.
+Method Exception::getMessage() invoked with 1 parameter, 0 required.
+Method FooWithoutNamespace::misleadingBoolReturnType() should return boolean but returns int.
+Method FooWithoutNamespace::misleadingBoolReturnType() should return boolean but returns true.
+Method FooWithoutNamespace::misleadingIntReturnType() should return integer but returns int.
+Method FooWithoutNamespace::misleadingIntReturnType() should return integer but returns true.
+Method ImmediatelyCalledArrowFunction\ImmediatelyCalledCallback::doFoo2() has InvalidArgumentException in PHPDoc @throws tag but it's not thrown.
+Method LessParametersVariadics\Bar::doFoo() overrides method LessParametersVariadics\Foo::doFoo() but misses parameter #2 $parameters.
+Method LessParametersVariadics\Bar::doFoo() overrides method LessParametersVariadics\Foo::doFoo() but misses parameter #3 $here.
+Method LessParametersVariadics\Baz::doFoo() overrides method LessParametersVariadics\Foo::doFoo() but misses parameter #2 $parameters.
+Method LessParametersVariadics\Baz::doFoo() overrides method LessParametersVariadics\Foo::doFoo() but misses parameter #3 $here.
+Method LessParametersVariadics\Lorem::doFoo() overrides method LessParametersVariadics\Foo::doFoo() but misses parameter #3 $here.
+Method MagicSerialization\WrongSignature::__serialize() should return array<mixed, mixed> but returns string.
+Method MagicSerialization\WrongSignature::__unserialize() with return type void returns string but should not return anything.
+Method MagicSignatures\WrongSignature::__clone() with return type void returns string but should not return anything.
+Method MagicSignatures\WrongSignature::__debugInfo() should return array<mixed, mixed>|null but returns string.
+Method MagicSignatures\WrongSignature::__isset() should return bool but returns string.
+Method MagicSignatures\WrongSignature::__set() with return type void returns string but should not return anything.
+Method MagicSignatures\WrongSignature::__set_state() should return object but returns string.
+Method MagicSignatures\WrongSignature::__sleep() should return array<int, string> but returns string.
+Method MagicSignatures\WrongSignature::__unset() with return type void returns string but should not return anything.
+Method MagicSignatures\WrongSignature::__wakeup() with return type void returns string but should not return anything.
+Method MethodIntersectionTypes\FooClass::doBar() has unresolvable native return type.
+Method MethodIntersectionTypes\FooClass::doBaz() has unresolvable native return type.
+Method MethodNever\Foo::callsNever() always terminates script execution, it should have return type "never".
+Method MethodNever\Foo::doBar() always throws an exception, it should have return type "never".
+Method MethodNever\Foo::doBaz() always terminates script execution, it should have return type "never".
+Method MethodThrowTypeCovariance\Baz::noThrowType() should not throw Exception because parent method MethodThrowTypeCovariance\Foo::noThrowType() does not have PHPDoc tag @throws.
+Method MethodThrowTypeCovariance\VoidInChild3::throwVoid() should not throw RuntimeException because parent method MethodThrowTypeCovariance\VoidInParent::throwVoid() has PHPDoc tag @throws void.
+Method MethodTooWideReturnAlwaysCheckFinal\FinalFoo::test() never returns null so it can be removed from the return type.
+Method MethodTooWideReturnAlwaysCheckFinal\FinalFoo::test2() never returns null so it can be removed from the return type.
+Method MethodTooWideReturnAlwaysCheckFinal\FinalFoo::test3() never returns null so it can be removed from the return type.
+Method MethodTooWideReturnAlwaysCheckFinal\Foo::test() never returns null so it can be removed from the return type.
+Method MethodTooWideReturnAlwaysCheckFinal\FooFinalMethods::test() never returns null so it can be removed from the return type.
+Method MethodTooWideReturnAlwaysCheckFinal\FooFinalMethods::test2() never returns null so it can be removed from the return type.
+Method MethodTooWideReturnAlwaysCheckFinal\FooFinalMethods::test3() never returns null so it can be removed from the return type.
+Method MissingExceptionMethodThrows\Foo::dateIntervalDoesThrows() throws checked exception DateMalformedIntervalStringException but it's missing from the PHPDoc @throws tag.
+Method MissingExceptionMethodThrows\Foo::dateTimeModifyDoesThrows() throws checked exception DateMalformedStringException but it's missing from the PHPDoc @throws tag.
+Method MissingExceptionMethodThrows\Foo::dateTimeZoneDoesThrows() throws checked exception DateInvalidTimeZoneException but it's missing from the PHPDoc @throws tag.
+Method MissingExceptionMethodThrows\Foo::doBaz() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
+Method MissingExceptionMethodThrows\Foo::doLorem() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
+Method MissingExceptionMethodThrows\Foo::doLorem2() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
+Method MissingMethodParameterTypehint\Bar::acceptsGenericClass() has parameter $c with generic class MissingMethodParameterTypehint\GenericClass but does not specify its types: A, B
+Method MissingMethodParameterTypehint\Bar::acceptsGenericInterface() has parameter $i with generic interface MissingMethodParameterTypehint\GenericInterface but does not specify its types: T, U
+Method MissingMethodParameterTypehint\Baz::acceptsGenericWithSomeDefaults() has parameter $c with generic class MissingMethodParameterTypehint\GenericClassWithSomeDefaults but does not specify its types: T, U (1-2 required)
+Method MissingMethodParameterTypehint\CallableSignature::doFoo() has parameter $cb with no signature specified for callable.
+Method MissingMethodParameterTypehint\CollectionIterableAndGeneric::acceptsCollection() has parameter $collection with generic interface DoctrineIntersectionTypeIsSupertypeOf\Collection but does not specify its types: TKey, T
+Method MissingMethodParameterTypehint\CollectionIterableAndGeneric::acceptsCollection2() has parameter $collection with generic interface DoctrineIntersectionTypeIsSupertypeOf\Collection but does not specify its types: TKey, T
+Method MissingMethodParameterTypehint\Foo::getBar() has parameter $p2 with no type specified.
+Method MissingMethodParameterTypehint\Foo::getBaz() has parameter $p3 with no type specified.
+Method MissingMethodParameterTypehint\Foo::getFoo() has parameter $p1 with no type specified.
+Method MissingMethodParameterTypehint\Foo::unionTypeWithUnknownArrayValueTypehint() has parameter $a with no value type specified in iterable type array.
+Method MissingMethodParameterTypehint\FooInterface::getFoo() has parameter $p1 with no type specified.
+Method MissingMethodParameterTypehint\FooParent::getBar() has parameter $p2 with no type specified.
+Method MissingMethodParameterTypehint\MissingParamClosureThisType::generics() has @param-closure-this PHPDoc tag for parameter $cb with generic class ReflectionClass but does not specify its types: T
+Method MissingMethodParameterTypehint\MissingParamOutType::generics() has @param-out PHPDoc tag for parameter $a with generic class ReflectionClass but does not specify its types: T
+Method MissingMethodParameterTypehint\MissingParamOutType::oneArray() has @param-out PHPDoc tag for parameter $a with no value type specified in iterable type array.
+Method MissingMethodParameterTypehint\MissingPureClosureSignatureType::doFoo() has parameter $cb with no signature specified for Closure.
+Method MissingMethodReturnTypehint\Bar::returnsGenericClass() return type with generic class MissingMethodReturnTypehint\GenericClass does not specify its types: A, B
+Method MissingMethodReturnTypehint\Bar::returnsGenericInterface() return type with generic interface MissingMethodReturnTypehint\GenericInterface does not specify its types: T, U
+Method MissingMethodReturnTypehint\Baz::returnsGenericWithSomeDefaults() return type with generic class MissingMethodReturnTypehint\GenericClassWithSomeDefaults does not specify its types: T, U (1-2 required)
+Method MissingMethodReturnTypehint\CallableSignature::doFoo() return type has no signature specified for callable.
+Method MissingMethodReturnTypehint\Foo::getBar() has no return type specified.
+Method MissingMethodReturnTypehint\Foo::getFoo() has no return type specified.
+Method MissingMethodReturnTypehint\Foo::unionTypeWithUnknownArrayValueTypehint() return type has no value type specified in iterable type array.
+Method MissingMethodReturnTypehint\FooInterface::getFoo() has no return type specified.
+Method MissingMethodReturnTypehint\FooParent::getBar() has no return type specified.
+Method MissingMethodReturnTypehint\IterableIntersection::doFoo() return type has no value type specified in iterable type Traversable.
+Method MissingMethodSelfOutType\Foo::doFoo() has PHPDoc tag @phpstan-self-out with no value type specified in iterable type array.
+Method MissingMethodSelfOutType\Foo::doFoo2() has PHPDoc tag @phpstan-self-out with generic class MissingMethodSelfOutType\Foo but does not specify its types: T
+Method MissingMethodSelfOutType\Foo::doFoo3() has PHPDoc tag @phpstan-self-out with no signature specified for callable.
+Method MissingMixedReturnEmptyBody\HelloWorld::doFoo() should return mixed but return statement is missing.
+Method MissingReturnTemplateMixedType\Foo::doFoo() should return T but return statement is missing.
+Method MissingReturnTypeGenericStatic\Foo::doFoo() return type has no value type specified in iterable type array.
+Method MissingReturn\Foo::doBar() should return int but return statement is missing.
+Method MissingReturn\Foo::doBaz() should return int but return statement is missing.
+Method MissingReturn\Foo::doFoo() should return int but return statement is missing.
+Method MissingReturn\Foo::doLorem() should return int but return statement is missing.
+Method MissingReturn\FooTemplateMixedType::doFoo() should return T but return statement is missing.
+Method MissingReturn\MissingReturnGenerators::bodySpecifiedTReturn() should return string but return statement is missing.
+Method MissingReturn\MissingReturnGenerators::emptyBodySpecifiedTReturn() should return Generator<int, int, int, string> but return statement is missing.
+Method MissingReturn\MissingReturnGenerators::emptyBodyUnspecifiedTReturn() should return Generator but return statement is missing.
+Method MissingReturn\MissingReturnGenerators::emptyBodyUnspecifiedTReturn2() should return Generator<int, int, mixed, mixed> but return statement is missing.
+Method MissingReturn\MorePreciseMissingReturnLines::doFoo() should return int but return statement is missing.
+Method MissingReturn\MorePreciseMissingReturnLines::doFoo2() should return int but return statement is missing.
+Method MissingReturn\NeverReturn::doBaz() should always throw an exception or terminate script execution but doesn't do that.
+Method MissingReturn\NeverReturn::doBaz2() should always throw an exception or terminate script execution but doesn't do that.
+Method MissingReturn\ReturnInPhpDoc::doFoo() should return int but return statement is missing.
+Method MissingReturn\SwitchBranches::doBar() should return int but return statement is missing.
+Method MissingReturn\SwitchBranches::doDolor() should return int but return statement is missing.
+Method MissingReturn\SwitchBranches::doIpsum() should return int but return statement is missing.
+Method MissingReturn\SwitchBranches::doLorem() should return int but return statement is missing.
+Method MissingReturn\TryCatchFinally::doBaz() should return int but return statement is missing.
+Method MissingReturn\TryCatchFinally::doDolor() should return int but return statement is missing.
+Method MissingTypehintPromotedProperties\Bar::__construct() has parameter $foo with no value type specified in iterable type array.
+Method MissingTypehintPromotedProperties\Foo::__construct() has parameter $foo with no value type specified in iterable type array.
+Method MixinMethods\Foo::doFoo() invoked with 1 parameter, 0 required.
+Method ModelMixin\Model::__callStatic() should return mixed but return statement is missing.
+Method NativeUnionTypesSupport\Foo::doBar() uses native union types but they're supported only on PHP 8.0 and later.
+Method NativeUnionTypesSupport\Foo::doFoo() uses native union types but they're supported only on PHP 8.0 and later.
+Method NoNamedArgumentsMethod\Bar::doFoo() invoked with named argument $i, but it's not allowed because of @no-named-arguments.
+Method NoNamedArgumentsMethod\Foo::doFoo() invoked with named argument $i, but it's not allowed because of @no-named-arguments.
+Method NullableParameters\Foo::doFoo() invoked with 0 parameters, 2 required.
+Method NullableParameters\Foo::doFoo() invoked with 1 parameter, 2 required.
+Method NullableParameters\Foo::doFoo() invoked with 3 parameters, 2 required.
+Method NullsafeMethodCall\Foo::doBar() invoked with 1 parameter, 0 required.
+Method OverrideAttribute\Bar::test2() has #[\Override] attribute but does not override any method.
+Method OverrideAttribute\ChildOfParentWithConstructor::__construct() has #[\Override] attribute but does not override any method.
+Method OverridingFinalMethod\Bar::doFoo() overrides final method OverridingFinalMethod\Foo::doFoo().
+Method OverridingFinalMethod\Dolor::doFoo() overrides method OverridingFinalMethod\Ipsum::doFoo() but misses parameter #1 $i.
+Method OverridingFinalMethod\ExtendsFinalWithAnnotation::doFoo() overrides @final method OverridingFinalMethod\FinalWithAnnotation::doFoo().
+Method OverridingFinalMethod\SomeOtherException::__construct() overrides final method OverridingFinalMethod\OtherException::__construct().
+Method PDO::query() invoked with 0 parameters, 1-4 required.
+Method PHPStan\Rules\Pure\data\A::pureWithThrowsVoid() is marked as pure but returns void.
+Method PromoteMissingOverride\Bar::doFoo() overrides method PromoteMissingOverride\Foo::doFoo() but is missing the #[\Override] attribute.
+Method PureConstructor\Bar::__construct() is marked as impure but does not have any side effects.
+Method PureMethod\ActuallyPure::doFoo() is marked as impure but does not have any side effects.
+Method PureMethod\ClassWithVoidMethods::privateEmptyVoidFunction() returns void but does not have any side effects.
+Method PureMethod\ExtendingClass::impure() is marked as impure but does not have any side effects.
+Method PureMethod\Foo::doFoo() is marked as pure but parameter $p is passed by reference.
+Method PureMethod\Foo::doFoo2() is marked as pure but returns void.
+Method RecursiveDirectoryIterator::getSubPathname() invoked with 1 parameter, 0 required.
+Method RequiredAfterOptional\Foo::doAmet() uses native union types but they're supported only on PHP 8.0 and later.
+Method RequiredAfterOptional\Foo::doConsectetur() uses native union types but they're supported only on PHP 8.0 and later.
+Method RequiredAfterOptional\Foo::doSed() uses native union types but they're supported only on PHP 8.0 and later.
+Method ReturnList\Foo::getList1() should return list<string> but returns array{0?: 'foo', 1?: 'bar'}.
+Method ReturnList\Foo::getList2() should return list<string> but returns array{0?: 'foo', 1?: 'bar'}.
+Method ReturnRuleConditionalTypes\Bar2::doFoo() should return int|string but returns stdClass.
+Method ReturnRuleConditionalTypes\Bar::doFoo() should return int|string but returns stdClass.
+Method ReturnRuleConditionalTypes\Foo::doFoo() should return int|string but returns stdClass.
+Method ReturnRuleError\Bar::processNode() should return list<PHPStan\Rules\IdentifierRuleError> but returns array{'foo'}.
+Method ReturnRuleError\Baz::processNode() should return list<PHPStan\Rules\IdentifierRuleError> but returns array{PHPStan\Rules\RuleError}.
+Method ReturnRuleError\Lorem::processNode() should return list<PHPStan\Rules\IdentifierRuleError> but returns array{1: PHPStan\Rules\IdentifierRuleError}.
+Method ReturnTemplateUnion\Foo::doFoo2() should return T of bool|float|int|string but returns (T of bool|float|int|string)|null.
+Method ReturnTypePhpDocMergeReturnInherited\ChildClass2::method() should return ReturnTypePhpDocMergeReturnInherited\D but returns ReturnTypePhpDocMergeReturnInherited\B.
+Method ReturnTypePhpDocMergeReturnInherited\ChildClass::method() should return ReturnTypePhpDocMergeReturnInherited\B but returns ReturnTypePhpDocMergeReturnInherited\A.
+Method ReturnTypePhpDocMergeReturnInherited\ParentClass::method() should return ReturnTypePhpDocMergeReturnInherited\B but returns ReturnTypePhpDocMergeReturnInherited\A.
+Method ReturnTypesIterable\Foo::stringIterable() should return iterable<string> but returns array<int, int>.
+Method ReturnTypesIterable\Foo::stringIterablePipe() should return iterable<string> but returns array<int, int>.
+Method ReturnTypes\AppendedArrayReturnType::bar() should return array<int> but returns array<int|stdClass>.
+Method ReturnTypes\AppendedArrayReturnType::foo() should return array<int> but returns array<int, stdClass>.
+Method ReturnTypes\ArrayFillKeysIssue::getIPs2() should return array<string, array<ReturnTypes\Foo>> but returns array<string, list<ReturnTypes\Bar>>.
+Method ReturnTypes\AssertThisInstanceOf::doBar() should return $this(ReturnTypes\AssertThisInstanceOf) but returns ReturnTypes\AssertThisInstanceOf&ReturnTypes\FooInterface.
+Method ReturnTypes\Foo2::returnIntFromParent() should return int but returns ReturnTypes\integer.
+Method ReturnTypes\Foo2::returnIntFromParent() should return int but returns string.
+Method ReturnTypes\Foo::misleadingBoolReturnType() should return ReturnTypes\boolean but returns int.
+Method ReturnTypes\Foo::misleadingBoolReturnType() should return ReturnTypes\boolean but returns true.
+Method ReturnTypes\Foo::misleadingIntReturnType() should return ReturnTypes\integer but returns int.
+Method ReturnTypes\Foo::misleadingIntReturnType() should return ReturnTypes\integer but returns true.
+Method ReturnTypes\Foo::returnChild() should return ReturnTypes\Foo but returns ReturnTypes\OtherInterfaceImpl.
+Method ReturnTypes\Foo::returnInteger() should return int but returns string.
+Method ReturnTypes\Foo::returnObject() should return ReturnTypes\Bar but returns ReturnTypes\Foo.
+Method ReturnTypes\Foo::returnObject() should return ReturnTypes\Bar but returns int.
+Method ReturnTypes\Foo::returnScalar() should return bool|float|int|string but returns stdClass.
+Method ReturnTypes\Foo::returnStatic() should return static(ReturnTypes\Foo) but returns ReturnTypes\FooParent.
+Method ReturnTypes\Foo::returnThis() should return $this(ReturnTypes\Foo) but returns ReturnTypes\Foo.
+Method ReturnTypes\Foo::returnThis() should return $this(ReturnTypes\Foo) but returns int.
+Method ReturnTypes\Foo::returnThis() should return $this(ReturnTypes\Foo) but returns null.
+Method ReturnTypes\Foo::returnThis() should return $this(ReturnTypes\Foo) but returns static(ReturnTypes\Foo).
+Method ReturnTypes\Foo::returnThisOrNull() should return $this(ReturnTypes\Foo)|null but returns ReturnTypes\Foo.
+Method ReturnTypes\Foo::returnThisOrNull() should return $this(ReturnTypes\Foo)|null but returns int.
+Method ReturnTypes\Foo::returnThisOrNull() should return $this(ReturnTypes\Foo)|null but returns static(ReturnTypes\Foo).
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but empty return statement found.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns (iterable<ReturnTypes\Foo>&ReturnTypes\AnotherCollection)|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection).
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns ReturnTypes\Bar.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns ReturnTypes\Foo.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns array<int, ReturnTypes\Bar>.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns int.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns iterable<ReturnTypes\Bar>&ReturnTypes\AnotherCollection.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns iterable<ReturnTypes\Bar>&ReturnTypes\Collection.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns iterable<ReturnTypes\Foo>&ReturnTypes\AnotherCollection.
+Method ReturnTypes\Foo::returnUnionIterableType() should return array<ReturnTypes\Foo>|(iterable<ReturnTypes\Foo>&ReturnTypes\Collection) but returns null.
+Method ReturnTypes\Foo::returnVoid() with return type void returns int but should not return anything.
+Method ReturnTypes\Foo::returnVoid() with return type void returns null but should not return anything.
+Method ReturnTypes\Foo::returnsNullInTernary() should return int but returns int|null.
+Method ReturnTypes\Foo::returnsParent() should return ReturnTypes\FooParent but returns int.
+Method ReturnTypes\Foo::returnsParent() should return ReturnTypes\FooParent but returns null.
+Method ReturnTypes\Foo::returnsPhpDocParent() should return ReturnTypes\FooParent but returns int.
+Method ReturnTypes\Foo::returnsPhpDocParent() should return ReturnTypes\FooParent but returns null.
+Method ReturnTypes\FooPhp70::returnInteger() should return int but empty return statement found.
+Method ReturnTypes\NestedArrayCheck::doBar() should return array<string, bool> but returns array<string, array<string, string>>.
+Method ReturnTypes\NestedArrayCheck::doFoo() should return array<string, bool> but returns array<string, list<string>>.
+Method ReturnTypes\NeverReturn::doBaz3() should never return but return statement found.
+Method ReturnTypes\NeverReturn::doFoo() should never return but return statement found.
+Method ReturnTypes\OverridenTypeInIfCondition::getAnotherAnotherStock() should return ReturnTypes\Stock but returns ReturnTypes\Stock|null.
+Method ReturnTypes\ReturnStaticGeneric::instanceReturnsStatic() should return static(ReturnTypes\ReturnStaticGeneric) but returns ReturnTypes\ReturnStaticGeneric.
+Method ReturnTypes\ReturnTernary::returnTernary() should return ReturnTypes\Foo but returns false.
+Method ReturnTypes\ReturningSomethingFromConstructor::__construct() with return type void returns ReturnTypes\Foo but should not return anything.
+Method ReturnTypes\Stock::getAnotherStock() should return ReturnTypes\Stock but returns ReturnTypes\Stock|null.
+Method ReturnTypes\Stock::returnSelfAgainError() should return ReturnTypes\Stock but returns ReturnTypes\Stock|null.
+Method ReturnTypes\Stock::returnYetSelfAgainError() should return ReturnTypes\Stock but returns ReturnTypes\Stock|null.
+Method ReturnTypes\TernaryWithJsonEncode::toJson() should return string but returns string|false.
+Method ReturnTypes\TrickyVoid::returnVoidOrInt() should return int|void but returns string.
+Method ReturnTypes\VariableOverwrittenInForeach::doBar() should return int but returns int|string.
+Method ReturnTypes\VariableOverwrittenInForeach::doFoo() should return int but returns int|string.
+Method ReturnTypes\WrongMagicMethods::__clone() with return type void returns int but should not return anything.
+Method ReturnTypes\WrongMagicMethods::__destruct() with return type void returns int but should not return anything.
+Method ReturnTypes\WrongMagicMethods::__isset() should return bool but returns int.
+Method ReturnTypes\WrongMagicMethods::__set_state() should return object but returns array<string, string>.
+Method ReturnTypes\WrongMagicMethods::__sleep() should return array<int, string> but returns array<int, stdClass>.
+Method ReturnTypes\WrongMagicMethods::__toString() should return string but returns true.
+Method ReturnTypes\WrongMagicMethods::__unset() with return type void returns int but should not return anything.
+Method ReturnTypes\WrongMagicMethods::__wakeup() with return type void returns int but should not return anything.
+Method SelfOutClasses\Foo::doBar() has invalid @phpstan-self-out type SelfOutClasses\FooTrait.
+Method SelfOutClasses\Foo::doFoo() has invalid @phpstan-self-out type SelfOutClasses\Nonexistent.
+Method StaticCallsToInstanceMethods\Foo::doFoo() invoked with 1 parameter, 0 required.
+Method TaggedUnionReturnCheck\HelloWorld::sayHello() should return array{updated: false, id: null}|array{updated: true, id: int} but returns array{updated: false, id: 5}.
+Method TestMethodTypehints\FooMethodTypehints::dolor() has invalid return type TestMethodTypehints\BazMethodTypehints.
+Method TestMethodTypehints\FooMethodTypehints::foo() has invalid return type TestMethodTypehints\NonexistentClass.
+Method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid return type TestMethodTypehints\BazMethodTypehints.
+Method TestMethodTypehints\FooMethodTypehints::lorem() has invalid return type TestMethodTypehints\BazMethodTypehints.
+Method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid return type parent.
+Method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid return type parent.
+Method Test\FirstInterface::firstMethod() invoked with 1 parameter, 0 required.
+Method Test\Foo::foo() invoked with 1 parameter, 0 required.
+Method Test\Foo::ipsum() invoked with 1 parameter, 0 required.
+Method Test\Foo::test() invoked with 0 parameters, 1 required.
+Method Test\SecondInterface::secondMethod() invoked with 1 parameter, 0 required.
+Method Test\VariadicAnnotationMethod::definedInPhpDoc() invoked with 0 parameters, at least 1 required.
+Method ThrowsVoidMethod\Foo::doFoo() throws exception ThrowsVoidMethod\MyException but the PHPDoc contains @throws void.
+Method TooWideImplicitThrows\Bar::doFoo() has LogicException in PHPDoc @throws tag but it's not thrown.
+Method TooWideMethodParameterOut\FinalFoo::doBar() never assigns null to &$p so it can be removed from the by-ref type.
+Method TooWideMethodParameterOut\FinalFoo::doBaz() never assigns null to &$p so it can be removed from the @param-out type.
+Method TooWideMethodParameterOut\FinalFoo::doBool() never assigns false to &$b so the by-ref type can be changed to true.
+Method TooWideMethodParameterOut\FinalFoo::doBool2() never assigns false to &$b so the @param-out type can be changed to true.
+Method TooWideMethodParameterOut\FinalFoo::doLorem() never assigns null to &$p so it can be removed from the by-ref type.
+Method TooWideMethodParameterOut\Foo::doBar() never assigns null to &$p so it can be removed from the by-ref type.
+Method TooWideMethodParameterOut\Foo::doBaz() never assigns null to &$p so it can be removed from the @param-out type.
+Method TooWideMethodParameterOut\Foo::doBazPrivate() never assigns null to &$p so it can be removed from the @param-out type.
+Method TooWideMethodParameterOut\Foo::doBazProtected() never assigns null to &$p so it can be removed from the @param-out type.
+Method TooWideMethodParameterOut\Foo::doLorem() never assigns null to &$p so it can be removed from the by-ref type.
+Method TooWideMethodParameterOut\Foo::finalDoBaz() never assigns null to &$p so it can be removed from the @param-out type.
+Method TooWideMethodReturnType\Bar::bar() never returns string so it can be removed from the return type.
+Method TooWideMethodReturnType\Bar::baz() never returns null so it can be removed from the return type.
+Method TooWideMethodReturnType\BarClass::doFoo() never returns null so it can be removed from the return type.
+Method TooWideMethodReturnType\Baz::baz() never returns null so it can be removed from the return type.
+Method TooWideMethodReturnType\Bazz::lorem() never returns string so it can be removed from the return type.
+Method TooWideMethodReturnType\ConditionalTypeClass::conditionalType() never returns string so it can be removed from the return type.
+Method TooWideMethodReturnType\Foo::bar() never returns string so it can be removed from the return type.
+Method TooWideMethodReturnType\Foo::baz() never returns null so it can be removed from the return type.
+Method TooWideMethodReturnType\Foo::dolor() never returns null so it can be removed from the return type.
+Method TooWideMethodReturnType\Foo::dolor2() never returns null so it can be removed from the return type.
+Method TooWideMethodReturnType\Foo::dolor4() never returns int so it can be removed from the return type.
+Method TooWideMethodReturnType\Foo::dolor6() never returns null so it can be removed from the return type.
+Method TooWideThrowTypeAlwaysCheckFinal\Baz::doBar() has RuntimeException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowTypeAlwaysCheckFinal\Baz::doFoo() has RuntimeException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowTypeAlwaysCheckFinal\Foo::doFoo() has RuntimeException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsExplicit\Foo::doFoo() has Exception in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\ChildClass::doFoo() has LogicException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\Foo::doFoo3() has InvalidArgumentException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\Foo::doFoo4() has DomainException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\Foo::doFoo7() has DomainException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\Foo::doFoo8() has DomainException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\Foo::doFoo9() has DomainException in PHPDoc @throws tag but it's not thrown.
+Method TooWideThrowsMethod\ImmediatelyCalledCallback::doFoo2() has InvalidArgumentException in PHPDoc @throws tag but it's not thrown.
+Method UnusedPrivateMethodEnunm\Foo::doBaz() is unused.
+Method UnusedPrivateMethod\Bar::doBaz() is unused.
+Method UnusedPrivateMethod\Foo::doBar() is unused.
+Method UnusedPrivateMethod\Foo::doFoo() is unused.
+Method UnusedPrivateMethod\IgnoredByExtension::bar() is unused.
+Method UnusedPrivateMethod\Lorem::doBaz() is unused.
+Method VisibilityInInterface\FooInterface::sayPrivate() cannot use non-public visibility in interface.
+Method VisibilityInInterface\FooInterface::sayProtected() cannot use non-public visibility in interface.
+Method WrongListTip\Test2::doFoo() should return non-empty-array<WrongListTip\Foo> but returns non-empty-array<WrongListTip\Bar>.
+Method WrongListTip\Test3::doFoo() should return non-empty-list<WrongListTip\Foo> but returns array<WrongListTip\Bar>.
+Method WrongListTip\Test::doFoo() should return list<WrongListTip\Foo> but returns list<WrongListTip\Bar>.
+Method class@anonymous/tests/PHPStan/Rules/Methods/data/bug-11559c.php:6:1::regular_fn() invoked with 3 parameters, 1 required.
+Method mysqli::query() invoked with 0 parameters, 1-2 required.
+Missing parameter $ (int) in call to callable callable(int, int): void.
+Missing parameter $a (int) in call to method NamedArgumentsMethod\Foo::doIpsum().
+Missing parameter $b (int) in call to method NamedArgumentsMethod\Foo::doIpsum().
+Missing parameter $bar (string) in call to method Bug4800\HelloWorld2::a().
+Missing parameter $end (int|TEnd of DateTimeInterface) in call to DatePeriod constructor.
+Missing parameter $i (int) in call to callable passed to call_user_func().
+Missing parameter $i (int) in call to callable passed to call_user_func_array().
+Missing parameter $j (int) in call to InstantiationNamedArguments\Foo constructor.
+Missing parameter $j (int) in call to callable callable(int, int): void.
+Missing parameter $j (int) in call to closure.
+Missing parameter $j (int) in call to function FunctionNamedArguments\foo.
+Missing parameter $j (int) in call to method NamedArgumentsMethod\Foo::doFoo().
+Missing parameter $j (int) in call to static method StaticMethodNamedArguments\Foo::doFoo().
+Missing parameter $k (int) in call to method NamedArgumentsMethod\Foo::doFoo().
+Missing parameter $name (array) in call to method XSLTProcessor::setParameter().
+Missing parameter $separator (string) in call to function implode.
+Missing parameter $separator (string) in call to function join.
+Missing parameter $start (string) in call to DatePeriod constructor.
+Missing parameter $string1 (string) in call to function levenshtein.
+Missing parameter $string2 (string) in call to function levenshtein.
+Multiple PHPDoc @var tags above single variable assignment are not supported.
+Named argument bar for variadic parameter ...$args of method NamedArgumentsMethod\Foo::doIpsum() expects string, int given.
+Named argument cannot be followed by a positional argument.
+Named argument cannot be followed by an unpacked (...) argument.
+Named argument foo for variadic parameter ...$args of method NamedArgumentsMethod\Foo::doIpsum() expects string, int given.
+Named arguments are supported only on PHP 8.0 and later.
+Named parameter $var overwrites previous argument.
+Native type int|string of constant OverridingConstantNativeTypes\Bar::D is not covariant with native type int of constant OverridingConstantNativeTypes\Foo::D.
+Native type int|string of constant OverridingConstantNativeTypes\PharChild::NONE is not covariant with native type int of constant Phar::NONE.
+Negated boolean expression is always false.
+Negated boolean expression is always true.
+Node attribute 'parent' is no longer available.
+Non-abstract class AbstractMethod\Bar contains abstract method doBar().
+Non-abstract class MissingMagicSerializationMethods\myObj implements the Serializable interface, but does not implement __serialize().
+Non-abstract class MissingMagicSerializationMethods\myObj implements the Serializable interface, but does not implement __unserialize().
+Non-abstract class MissingMethodImpl\Baz contains abstract method doBaz() from class MissingMethodImpl\Baz.
+Non-abstract class MissingMethodImpl\Baz contains abstract method doFoo() from interface MissingMethodImpl\Foo.
+Non-abstract class MissingMethodImpl\Foo@anonymous/tests/PHPStan/Rules/Methods/data/missing-method-impl.php:41 contains abstract method doFoo() from interface MissingMethodImpl\Foo.
+Non-abstract method Bug4244\HelloWorld::sayHello() must contain a body.
+Non-abstract method MethodInEnumWithoutBody\Foo::doFoo() must contain a body.
+Non-final constant ConflictingTraitConstants\Bar7::PUBLIC_FINAL_CONSTANT overriding final constant ConflictingTraitConstants\Foo::PUBLIC_FINAL_CONSTANT should also be final.
+Non-readonly class ExtendsReadOnlyClass\Bar extends readonly class ExtendsReadOnlyClass\ReadonlyClass.
+Non-static access to static property Bug12692\Foo::$static.
+Non-static access to static property Bug8668\Sample2::$sample.
+Non-static access to static property Bug8668\Sample::$sample.
+Non-static method OverridingFinalMethod\Bar::doIpsum() overrides static method OverridingFinalMethod\Foo::doIpsum().
+Non-static method OverridingTraitMethods\Dolor::doBar() overrides static method OverridingTraitMethods\FooStatic::doBar().
+Non-static property OverridingProperty\Bar::$protectedStaticFoo overrides static property OverridingProperty\Foo::$protectedStaticFoo.
+Non-static property OverridingProperty\Bar::$publicStaticFoo overrides static property OverridingProperty\Foo::$publicStaticFoo.
+Nullable method call detected
+Nullable property fetch detected
+Nullsafe cannot be returned by reference.
+Nullsafe operator cannot be on left side of assignment.
+Nullsafe operator cannot be on right side of assignment by reference.
+Offset '0' does not exist on array<string, string>.
+Offset 'a' does not exist on array{b: 1}.
+Offset 'b' does not exist on array<'a', string>.
+Offset 'b' does not exist on array{a: 'blabla'}.
+Offset 'b' does not exist on array{a: 1}.
+Offset 'b' does not exist on array{a: stdClass, 0: 2}.
+Offset 'b' on array{} in isset() does not exist.
+Offset 'b' on array{} on left side of ?? does not exist.
+Offset 'b' on array{} on left side of ??= does not exist.
+Offset 'bar' might not exist on non-empty-array{foo?: string, bar?: string, 1?: 1, 2?: 2, 3?: 3, 4?: 4, 5?: 5, 6?: 6, ...}.
+Offset 'bar' might not exist on non-empty-array{foo?: string, bar?: string}.
+Offset 'bar' on array{bar: 1} in isset() always exists and is not nullable.
+Offset 'baz' might not exist on array{bar: 1, baz?: 2}.
+Offset 'c' might not exist on array{c: false}|array{c: true}|array{e: true}.
+Offset 'dim' on array{dim: 1, dim-null: 1|null, dim-null-offset: array{a: true|null}, dim-empty: array{}} in isset() always exists and is not nullable.
+Offset 'dim' on array{dim: 1, dim-null: 1|null, dim-null-offset: array{a: true|null}, dim-empty: array{}} on left side of ?? always exists and is not nullable.
+Offset 'dim' on array{dim: 1, dim-null: 1|null, dim-null-offset: array{a: true|null}, dim-empty: array{}} on left side of ??= always exists and is not nullable.
+Offset 'dim-null-not-set' on array{dim: 1, dim-null: 0|1, dim-null-offset: array{a: true|null}, dim-empty: array{}} on left side of ??= does not exist.
+Offset 'dim-null-not-set' on array{dim: 1, dim-null: 1|null, dim-null-offset: array{a: true|null}, dim-empty: array{}} in isset() does not exist.
+Offset 'dim-null-not-set' on array{dim: 1, dim-null: 1|null, dim-null-offset: array{a: true|null}, dim-empty: array{}} on left side of ?? does not exist.
+Offset 'feature_pretty_version' might not exist on array{version: non-falsy-string, commit: string|null, pretty_version: string|null, feature_version: non-falsy-string, feature_pretty_version?: string|null}.
+Offset 'foo' does not exist on 'Foo'.
+Offset 'foo' does not exist on 'foo'.
+Offset 'foo' does not exist on ArrayAccess<int, stdClass>.
+Offset 'foo' does not exist on array{}.
+Offset 'foo' might not exist on array.
+Offset 'foo' might not exist on array|string.
+Offset 'foo' might not exist on non-empty-array{foo?: string, bar?: string, 1?: 1, 2?: 2, 3?: 3, 4?: 4, 5?: 5, 6?: 6, ...}.
+Offset 'foo' might not exist on non-empty-array{foo?: string, bar?: string}.
+Offset 'foo' on array{foo: string} in isset() always exists and is not nullable.
+Offset 'invalid' does not exist on array{a: array{b: array{5}}}.
+Offset 'invalid' does not exist on array{b: array{5}}.
+Offset 'nonexistent' on array{2: bool, 3: false, 4: true}|array{bool, false, bool, false, true} in empty() does not exist.
+Offset 'one'|'two' might not exist on array{two: 1, three: 2}.
+Offset 'require'|'require-dev' might not exist on array{require?: array<string, string>, require-dev?: array<string, string>}.
+Offset 'require'|'require-dev' might not exist on non-empty-array{require?: array<string, string>, require-dev?: array<string, string>}.
+Offset 'something' does not exist on array{categoryKeys: array<string>, tagNames: array<string>}.
+Offset 'string' on array{1, 2, 3} in isset() does not exist.
+Offset 'string' on array{1, 2, 3} on left side of ?? does not exist.
+Offset 'string' on array{1, 2, 3} on left side of ??= does not exist.
+Offset 'string' on array{array{1}, array{2}, array{3}} in isset() does not exist.
+Offset 'string' on array{array{1}, array{2}, array{3}} on left side of ?? does not exist.
+Offset 'string' on array{array{1}, array{2}, array{3}} on left side of ??= does not exist.
+Offset 'test' does not exist on null.
+Offset 'unique' on array{unique: bool} in isset() always exists and is not nullable.
+Offset 'unique' on array{unique: bool} on left side of ?? always exists and is not nullable.
+Offset 'x' might not exist on array<mixed>|string.
+Offset (int|string) might not exist on non-empty-list<string>.
+Offset -1|3|6|10 might not exist on list<int>.
+Offset -5|int<0, max> might not exist on list<int>.
+Offset 0 does not exist on array<string, string>.
+Offset 0 does not exist on array{}.
+Offset 0 on array{'', '0', 'foo', ''|'foo'} in empty() always exists and is always falsy.
+Offset 0 on non-empty-list<array<string|null>> on left side of ?? always exists and is not nullable.
+Offset 0|array<int> might not exist on array<int>.
+Offset 1 does not exist on array{a: int}.
+Offset 1 does not exist on array{a: stdClass, 0: 2}.
+Offset 1 might not exist on list<int>.
+Offset 1 on array{'', '0', 'foo', ''|'foo'} in empty() always exists and is always falsy.
+Offset 10 might not exist on non-empty-list<int>.
+Offset 12.34 does not exist on 'foo'.
+Offset 12.34 might not exist on array|string.
+Offset 1|int<3, max> does not exist on array{}.
+Offset 2 does not exist on array{1, 2}.
+Offset 2 on array{'', '0', 'foo', ''|'foo'} in empty() always exists and is not falsy.
+Offset 2 on array{0: string, 1: string, 2: string, 3: string, 4?: string} in isset() always exists and is not nullable.
+Offset 2|4 might not exist on array{array{0}, array{1}, array{2}}.
+Offset 3 does not exist on array{non-falsy-string, 'x', array{non-falsy-string, 'x'}}.
+Offset 3 on array{2: bool, 3: false, 4: true}|array{bool, false, bool, false, true} in empty() always exists and is always falsy.
+Offset 3 on array{string, string, string, string, string} in isset() always exists and is not nullable.
+Offset 4 on array{2: bool, 3: false, 4: true}|array{bool, false, bool, false, true} in empty() always exists and is not falsy.
+Offset array<int, int|string>|int|string might not exist on non-empty-array<bool|float|int|string>.
+Offset array<int>|int might not exist on array<int>.
+Offset array<int>|int might not exist on array<int>|string.
+Offset array<int>|int might not exist on array{string}.
+Offset array<int>|string might not exist on array<int>.
+Offset array<int>|string might not exist on array{string}.
+Offset int does not exist on array<string, string>.
+Offset int might not exist on array.
+Offset int might not exist on array<int>.
+Offset int might not exist on array{string}.
+Offset int might not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.
+Offset int might not exist on list<int>.
+Offset int might not exist on non-empty-array<int, ''>.
+Offset int on non-empty-array<int, int> on left side of ?? always exists and is not nullable.
+Offset int<-1, max> might not exist on array<string>.
+Offset int<-1, max> might not exist on non-empty-list<string>.
+Offset int<0, 4> might not exist on array{1, 2, 3, 4}.
+Offset int<0, max> might not exist on array.
+Offset int<0, max> might not exist on list<int>.
+Offset int<0, max> might not exist on list<mixed>.
+Offset int<0, max> might not exist on list<string>.
+Offset int<0, max> might not exist on non-empty-array<int, string>.
+Offset int<0, max> might not exist on non-empty-array<string>.
+Offset int<0, max>|null might not exist on list<string>.
+Offset int<1, max> might not exist on non-empty-list<int>.
+Offset int<2, max> might not exist on non-empty-array<int<0, max>, string>.
+Offset int|null might not exist on array<int, string>.
+Offset int|null might not exist on array<string, string>.
+Offset int|object does not exist on array{baz: 21}|array{foo: 17, bar: 19}.
+Offset int|object might not exist on 'foo'.
+Offset int|object might not exist on array|string.
+Offset int|string might not exist on non-empty-array.
+Offset null does not exist on array<int, string>.
+Offset null does not exist on array{}.
+Offset string might not exist on array<int>.
+Offset string might not exist on array{foo: 1}.
+Offset string might not exist on array{string}.
+Offset string on non-empty-array<PR4374\Foo> in isset() always exists and is not nullable.
+Only iterables can be unpacked, T of mixed given in argument #1.
+Only iterables can be unpacked, T of mixed given.
+Only iterables can be unpacked, array<int>|null given in argument #5.
+Only iterables can be unpacked, array<int>|null given.
+Only iterables can be unpacked, int given in argument #6.
+Only iterables can be unpacked, int given.
+Only iterables can be unpacked, mixed given in argument #1.
+Only iterables can be unpacked, mixed given.
+Only iterables can be unpacked, string given in argument #7.
+Only iterables can be unpacked, string given.
+Only the last parameter can be variadic.
+Original constructor of trait ConstructorReturnType\BarTrait has a return type.
+PHPDoc tag @extends has invalid type ClassAncestorsExtends\FooTrait.
+PHPDoc tag @extends has invalid type ClassAncestorsExtends\Zazzuuuu.
+PHPDoc tag @extends has invalid type InterfaceAncestorsExtends\Zazzuuuu.
+PHPDoc tag @implements contains generic type EnumGenericAncestors\NonGeneric<int> but interface EnumGenericAncestors\NonGeneric is not generic.
+PHPDoc tag @implements has invalid type ClassAncestorsImplements\Zazzuuuu.
+PHPDoc tag @method for method MethodTagTraitEnum\Foo::doFoo() return type contains unknown class MethodTagTraitEnum\intt.
+PHPDoc tag @method for method MethodTagTrait\Foo::doBar() parameter #1 $a contains unresolvable type.
+PHPDoc tag @method for method MethodTagTrait\Foo::doBaz2() parameter #1 $a default value contains unresolvable type.
+PHPDoc tag @method for method MethodTagTrait\Foo::doFoo() return type contains unknown class MethodTagTrait\intt.
+PHPDoc tag @method for method MethodTag\Foo::doBar() parameter #1 $a contains unresolvable type.
+PHPDoc tag @method for method MethodTag\Foo::doBaz2() parameter #1 $a default value contains unresolvable type.
+PHPDoc tag @method for method MethodTag\Foo::doFoo() return type contains unknown class MethodTag\intt.
+PHPDoc tag @method for method MethodTag\MissingGenerics::doA() return type contains generic class MethodTag\Generic but does not specify its types: T, U
+PHPDoc tag @method for method MethodTag\NonexistentClasses::doA() return type contains unknown class MethodTag\Nonexistent.
+PHPDoc tag @method for method MethodTag\NonexistentClasses::doB() return type contains invalid type PropertyTagTrait\Foo.
+PHPDoc tag @method for method MethodTag\TestGenerics::doA() return type contains generic type Exception<int> but class Exception is not generic.
+PHPDoc tag @method template T for method MethodTagTemplate\HelloWorld::sayHello() shadows @template T for class MethodTagTemplate\HelloWorld.
+PHPDoc tag @method template T for method MethodTagTraitTemplate\HelloWorld::sayHello() shadows @template T for class MethodTagTraitTemplate\HelloWorld.
+PHPDoc tag @method template U for method MethodTagTemplate\HelloWorld::sayHello() has invalid bound type MethodTagTemplate\Nonexisting.
+PHPDoc tag @method template U for method MethodTagTraitTemplate\HelloWorld::sayHello() has invalid bound type MethodTagTraitTemplate\Nonexisting.
+PHPDoc tag @method template for method MethodTagTemplate\HelloWorld::sayHello() cannot have existing class stdClass as its name.
+PHPDoc tag @method template for method MethodTagTemplate\HelloWorld::typeAlias() cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @method template for method MethodTagTraitTemplate\HelloWorld::sayHello() cannot have existing class stdClass as its name.
+PHPDoc tag @method template for method MethodTagTraitTemplate\HelloWorld::typeAlias() cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @mixin contains generic class ReflectionClass but does not specify its types: T
+PHPDoc tag @mixin contains generic interface Iterator but does not specify its types: TKey, TValue
+PHPDoc tag @mixin contains generic type Exception<MixinRule\Foo> but class Exception is not generic.
+PHPDoc tag @mixin contains invalid type MixinRule\FooTrait.
+PHPDoc tag @mixin contains non-object type int.
+PHPDoc tag @mixin contains unknown class MixinRule\U.
+PHPDoc tag @mixin contains unknown class MixinRule\UnknownestClass.
+PHPDoc tag @mixin contains unresolvable type.
+PHPDoc tag @param for parameter $a with type T is not subtype of native type int.
+PHPDoc tag @param for parameter $arr contains unresolvable type.
+PHPDoc tag @param for parameter $b with type U of DateTimeInterface is not subtype of native type DateTime.
+PHPDoc tag @param for parameter $b with type array is incompatible with native type string.
+PHPDoc tag @param for parameter $cb contains unresolvable type.
+PHPDoc tag @param for parameter $cl contains unresolvable type.
+PHPDoc tag @param for parameter $d with type float|int is not subtype of native type int.
+PHPDoc tag @param for parameter $e contains generic type GenericEnumParam\FooEnum<int> but enum GenericEnumParam\FooEnum is not generic.
+PHPDoc tag @param for parameter $existingClass template of Closure<stdClass of mixed>(stdClass): stdClass cannot have existing class stdClass as its name.
+PHPDoc tag @param for parameter $existingTypeAlias template of Closure<TypeAlias of mixed>(TypeAlias): TypeAlias cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @param for parameter $foo contains generic type InvalidPhpDocDefinitions\Foo<stdClass> but class InvalidPhpDocDefinitions\Foo is not generic.
+PHPDoc tag @param for parameter $foo contains unresolvable type.
+PHPDoc tag @param for parameter $i with type TFoo is not subtype of native type int.
+PHPDoc tag @param for parameter $invalidBoundType template T of Closure<T of GenericCallablesIncompatible\Invalid>(T): T has invalid bound type GenericCallablesIncompatible\Invalid.
+PHPDoc tag @param for parameter $numbers with type string is incompatible with native type int.
+PHPDoc tag @param for parameter $shadows template T of Closure<T of mixed, U of mixed>(T): T shadows @template T for method GenericCallablesIncompatible\Test::testShadowMethod.
+PHPDoc tag @param for parameter $shadows template T of Closure<T of mixed>(T): T shadows @template T for class GenericCallablesIncompatible\Test3.
+PHPDoc tag @param for parameter $shadows template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\testShadowFunction.
+PHPDoc tag @param for parameter $shadows template U of Closure<T of mixed, U of mixed>(T): T shadows @template U for class GenericCallablesIncompatible\Test.
+PHPDoc tag @param for parameter $shouldError with type int is incompatible with native type string.
+PHPDoc tag @param for parameter $shouldError with type string is incompatible with native type int.
+PHPDoc tag @param for parameter $strings with type array<int> is incompatible with native type string.
+PHPDoc tag @param for parameter $value with type array{a: string, b: bool, c: int, d: float}[TKey] is not subtype of native type bool|int|string.
+PHPDoc tag @param has invalid value ((A & B $paramNameB): Unexpected token "$paramNameB", expected ')' at offset 105 on line 6
+PHPDoc tag @param has invalid value (): Unexpected token "\n * ", expected type at offset 13 on line 2
+PHPDoc tag @param has invalid value (A & B | C $paramNameA): Unexpected token "|", expected variable at offset 72 on line 5
+PHPDoc tag @param has invalid value (~A & B $paramNameC): Unexpected token "~A", expected type at offset 127 on line 7
+PHPDoc tag @param references unknown parameter: $arrX
+PHPDoc tag @param references unknown parameter: $unknown
+PHPDoc tag @param-closure-this for parameter $i contains generic type Exception<int, float> but class Exception is not generic.
+PHPDoc tag @param-closure-this for parameter $i contains unresolvable type.
+PHPDoc tag @param-closure-this is for parameter $i with non-Closure type string.
+PHPDoc tag @param-closure-this references unknown parameter: $b
+PHPDoc tag @param-immediately-invoked-callable is for parameter $b with non-callable type int.
+PHPDoc tag @param-immediately-invoked-callable references unknown parameter: $b
+PHPDoc tag @param-later-invoked-callable is for parameter $b with non-callable type int.
+PHPDoc tag @param-later-invoked-callable references unknown parameter: $c
+PHPDoc tag @param-out for parameter $existingClass template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\shadowsParamOut.
+PHPDoc tag @param-out for parameter $existingClass template of Closure<stdClass of mixed>(stdClass): stdClass cannot have existing class stdClass as its name.
+PHPDoc tag @param-out for parameter $existingClasses template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\shadowsParamOutArray.
+PHPDoc tag @param-out for parameter $i contains generic type Exception<int, float> but class Exception is not generic.
+PHPDoc tag @param-out references unknown parameter: $z
+PHPDoc tag @param-out type array<array{int, bool}> of function NestedTooWideFunctionParameterOutType\doFoo() can be narrowed to array<array{int, false}>.
+PHPDoc tag @param-out type array<array{int, bool}> of method NestedTooWideMethodParameterOutType\Foo::doFoo() can be narrowed to array<array{int, false}>.
+PHPDoc tag @phpstan-assert for $a contains unknown class MethodAssert\Nonexistent.
+PHPDoc tag @phpstan-assert for $array has no value type specified in iterable type list.
+PHPDoc tag @phpstan-assert for $b contains invalid type MethodAssert\FooTrait.
+PHPDoc tag @phpstan-assert for $m contains generic class MethodAssert\FooBar but does not specify its types: T, TT
+PHPDoc tag @phpstan-assert for $m contains generic type Exception<int, float> but class Exception is not generic.
+PHPDoc tag @phpstan-assert for $m has no signature specified for callable.
+PHPDoc tag @phpstan-assert for $m has no value type specified in iterable type array.
+PHPDoc tag @phpstan-assert for $this->fooProp contains unresolvable type.
+PHPDoc tag @phpstan-assert-if-true for $a contains unresolvable type.
+PHPDoc tag @phpstan-require-extends can only be used once.
+PHPDoc tag @phpstan-require-extends cannot contain an interface IncompatibleRequireExtends\SomeInterface, expected a class.
+PHPDoc tag @phpstan-require-extends cannot contain an interface IncompatibleRequireExtends\UnresolvableExtendsInterface, expected a class.
+PHPDoc tag @phpstan-require-extends cannot contain final class IncompatibleRequireExtends\SomeFinalClass.
+PHPDoc tag @phpstan-require-extends cannot contain non-class type IncompatibleRequireExtends\SomeEnum.
+PHPDoc tag @phpstan-require-extends cannot contain non-class type IncompatibleRequireExtends\SomeTrait.
+PHPDoc tag @phpstan-require-extends contains non-object type *NEVER*.
+PHPDoc tag @phpstan-require-extends contains non-object type int.
+PHPDoc tag @phpstan-require-extends contains unknown class IncompatibleRequireExtends\NonExistentClass.
+PHPDoc tag @phpstan-require-extends contains unknown class IncompatibleRequireExtends\TypeDoesNotExist.
+PHPDoc tag @phpstan-require-extends is only valid on trait or interface.
+PHPDoc tag @phpstan-require-implements cannot contain non-interface type IncompatibleRequireImplements\SomeClass.
+PHPDoc tag @phpstan-require-implements cannot contain non-interface type IncompatibleRequireImplements\SomeEnum.
+PHPDoc tag @phpstan-require-implements cannot contain non-interface type IncompatibleRequireImplements\SomeTrait.
+PHPDoc tag @phpstan-require-implements contains non-object type *NEVER*.
+PHPDoc tag @phpstan-require-implements contains non-object type int.
+PHPDoc tag @phpstan-require-implements contains unknown class IncompatibleRequireImplements\TypeDoesNotExist.
+PHPDoc tag @phpstan-require-implements is only valid on trait.
+PHPDoc tag @phpstan-return has invalid value (array{'numeric': stdClass[], 'branches': array{'names': string[], 'exclude': bool}}}|int): Unexpected token "}", expected TOKEN_HORIZONTAL_WS at offset 107 on line 2
+PHPDoc tag @phpstan-sealed contains unknown class IncompatibleSealed\UnknownClass.
+PHPDoc tag @phpstan-sealed is only valid on class or interface.
+PHPDoc tag @phpstan-self-out contains generic type IncompatibleSelfOutType\GenericCheck<int> but class IncompatibleSelfOutType\GenericCheck is not generic.
+PHPDoc tag @phpstan-self-out for method IncompatibleSelfOutType\Foo::doBar() contains unresolvable type.
+PHPDoc tag @phpstan-self-out for method IncompatibleSelfOutType\Foo::doFoo() contains unresolvable type.
+PHPDoc tag @phpstan-self-out is not supported above static method IncompatibleSelfOutType\Foo::selfOutStatic().
+PHPDoc tag @phpstan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 65 on line 3
+PHPDoc tag @property for property PropertyTagTrait\Foo::$foo contains unknown class PropertyTagTrait\intt.
+PHPDoc tag @property for property PropertyTag\Bar::$unresolvable contains unresolvable type.
+PHPDoc tag @property for property PropertyTag\Foo::$a contains unknown class PropertyTag\intt.
+PHPDoc tag @property for property PropertyTag\Foo::$b contains unknown class PropertyTag\intt.
+PHPDoc tag @property for property PropertyTag\Foo::$c contains unknown class PropertyTag\intt.
+PHPDoc tag @property for property PropertyTag\Foo::$c contains unknown class PropertyTag\stringg.
+PHPDoc tag @property for property PropertyTag\Foo::$d contains unknown class PropertyTag\intt.
+PHPDoc tag @property for property PropertyTag\Foo::$e contains unknown class PropertyTag\intt.
+PHPDoc tag @property for property PropertyTag\Foo::$e contains unknown class PropertyTag\stringg.
+PHPDoc tag @property for property PropertyTag\MissingGenerics::$a contains generic class PropertyTag\Generic but does not specify its types: T, U
+PHPDoc tag @property for property PropertyTag\NonexistentClasses::$a contains unknown class PropertyTag\Nonexistent.
+PHPDoc tag @property for property PropertyTag\NonexistentClasses::$b contains invalid type PropertyTagTrait\Foo.
+PHPDoc tag @property for property PropertyTag\TestGenerics::$a contains generic type Exception<int> but class Exception is not generic.
+PHPDoc tag @property-read for property PropertyTag\Foo::$f contains unknown class PropertyTag\intt.
+PHPDoc tag @property-write for property PropertyTag\Foo::$g contains unknown class PropertyTag\stringg.
+PHPDoc tag @return contains generic type InvalidPhpDocDefinitions\Foo<int, Exception> but class InvalidPhpDocDefinitions\Foo is not generic.
+PHPDoc tag @return contains generic type InvalidPhpDocDefinitions\Foo<stdClass> but class InvalidPhpDocDefinitions\Foo is not generic.
+PHPDoc tag @return contains unresolvable type.
+PHPDoc tag @return has invalid value ($this<string>): Unexpected token "<", expected TOKEN_HORIZONTAL_WS at offset 21 on line 2
+PHPDoc tag @return has invalid value (): Unexpected token "\n * ", expected type at offset 208 on line 13
+PHPDoc tag @return has invalid value (A & B | C): Unexpected token "|", expected TOKEN_OTHER at offset 251 on line 15
+PHPDoc tag @return has invalid value ([int, string]): Unexpected token "[", expected type at offset 220 on line 14
+PHPDoc tag @return template T of Closure<T of GenericCallablesIncompatible\Invalid>(T): T has invalid bound type GenericCallablesIncompatible\Invalid.
+PHPDoc tag @return template T of Closure<T of mixed, U of mixed>(T): T shadows @template T for method GenericCallablesIncompatible\Test::testShadowMethodReturn.
+PHPDoc tag @return template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\shadowsReturnArray.
+PHPDoc tag @return template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\testShadowFunctionReturn.
+PHPDoc tag @return template U of Closure<T of mixed, U of mixed>(T): T shadows @template U for class GenericCallablesIncompatible\Test.
+PHPDoc tag @return template of Closure<TypeAlias of mixed>(TypeAlias): TypeAlias cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @return template of Closure<stdClass of mixed>(stdClass): stdClass cannot have existing class stdClass as its name.
+PHPDoc tag @return with type ($p is int ? int : string) is not subtype of native type int.
+PHPDoc tag @return with type T is not subtype of native type object.
+PHPDoc tag @return with type U of DateTimeInterface is not subtype of native type DateTime.
+PHPDoc tag @return with type array{a: string, b: bool, c: int, d: float}[TKey] is not subtype of native type bool|int|string.
+PHPDoc tag @return with type int|string is not subtype of native type int.
+PHPDoc tag @return with type string is incompatible with native type int.
+PHPDoc tag @template T for anonymous class has invalid bound type ClassTemplateType\Zazzzu.
+PHPDoc tag @template T for class ClassTemplateType\Bar has invalid bound type ClassTemplateType\Zazzzu.
+PHPDoc tag @template T for class ClassTemplateType\Elit has invalid default type ClassTemplateType\Zazzzu.
+PHPDoc tag @template T for function FunctionTemplateType\bar() has invalid bound type FunctionTemplateType\Zazzzu.
+PHPDoc tag @template T for function FunctionTemplateType\invalidDefault() has invalid default type FunctionTemplateType\Zazzzu.
+PHPDoc tag @template T for function FunctionTemplateType\resourceBound() with bound type resource is not supported.
+PHPDoc tag @template T for interface InterfaceTemplateType\Bar has invalid bound type InterfaceTemplateType\Zazzzu.
+PHPDoc tag @template T for interface InterfaceTemplateType\InvalidDefault has invalid default type InterfaceTemplateType\Zazzzu.
+PHPDoc tag @template T for method MethodTemplateType\Bar::doFoo() shadows @template T of Exception for class MethodTemplateType\Bar.
+PHPDoc tag @template T for method MethodTemplateType\Foo::doBar() has invalid bound type MethodTemplateType\Zazzzu.
+PHPDoc tag @template T for method MethodTemplateType\InvalidDefault::invalid() has invalid default type MethodTemplateType\Zazzzu.
+PHPDoc tag @template T for trait TraitTemplateType\Adipiscing has invalid default type TraitTemplateType\Zazzzu.
+PHPDoc tag @template T for trait TraitTemplateType\Bar has invalid bound type TraitTemplateType\Zazzzu.
+PHPDoc tag @template U bound contains generic type NestedGenericTypesClassCheck\NotGeneric<mixed> but interface NestedGenericTypesClassCheck\NotGeneric is not generic.
+PHPDoc tag @template V bound has type NestedGenericTypesClassCheck\MultipleGenerics<stdClass> which does not specify all template types of interface NestedGenericTypesClassCheck\MultipleGenerics: T, U
+PHPDoc tag @template V for class ClassTemplateType\Mauris does not have a default type but follows an optional @template U.
+PHPDoc tag @template V for function FunctionTemplateType\requiredAfterOptional() does not have a default type but follows an optional @template U.
+PHPDoc tag @template V for interface InterfaceTemplateType\RequiredAfterOptional does not have a default type but follows an optional @template U.
+PHPDoc tag @template V for method MethodTemplateType\InvalidDefault::requiredAfterOptional() does not have a default type but follows an optional @template U.
+PHPDoc tag @template V for trait TraitTemplateType\Consecteur does not have a default type but follows an optional @template U.
+PHPDoc tag @template W bound has type NestedGenericTypesClassCheck\MultipleGenerics<stdClass, Exception, SplFileInfo> which specifies 3 template types, but interface NestedGenericTypesClassCheck\MultipleGenerics supports only 2: T, U
+PHPDoc tag @template for anonymous class cannot have existing class stdClass as its name.
+PHPDoc tag @template for anonymous class cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @template for class Bug10049\SimpleEntity cannot have existing class Bug10049\SimpleEntity as its name.
+PHPDoc tag @template for class ClassTemplateType\Dolor cannot have existing type alias ImportedAlias as its name.
+PHPDoc tag @template for class ClassTemplateType\Dolor cannot have existing type alias LocalAlias as its name.
+PHPDoc tag @template for class ClassTemplateType\Foo cannot have existing class stdClass as its name.
+PHPDoc tag @template for class ClassTemplateType\Ipsum cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @template for function FunctionTemplateType\foo() cannot have existing class stdClass as its name.
+PHPDoc tag @template for function FunctionTemplateType\lorem() cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @template for interface InterfaceTemplateType\Foo cannot have existing class stdClass as its name.
+PHPDoc tag @template for interface InterfaceTemplateType\Ipsum cannot have existing type alias ImportedAlias as its name.
+PHPDoc tag @template for interface InterfaceTemplateType\Ipsum cannot have existing type alias LocalAlias as its name.
+PHPDoc tag @template for interface InterfaceTemplateType\Lorem cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @template for method MethodTemplateType\Foo::doFoo() cannot have existing class stdClass as its name.
+PHPDoc tag @template for method MethodTemplateType\Ipsum::doFoo() cannot have existing type alias ImportedAlias as its name.
+PHPDoc tag @template for method MethodTemplateType\Ipsum::doFoo() cannot have existing type alias LocalAlias as its name.
+PHPDoc tag @template for method MethodTemplateType\Lorem::doFoo() cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @template for trait TraitTemplateType\Foo cannot have existing class stdClass as its name.
+PHPDoc tag @template for trait TraitTemplateType\Ipsum cannot have existing type alias ImportedAlias as its name.
+PHPDoc tag @template for trait TraitTemplateType\Ipsum cannot have existing type alias LocalAlias as its name.
+PHPDoc tag @template for trait TraitTemplateType\Lorem cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @throws has invalid value ((\Exception): Unexpected token "*/", expected ')' at offset 24 on line 1
+PHPDoc tag @throws type RuntimeException of method MethodThrowTypeCovariance\Baz::logicException() should be covariant with PHPDoc @throws type LogicException of method MethodThrowTypeCovariance\Foo::logicException().
+PHPDoc tag @throws with type DateTimeImmutable is not subtype of Throwable
+PHPDoc tag @throws with type DateTimeImmutable&IteratorAggregate is not subtype of Throwable
+PHPDoc tag @throws with type DateTimeImmutable|Throwable is not subtype of Throwable
+PHPDoc tag @throws with type DateTimeInterface|ThrowsWithRequire\RequiresExtendsExceptionInterface is not subtype of Throwable
+PHPDoc tag @throws with type Exception|ThrowsWithRequire\RequiresExtendsStdClassInterface is not subtype of Throwable
+PHPDoc tag @throws with type InvalidThrowsPhpDocMergeInherited\A is not subtype of Throwable
+PHPDoc tag @throws with type InvalidThrowsPhpDocMergeInherited\B is not subtype of Throwable
+PHPDoc tag @throws with type InvalidThrowsPhpDocMergeInherited\C|InvalidThrowsPhpDocMergeInherited\D is not subtype of Throwable
+PHPDoc tag @throws with type Iterator&ThrowsWithRequire\RequiresExtendsStdClassInterface is not subtype of Throwable
+PHPDoc tag @throws with type Throwable|void is not subtype of Throwable
+PHPDoc tag @throws with type ThrowsWithRequire\RequiresExtendsStdClassInterface is not subtype of Throwable
+PHPDoc tag @throws with type Undefined is not subtype of Throwable
+PHPDoc tag @throws with type bool is not subtype of Throwable
+PHPDoc tag @throws with type stdClass is not subtype of Throwable
+PHPDoc tag @throws with type stdClass|void is not subtype of Throwable
+PHPDoc tag @use contains generic type UsedTraits\NongenericTrait<stdClass> but trait UsedTraits\NongenericTrait is not generic.
+PHPDoc tag @var above a class has no effect.
+PHPDoc tag @var above a function has no effect.
+PHPDoc tag @var above a method has no effect.
+PHPDoc tag @var above an enum has no effect.
+PHPDoc tag @var above assignment does not specify variable name.
+PHPDoc tag @var above foreach loop does not specify variable name.
+PHPDoc tag @var above multiple global variables does not specify variable name.
+PHPDoc tag @var above multiple static variables does not specify variable name.
+PHPDoc tag @var assumes the expression with type PHPStan\Type\ObjectType|null is always PHPStan\Type\ObjectType but it's error-prone and dangerous.
+PHPDoc tag @var assumes the expression with type PHPStan\Type\Type|null is always PHPStan\Type\ObjectType but it's error-prone and dangerous.
+PHPDoc tag @var assumes the expression with type PHPStan\Type\Type|null is always PHPStan\Type\ObjectType|null but it's error-prone and dangerous.
+PHPDoc tag @var contains unresolvable type.
+PHPDoc tag @var does not specify variable name.
+PHPDoc tag @var for constant IncompatibleClassConstantPhpDocNativeType\Foo::BAZ with type string is incompatible with native type int.
+PHPDoc tag @var for constant IncompatibleClassConstantPhpDocNativeType\Foo::LOREM with type int|string is not subtype of native type int.
+PHPDoc tag @var for constant IncompatibleClassConstantPhpDoc\Foo::DOLOR contains generic type IncompatibleClassConstantPhpDoc\Foo<int> but class IncompatibleClassConstantPhpDoc\Foo is not generic.
+PHPDoc tag @var for constant IncompatibleClassConstantPhpDoc\Foo::FOO contains unresolvable type.
+PHPDoc tag @var for constant ValueAssignedToClassConstantNativeType\Floats::BAZ with type float is incompatible with value 1.
+PHPDoc tag @var for constant ValueAssignedToClassConstant\Bar::BAZ with type string is incompatible with value 2.
+PHPDoc tag @var for constant ValueAssignedToClassConstant\Foo::BAZ with type string is incompatible with value 1.
+PHPDoc tag @var for constant ValueAssignedToClassConstant\Foo::DOLOR with type ValueAssignedToClassConstant\Foo<int> is incompatible with value 1.
+PHPDoc tag @var for property IncompatiblePhpDocPropertyNativeType\Foo::$foo with type IncompatiblePhpDocPropertyNativeType\Bar is incompatible with native type IncompatiblePhpDocPropertyNativeType\Foo.
+PHPDoc tag @var for property IncompatiblePhpDocPropertyNativeType\Foo::$selfTwo with type object is not subtype of native type IncompatiblePhpDocPropertyNativeType\Foo.
+PHPDoc tag @var for property IncompatiblePhpDocPropertyNativeType\Foo::$stringOrInt with type int|string is not subtype of native type string.
+PHPDoc tag @var for property IncompatiblePhpDocPropertyNativeType\Lorem::$string with type T is not subtype of native type string.
+PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$bar contains unresolvable type.
+PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$classStringInt contains unresolvable type.
+PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$fooGeneric contains generic type InvalidPhpDocDefinitions\Foo<stdClass> but class InvalidPhpDocDefinitions\Foo is not generic.
+PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$unknownClassConstant contains unresolvable type.
+PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$unknownClassConstant2 contains unresolvable type.
+PHPDoc tag @var for variable $foo contains unknown class InvalidVarTagType\Blabla.
+PHPDoc tag @var for variable $one contains unknown class Bug4486Namespace\ClassName1.
+PHPDoc tag @var for variable $one contains unknown class Some\Namespaced\ClassName1.
+PHPDoc tag @var for variable $staticVar contains unresolvable type.
+PHPDoc tag @var for variable $test contains generic class InvalidPhpDocDefinitions\FooGeneric but does not specify its types: T, U
+PHPDoc tag @var for variable $test contains generic class InvalidPhpDocDefinitions\FooGenericWithSomeDefaults but does not specify its types: T, U (1-2 required)
+PHPDoc tag @var for variable $test contains generic type InvalidPhpDoc\Foo<stdClass> but class InvalidPhpDoc\Foo is not generic.
+PHPDoc tag @var for variable $test contains unknown class InvalidVarTagType\aray.
+PHPDoc tag @var for variable $test contains unresolvable type.
+PHPDoc tag @var for variable $test has invalid type InvalidVarTagType\FooTrait.
+PHPDoc tag @var for variable $test has no value type specified in iterable type array.
+PHPDoc tag @var for variable $three contains unknown class Some\Namespaced\ClassName1.
+PHPDoc tag @var for variable $two contains unknown class Bug4486Namespace\ClassName1.
+PHPDoc tag @var for variable $two contains unknown class Some\Namespaced\ClassName2.
+PHPDoc tag @var for variable $value contains unresolvable type.
+PHPDoc tag @var for variable $x contains unknown class Bug9055\uncheckedNotExisting.
+PHPDoc tag @var has invalid value ($invalid Foo): Unexpected token "$invalid", expected type at offset 182 on line 11
+PHPDoc tag @var has invalid value ($invalid): Unexpected token "$invalid", expected type at offset 165 on line 10
+PHPDoc tag @var has invalid value ((Foo&): Unexpected token "*/", expected type at offset 15 on line 1
+PHPDoc tag @var has invalid value ((Foo|Bar): Unexpected token "*/", expected ')' at offset 18 on line 1
+PHPDoc tag @var has invalid value (): Unexpected token "\n * ", expected type at offset 156 on line 9
+PHPDoc tag @var has invalid value (\\Foo|\Bar $test): Unexpected token "\\\\Foo|\\Bar", expected type at offset 9 on line 1
+PHPDoc tag @var has invalid value (callable(int)): Unexpected token "(", expected TOKEN_HORIZONTAL_WS at offset 17 on line 1
+PHPDoc tag @var template T of Closure<T of mixed>(T): T shadows @template T for class GenericCallableProperties\Test.
+PHPDoc tag @var template TInvalid of callable<TInvalid of GenericCallableProperties\Invalid>(TInvalid): TInvalid has invalid bound type GenericCallableProperties\Invalid.
+PHPDoc tag @var template of Closure<stdClass of mixed>(stdClass): stdClass cannot have existing class stdClass as its name.
+PHPDoc tag @var template of callable<TypeAlias of mixed>(TypeAlias): TypeAlias cannot have existing type alias TypeAlias as its name.
+PHPDoc tag @var with type Closure(string): array<int> is not subtype of native type Closure(string): array{1, 2, 3}.
+PHPDoc tag @var with type GenericSubtype\IRepository<E of GenericSubtype\IEntity> is not subtype of type GenericSubtype\IRepository<GenericSubtype\IEntity>.
+PHPDoc tag @var with type GenericSubtype\IRepository<GenericSubtype\Foo> is not subtype of type GenericSubtype\IRepository<GenericSubtype\IEntity>.
+PHPDoc tag @var with type Iterator<mixed, int> is not subtype of native type array.
+PHPDoc tag @var with type Iterator<mixed, string> is not subtype of type Iterator<int, int>.
+PHPDoc tag @var with type PHPStan\Type\ObjectType|null is not subtype of type PHPStan\Type\Generic\GenericObjectType|null.
+PHPDoc tag @var with type PHPStan\Type\Type|null is not subtype of native type PHPStan\Type\ObjectType|null.
+PHPDoc tag @var with type array<Traversable<mixed, string>> is not subtype of type array<list<string|null>>.
+PHPDoc tag @var with type array<array<int>> is not subtype of type array<list<string|null>>.
+PHPDoc tag @var with type array<array<string>> is not subtype of type array<list<string|null>>.
+PHPDoc tag @var with type array<int> is not subtype of type array<int, int>.
+PHPDoc tag @var with type array<int> is not subtype of type array<int, string>.
+PHPDoc tag @var with type array<int> is not subtype of type list<int>.
+PHPDoc tag @var with type array<mixed> is not subtype of type array<int>.
+PHPDoc tag @var with type array<mixed> is not subtype of type array{id: int}.
+PHPDoc tag @var with type array<mixed> is not subtype of type list<array{id: int}>.
+PHPDoc tag @var with type array<mixed> is not subtype of type list<int>.
+PHPDoc tag @var with type array<mixed>|null is not subtype of type array{id: int}|null.
+PHPDoc tag @var with type array<string> is not subtype of type array<int, string>.
+PHPDoc tag @var with type array<string> is not subtype of type list<int>.
+PHPDoc tag @var with type array{numeric-string} is not subtype of type array{lowercase-string&numeric-string&uppercase-string}.
+PHPDoc tag @var with type callable(): string is not subtype of type callable(): numeric-string&lowercase-string&uppercase-string.
+PHPDoc tag @var with type int is not subtype of native type 'foo'.
+PHPDoc tag @var with type int is not subtype of native type array{}.
+PHPDoc tag @var with type int is not subtype of native type string.
+PHPDoc tag @var with type int is not subtype of native type void.
+PHPDoc tag @var with type int is not subtype of type string.
+PHPDoc tag @var with type list<string> is not subtype of native type array{-1: 'z', 0: 'a', 1: 'b', 2: 'c'}.
+PHPDoc tag @var with type list<string> is not subtype of native type array{0: 'a', -1: 'z', 1: 'b', 2: 'c'}.
+PHPDoc tag @var with type list<string> is not subtype of native type array{0: 'a', 2: 'c'}.
+PHPDoc tag @var with type list<string> is not subtype of native type array{1: 'b', 2: 'c'}.
+PHPDoc tag @var with type stdClass is not subtype of native type PHPStan\Type\Type|null.
+PHPDoc tag @var with type stdClass is not subtype of native type SplObjectStorage<object, mixed>.
+PHPDoc tag @var with type string is not subtype of native type 1.
+PHPDoc tag @var with type string is not subtype of native type int.
+PHPDoc tag @var with type string is not subtype of type int.
+PHPDoc tag @var with type string|null is not subtype of native type string.
+PHPDoc type 4 of property OverridingProperty\Typed2WithPhpDoc::$foo is not the same as PHPDoc type 1|2|3 of overridden property OverridingProperty\TypedWithPhpDoc::$foo.
+PHPDoc type array of property OverridingPropertyPhpDoc\Bar::$arrayClassStrings is not covariant with PHPDoc type array<class-string> of overridden property OverridingPropertyPhpDoc\Foo::$arrayClassStrings.
+PHPDoc type array of property OverridingPropertyPhpDoc\Bar::$arrayClassStrings is not the same as PHPDoc type array<class-string> of overridden property OverridingPropertyPhpDoc\Foo::$arrayClassStrings.
+PHPDoc type array<class-string> of property OverridingPropertyPhpDoc\Bar::$array is not the same as PHPDoc type array of overridden property OverridingPropertyPhpDoc\Foo::$array.
+PHPDoc type for property InvalidPhpDocPromotedProperties\BazWithProperty::$bar with type string is incompatible with native type int.
+PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$bar contains unresolvable type.
+PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$classStringInt contains unresolvable type.
+PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$fooGeneric contains generic type InvalidPhpDocDefinitions\Foo<stdClass> but class InvalidPhpDocDefinitions\Foo is not generic.
+PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$unknownClassConstant contains unresolvable type.
+PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$unknownClassConstant2 contains unresolvable type.
+PHPDoc type int of property OverridingPropertyPhpDoc\Bar::$string is not covariant with PHPDoc type string of overridden property OverridingPropertyPhpDoc\Foo::$string.
+PHPDoc type int of property OverridingPropertyPhpDoc\Bar::$string is not the same as PHPDoc type string of overridden property OverridingPropertyPhpDoc\Foo::$string.
+Parameter #1 $a (Bug4017_2\Foo) of method Bug4017_2\Lorem::doFoo() should be compatible with parameter $a (stdClass) of method Bug4017_2\Bar<stdClass>::doFoo()
+Parameter #1 $a (T of stdClass) of method Bug4017_3\Lorem::doFoo() should be compatible with parameter $a (Bug4017_3\Foo) of method Bug4017_3\Bar::doFoo()
+Parameter #1 $a (iterable) of method ParameterContravarianceArray\Baz::doBar() is not compatible with parameter #1 $a (array|null) of method ParameterContravarianceArray\Foo::doBar().
+Parameter #1 $a (iterable) of method ParameterContravarianceArray\Baz::doBar() is not contravariant with parameter #1 $a (array|null) of method ParameterContravarianceArray\Foo::doBar().
+Parameter #1 $a (iterable) of method ParameterContravarianceTraversable\Baz::doBar() is not compatible with parameter #1 $a (Traversable|null) of method ParameterContravarianceTraversable\Foo::doBar().
+Parameter #1 $a (iterable) of method ParameterContravarianceTraversable\Baz::doBar() is not contravariant with parameter #1 $a (Traversable|null) of method ParameterContravarianceTraversable\Foo::doBar().
+Parameter #1 $a of function CallGenericFunction\g expects DateTime, DateTimeImmutable given.
+Parameter #1 $a of method Bug3481\Foo::doSomething() expects string, int|string given.
+Parameter #1 $a of method LiteralStringMethod\Foo::requireArrayOfLiteralStrings() expects array<literal-string>, array<mixed> given.
+Parameter #1 $a of method LiteralStringMethod\Foo::requireArrayOfLiteralStrings() expects array<literal-string>, array<string> given.
+Parameter #1 $a of method OnlyRelevantUnableToResolve\Foo::doBaz() expects array<mixed>, int given.
+Parameter #1 $a of method Test\CallableWithMixedArray::doBar() expects callable(array<string>): array<string>, Closure(array): (array{'foo'}|null) given.
+Parameter #1 $a of method Test\InvalidReturnTypeUsingArrayTemplateTypeBound::bar() expects array<string>, array<int, int> given.
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClass::parameterTypeTest4() should be contravariant with parameter $animal (MethodSignature\Animal) of method MethodSignature\BaseClass::parameterTypeTest4()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClass::parameterTypeTest4() should be contravariant with parameter $animal (MethodSignature\Animal) of method MethodSignature\BaseInterface::parameterTypeTest4()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClass::parameterTypeTest5() should be compatible with parameter $animal (MethodSignature\Cat) of method MethodSignature\BaseClass::parameterTypeTest5()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClass::parameterTypeTest5() should be compatible with parameter $animal (MethodSignature\Cat) of method MethodSignature\BaseInterface::parameterTypeTest5()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClassUsingTrait::parameterTypeTest4() should be contravariant with parameter $animal (MethodSignature\Animal) of method MethodSignature\BaseClass::parameterTypeTest4()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClassUsingTrait::parameterTypeTest4() should be contravariant with parameter $animal (MethodSignature\Animal) of method MethodSignature\BaseInterface::parameterTypeTest4()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClassUsingTrait::parameterTypeTest5() should be compatible with parameter $animal (MethodSignature\Cat) of method MethodSignature\BaseClass::parameterTypeTest5()
+Parameter #1 $animal (MethodSignature\Dog) of method MethodSignature\SubClassUsingTrait::parameterTypeTest5() should be compatible with parameter $animal (MethodSignature\Cat) of method MethodSignature\BaseInterface::parameterTypeTest5()
+Parameter #1 $arg of method Bug3555\Enum::run() expects 1|2|3|4|5|6|7|8|9, 100 given.
+Parameter #1 $arg of static method Bug2164\A::staticTest() expects static(Bug2164\B)|string, Bug2164\B|string given.
+Parameter #1 $arr1 of function array_udiff expects array<(int&TK)|(string&TK), string>, null given.
+Parameter #1 $array (array<class-string>) to function array_filter does not contain falsy values, the array will always stay the same.
+Parameter #1 $array (array<false|null>) to function array_filter contains falsy values only, the result will always be an empty array.
+Parameter #1 $array (array<stdClass>) to function array_filter does not contain falsy values, the array will always stay the same.
+Parameter #1 $array (array{'', 'test'}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{'test'}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{'test'}) to function array_filter does not contain falsy values, the array will always stay the same.
+Parameter #1 $array (array{0, 1, 3}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{0}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{0}) to function array_filter contains falsy values only, the result will always be an empty array.
+Parameter #1 $array (array{1, 3}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{1, 3}) to function array_filter does not contain falsy values, the array will always stay the same.
+Parameter #1 $array (array{null, 0}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{null, 0}) to function array_filter contains falsy values only, the result will always be an empty array.
+Parameter #1 $array (array{null, null}) of array_values is already a list, call has no effect.
+Parameter #1 $array (array{null, null}) to function array_filter contains falsy values only, the result will always be an empty array.
+Parameter #1 $array (array{null}) to function array_filter contains falsy values only, the result will always be an empty array.
+Parameter #1 $array (array{stdClass}) to function array_filter does not contain falsy values, the array will always stay the same.
+Parameter #1 $array (array{true, true}) to function array_filter does not contain falsy values, the array will always stay the same.
+Parameter #1 $array (array{}) to function array_filter is empty, call has no effect.
+Parameter #1 $array (array{}) to function array_values is empty, call has no effect.
+Parameter #1 $array (list<int>) of array_values is already a list, call has no effect.
+Parameter #1 $array is passed by reference so it does not accept @readonly property Bug12676\A::$a.
+Parameter #1 $array is passed by reference so it does not accept @readonly property Bug12676\B::$readonlyArr.
+Parameter #1 $array is passed by reference so it does not accept static @readonly property Bug12676\C::$readonlyArr.
+Parameter #1 $array of function Bug12847\doSomething expects non-empty-array<mixed>, mixed given.
+Parameter #1 $array of function Bug12847\doSomethingWithInt expects non-empty-array<int>, non-empty-array given.
+Parameter #1 $array of function Bug2911\bar expects array{bar: string}, non-empty-array<mixed> given.
+Parameter #1 $array of function array_count_values expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function array_count_values expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter #1 $array of function array_diff expects an array of values castable to string, array<int, Bug11141\Language::DAN|Bug11141\Language::ENG|Bug11141\Language::GER> given.
+Parameter #1 $array of function array_diff expects an array of values castable to string, array<int, stdClass> given.
+Parameter #1 $array of function array_intersect expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function array_intersect expects an array of values castable to string, array<int, array> given.
+Parameter #1 $array of function array_intersect expects an array of values castable to string, array<int|stdClass> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, Bug11883\SomeEnum::A|Bug11883\SomeEnum::B> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, CurlHandle> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, GMP|stdClass> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, ParamCastableToNumberFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, ParamCastableToNumberFunctions\ClassWithToString> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, array<int, int>> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, array> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, int|string> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, mixed> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, resource|false> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, stdClass> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int, string> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<int|stdClass> given.
+Parameter #1 $array of function array_product expects an array of values castable to number, array<string> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, Bug11883\SomeEnum::A|Bug11883\SomeEnum::B> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, CurlHandle> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, GMP|stdClass> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, ParamCastableToNumberFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, ParamCastableToNumberFunctions\ClassWithToString> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, array<int, int>> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, array> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, int|string> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, mixed> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, resource|false> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, stdClass> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int, string> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<int|stdClass> given.
+Parameter #1 $array of function array_sum expects an array of values castable to number, array<string> given.
+Parameter #1 $array of function array_unique expects an array of values castable to string, array<int, SortParamCastableToStringFunctionsEnum\FooEnum::A|string> given.
+Parameter #1 $array of function array_unique expects an array of values castable to string, array<int, list<string>> given.
+Parameter #1 $array of function array_unique expects an array of values castable to string, array<int|stdClass> given.
+Parameter #1 $array of function arsort expects an array of values castable to float, array<int, SortParamCastableToStringFunctions\ClassWithToString> given.
+Parameter #1 $array of function arsort expects an array of values castable to string and float, array<int, SortParamCastableToStringFunctions\ClassWithToString> given.
+Parameter #1 $array of function arsort expects an array of values castable to string, array<int, SortParamCastableToStringFunctionsEnum\FooEnum> given.
+Parameter #1 $array of function arsort expects an array of values castable to string, array<int, list<string>> given.
+Parameter #1 $array of function asort expects an array of values castable to string, list<SortParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function asort expects an array of values castable to string, list<array<int, string>> given.
+Parameter #1 $array of function implode expects array<string>, array<int, array<int, int>> given.
+Parameter #1 $array of function implode expects array<string>, array<int, array<int, int|true>> given.
+Parameter #1 $array of function implode expects array<string>, array<int, array<int, string>> given.
+Parameter #1 $array of function natcasesort expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function natcasesort expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter #1 $array of function natsort expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function natsort expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter #1 $array of function reset expects array|object, null given.
+Parameter #1 $array of function rsort expects an array of values castable to string, list<SortParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function rsort expects an array of values castable to string, list<array<int, string>> given.
+Parameter #1 $array of function sort expects an array of values castable to string and float, list<array<int, string>> given.
+Parameter #1 $array of function sort expects an array of values castable to string, array<int, SortParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $array of function sort expects an array of values castable to string, array<int, SortParamCastableToStringFunctions\ClassWithoutToString> given.
+Parameter #1 $array of function sort expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter #1 $array of function sort expects an array of values castable to string, array<int, list<string>> given.
+Parameter #1 $array of method Random\Randomizer::pickArrayKeys() expects non-empty-array, array{} given.
+Parameter #1 $array of static method Bug9732\HelloWorld::stringifyKeys() expects array<string, mixed>, array<mixed> given.
+Parameter #1 $b (int) of method ConsistentConstructor\Bar2::__construct() is not contravariant with parameter #1 $b (string) of method ConsistentConstructor\Bar::__construct().
+Parameter #1 $bar of class Bug3311a\Foo constructor expects list<string>, array{1: 'baz'} given.
+Parameter #1 $bar of method Bug11463\FooType::foo() expects 'bar', 'bla' given.
+Parameter #1 $bar of method ObjectShapesAcceptance\Bar::requireBar() expects ObjectShapesAcceptance\Bar, object{a: int} given.
+Parameter #1 $bar of method Test\ClassWithNullableProperty::doBar() is passed by reference, so it expects variables only.
+Parameter #1 $c of method GenericObjectLowerBound\Foo::doFoo() expects GenericObjectLowerBound\Collection<GenericObjectLowerBound\Cat|GenericObjectLowerBound\Dog>, GenericObjectLowerBound\Collection<GenericObjectLowerBound\Dog> given.
+Parameter #1 $c of method GenericsInferCollection\Bar::doBar() expects GenericsInferCollection\ArrayCollection2<int, int>, GenericsInferCollection\ArrayCollection2<(int|string), mixed> given.
+Parameter #1 $c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<int, string> given.
+Parameter #1 $callable of method Test\MethodExists::doBar() expects callable(): mixed, array{class-string|object, 'bar'} given.
+Parameter #1 $callable of method Test\MethodExists::doBar() expects callable(): mixed, array{class-string|object, 'foo'} given.
+Parameter #1 $callable of method Test\MethodExists::doBar() expects callable(): mixed, array{object, 'bar'} given.
+Parameter #1 $callback of function array_map expects (callable(1|2, 'bar'|'foo'): mixed)|null, Closure(int, int): void given.
+Parameter #1 $callback of function array_map expects (callable(1|stdClass): mixed)|null, Closure(string): string given.
+Parameter #1 $callback of function array_map expects (callable(Bug12317\Uuid): mixed)|null, Closure(string): string given.
+Parameter #1 $callback of function array_map expects (callable(string): mixed)|null, Closure(array): 'a' given.
+Parameter #1 $callback of function set_error_handler expects (callable(int, string, string, int): bool)|null, Closure(mixed, mixed, mixed, mixed): void given.
+Parameter #1 $callback of static method Closure::fromCallable() expects callable(): mixed, array{'Bug1971\\HelloWorld', 'sayHello'} given.
+Parameter #1 $callback of static method Closure::fromCallable() expects callable(): mixed, array{class-string<static(Bug1971\HelloWorld)>, 'sayHello'} given.
+Parameter #1 $callback of static method Closure::fromCallable() expects callable(): mixed, array{class-string<static(Bug1971\HelloWorld)>, 'sayHello2'} given.
+Parameter #1 $cb of function FunctionCallParamClosureThis\acceptClosure expects bindable closure, static closure given.
+Parameter #1 $cb of method CallablesWithoutCheckNullables\Foo::doBar() expects callable(float|null): (float|null), Closure(float): float given.
+Parameter #1 $cb of method CallablesWithoutCheckNullables\Foo::doBar2() expects callable(float|null): float, Closure(float): float given.
+Parameter #1 $cb of method CallablesWithoutCheckNullables\Foo::doBar2() expects callable(float|null): float, Closure(float|null): (float|null) given.
+Parameter #1 $cb of method CallablesWithoutCheckNullables\Foo::doBaz() expects Closure(float|null): (float|null), Closure(float): float given.
+Parameter #1 $cb of method CallablesWithoutCheckNullables\Foo::doBaz2() expects Closure(float|null): float, Closure(float): float given.
+Parameter #1 $cb of method CallablesWithoutCheckNullables\Foo::doBaz2() expects Closure(float|null): float, Closure(float|null): (float|null) given.
+Parameter #1 $cb of method CheckExplicitMixedMethodCall\CallableMixed::doBar2() expects callable(): int, Closure(): mixed given.
+Parameter #1 $cb of method CheckExplicitMixedMethodCall\CallableMixed::doFoo() expects callable(mixed): void, Closure(int): void given.
+Parameter #1 $cb of method CheckImplicitMixedMethodCall\CallableMixed::doBar2() expects callable(): int, Closure(): mixed given.
+Parameter #1 $cb of method PureCallableMethodAccepts\Foo::acceptsPureCallable() expects pure-callable(): mixed, Closure(): 1 given.
+Parameter #1 $cb of method PureCallableMethodAccepts\Foo::acceptsPureCallable() expects pure-callable(): mixed, callable(): mixed given.
+Parameter #1 $cb of method PureCallableMethodAccepts\Foo::acceptsPureClosure() expects pure-Closure, Closure(): 1 given.
+Parameter #1 $cb of method TrickyCallables\Bar::doBar() expects callable(string=): void, callable(string): void given.
+Parameter #1 $cb of method TrickyCallables\Baz::doBar() expects callable(): void, callable(string): void given.
+Parameter #1 $cb of method TrickyCallables\Foo::doBar() expects callable(string|null): void, callable(string): void given.
+Parameter #1 $cb of static method CallStaticMethodMixed\CallableMixed::callAcceptsExplicitMixed() expects callable(mixed): void, Closure(int): void given.
+Parameter #1 $cb of static method CallStaticMethodMixed\CallableMixed::callReturnsInt() expects callable(): int, Closure(): mixed given.
+Parameter #1 $class of static method Bug4550\Test::valuesOf() expects class-string<Person>, string given.
+Parameter #1 $closure of function VaryingAcceptor\bar expects callable(callable(): string): string, callable(callable(): int): string given.
+Parameter #1 $cls of method RectorDoWhileVarIssue\Foo::processCharacterClass() expects string, int|string given.
+Parameter #1 $code of method Test\KeyOfParam::foo() expects 'jfk'|'lga', 'sfo' given.
+Parameter #1 $code of method Test\ValueOfParam::foo() expects 'John F. Kennedy…'|'La Guardia Airport', 'Newark Liberty…' given.
+Parameter #1 $command of function proc_open expects list<string>|string, array{something: 'bogus', in: 'here'} given.
+Parameter #1 $countryMap of method CallMethodInEnum\FooCall::helloArray() expects array<'The Netherlands'|'United States', bool>, array{abc: 123} given.
+Parameter #1 $countryMap of method CallMethodInEnum\FooCall::helloArray() expects array<'The Netherlands'|'United States', bool>, array{abc: true} given.
+Parameter #1 $countryMap of method CallMethodInEnum\FooCall::helloArray() expects array<'The Netherlands'|'United States', bool>, array{true} given.
+Parameter #1 $countryName of method CallMethodInEnum\FooCall::hello() expects 'The Netherlands'|'United States', CallMethodInEnum\CountryNo::NL given.
+Parameter #1 $data of class Bug14138\Foo constructor expects array{foo: int, bar: int}, array{foo: 1} given.
+Parameter #1 $data of function Bug5986\test2 expects array{mov?: int, appliesTo?: string, expireDate?: string|null, effectiveFrom?: int, merchantId?: int, link?: string, channel?: string, voucherExternalId?: int}, array{mov?: int, appliesTo?: string, expireDate?: string|null, effectiveFrom?: string, merchantId?: int, link?: string, channel?: string, voucherExternalId?: int} given.
+Parameter #1 $data of static method Discussion7004\Foo::fromArray1() expects array<array{newsletterName: string, subscriberCount: int}>, array<mixed, mixed> given.
+Parameter #1 $data of static method Discussion7004\Foo::fromArray2() expects array{array{newsletterName: string, subscriberCount: int}}, array<mixed, mixed> given.
+Parameter #1 $data of static method Discussion7004\Foo::fromArray3() expects array{newsletterName: string, subscriberCount: int}, array<mixed, mixed> given.
+Parameter #1 $date of function Bug4413\takesDate expects class-string<DateTime>, string given.
+Parameter #1 $date of method Test\HelloWorld3::sayHello() expects array<DateTime|DateTimeImmutable>|int, DateTimeInterface given.
+Parameter #1 $dateOrString of method Test\CheckDefaultArrayKeys::doSit() expects DateTimeImmutable|string, int|stdClass|string given.
+Parameter #1 $demoArg of static method ConditionalParam\HelloWorld::replaceCallback() expects bool, string given.
+Parameter #1 $demoArg of static method ConditionalParam\HelloWorld::replaceCallback() expects string, true given.
+Parameter #1 $depth of function xdebug_call_class expects int, string given.
+Parameter #1 $e (Exception) of method ParameterContravariance\Bar::doBar() is not compatible with parameter #1 $e (InvalidArgumentException) of method ParameterContravariance\Foo::doBar().
+Parameter #1 $e (Exception|null) of method ParameterContravariance\Baz::doBar() is not compatible with parameter #1 $e (InvalidArgumentException) of method ParameterContravariance\Foo::doBar().
+Parameter #1 $e (InvalidArgumentException) of method ParameterContravariance\Lorem::doFoo() is not compatible with parameter #1 $e (Exception) of method ParameterContravariance\Foo::doFoo().
+Parameter #1 $e (InvalidArgumentException) of method ParameterContravariance\Lorem::doFoo() is not contravariant with parameter #1 $e (Exception) of method ParameterContravariance\Foo::doFoo().
+Parameter #1 $e (InvalidArgumentException|null) of method ParameterContravariance\Ipsum::doFoo() is not compatible with parameter #1 $e (Exception) of method ParameterContravariance\Foo::doFoo().
+Parameter #1 $e (InvalidArgumentException|null) of method ParameterContravariance\Ipsum::doFoo() is not contravariant with parameter #1 $e (Exception) of method ParameterContravariance\Foo::doFoo().
+Parameter #1 $everything of method LessParametersVariadics\Bar::doFoo() is variadic but parameter #1 $many of method LessParametersVariadics\Foo::doFoo() is not variadic.
+Parameter #1 $everything of method LessParametersVariadics\Baz::doFoo() is variadic but parameter #1 $many of method LessParametersVariadics\Foo::doFoo() is not variadic.
+Parameter #1 $exception of method Generator<mixed,mixed,mixed,mixed>::throw() expects Throwable, int given.
+Parameter #1 $f of function Bug9699\int_int_int_string expects Closure(int, int, int, string): int, Closure(int, int, int ...): int given.
+Parameter #1 $field of method Bug9951\Cl::addCondition() expects array<int, Bug9951\AbstractScope|Bug9951\Expressionable>|Bug9951\AbstractScope|Bug9951\Expressionable|string, mixed given.
+Parameter #1 $field of method Bug9951\Cl::addCondition() expects array<int, Bug9951\AbstractScope|Bug9951\Expressionable>|Bug9951\AbstractScope|Bug9951\Expressionable|string, object|string|null given.
+Parameter #1 $filter of method TrickyCallables\TwoErrorsAtOnce::run() expects callable(int|string=): bool, Closure(int): true given.
+Parameter #1 $foo (mixed) of method ParameterTypeWidening\Bar::doFoo() does not match parameter #1 $foo (string) of method ParameterTypeWidening\Foo::doFoo().
+Parameter #1 $foo of function Discussion7450\foo expects array{policy: non-empty-string, entitlements: array<non-empty-string>}, array{policy: mixed, entitlements: mixed} given.
+Parameter #1 $foo of function IncorrectCallToFunction\bar expects int, string given.
+Parameter #1 $foo of function PassedByReference\foo is passed by reference, so it expects variables only.
+Parameter #1 $foo of method Bug11463\BarType::bar() expects 'foo', 'bla' given.
+Parameter #1 $foo of method CallVariadicMethods\Foo::doIntegerParameters() expects int, string given.
+Parameter #1 $foo of method CheckNullables\Foo::doFoo() expects string, null given.
+Parameter #1 $foo of method CheckNullables\Foo::doFoo() expects string, string|null given.
+Parameter #1 $foo of method InvokeMagicInvokeMethod\ClassForCallable::doFoo() expects callable(): mixed, InvokeMagicInvokeMethod\ClassForCallable given.
+Parameter #1 $foo of method Test\ClassWithToString::acceptsString() expects string, Test\ClassWithToString given.
+Parameter #1 $foo of method Test\ExpectsExceptionGenerics::requiresFoo() expects Test\Foo, Exception given.
+Parameter #1 $foo of method Test\ObjectTypehint::doBar() expects Test\Foo, object given.
+Parameter #1 $fooId of method Bug3589\FooRepository::load() expects Bug3589\Id<Bug3589\Foo>, Bug3589\Id<Bug3589\Bar> given.
+Parameter #1 $fooId of method Bug3589\FooRepository::load() expects Bug3589\Id<Bug3589\Foo>, Bug3589\Id<mixed> given.
+Parameter #1 $g of method MethodWithPhpDocsImplicitInheritance\Dolor::doLorem() expects MethodWithPhpDocsImplicitInheritance\A, int given.
+Parameter #1 $globalTitle of method Test\ThreeTypesCall::threeTypes() expects string, float given.
+Parameter #1 $i (int) of method OverridingTraitMethods\Bar::doBar() is not contravariant with parameter #1 $i (string) of method OverridingTraitMethods\Foo::doBar().
+Parameter #1 $i (int) of method OverridingTraitMethods\Baz::doBar() is not contravariant with parameter #1 $i (string) of method OverridingTraitMethods\FooPrivate::doBar().
+Parameter #1 $i (non-empty-string) of method OverridingTraitMethodsPhpDoc\Bar::doBar() should be contravariant with parameter $i (string) of method OverridingTraitMethodsPhpDoc\Foo::doBar()
+Parameter #1 $i of callable array{$this(CallCallables\Foo), 'doBar'} expects int, string given.
+Parameter #1 $i of callable passed to call_user_func() expects int, string given.
+Parameter #1 $i of callable passed to call_user_func_array() expects int, string given.
+Parameter #1 $i of callable passed to call_user_func_array() expects int|null, string given.
+Parameter #1 $i of class ClassString\A constructor expects int, string given.
+Parameter #1 $i of class ClassString\C constructor expects int, string given.
+Parameter #1 $i of class InstantiationNewStaticConsistentConstructor\Foo constructor expects int, string given.
+Parameter #1 $i of closure expects int, string given.
+Parameter #1 $i of function CallToFunctionInForeachCondition\takesString expects string, int given.
+Parameter #1 $i of method AcceptThrowable\Foo::doBar() expects int, AcceptThrowable\InterfaceExtendingThrowable given.
+Parameter #1 $i of method AcceptThrowable\Foo::doBar() expects int, AcceptThrowable\NonExceptionClass&Throwable given.
+Parameter #1 $i of method AcceptThrowable\Foo::doBar() expects int, AcceptThrowable\SomeInterface&Throwable given.
+Parameter #1 $i of method AcceptThrowable\Foo::doBar() expects int, Exception given.
+Parameter #1 $i of method CheckExplicitMixedMethodCall\Bar::doBar() expects int, T given.
+Parameter #1 $i of method CheckExplicitMixedMethodCall\Bar::doBar() expects int, mixed given.
+Parameter #1 $i of method CheckImplicitMixedMethodCall\Bar::doBar() expects int, mixed given.
+Parameter #1 $i of method ConsistentConstructor\ChildTwo::__construct() is not optional.
+Parameter #1 $i of method ConsistentConstructor\ParentWithoutConstructorChildWithConstructorRequiredParams::__construct() is not optional.
+Parameter #1 $i of method MethodWithInheritDocWithoutCurlyBraces\Baz::doFoo() expects int, string given.
+Parameter #1 $i of method MethodWithInheritDoc\Baz::doFoo() expects int, string given.
+Parameter #1 $i of method MethodWithPhpDocsImplicitInheritance\Baz::doFoo() expects int, string given.
+Parameter #1 $i of method NamedArgumentsMethod\Foo::doFoo() expects int, string given.
+Parameter #1 $i of method NonEmptyStringVerbosity\Foo::doBar() expects int, string given.
+Parameter #1 $i of method OverridingFinalMethod\BazBaz::doBar() is not optional.
+Parameter #1 $i of method OverridingFinalMethod\Lacus::doFoo() is not passed by reference but parameter #1 $i of method OverridingFinalMethod\Etiam::doFoo() is passed by reference.
+Parameter #1 $i of method PureCallableMethodAccepts\Foo::acceptsInt() expects int, callable given.
+Parameter #1 $i of method Test\CheckDefaultArrayKeys::doBar() expects int, int|stdClass|string given.
+Parameter #1 $i of method Test\CheckDefaultArrayKeys::doBar() expects int, int|string given.
+Parameter #1 $i of method Test\SubtractedMixed::requireInt() expects int, mixed given.
+Parameter #1 $i of method Test\TernaryEvaluation::doBar() expects int, Test\Foo given.
+Parameter #1 $i of method Test\TernaryEvaluation::doBar() expects int, false given.
+Parameter #1 $i of static method CallStaticMethodMixed\Bar::doBar() expects int, T given.
+Parameter #1 $i of static method CallStaticMethodMixed\Bar::doBar() expects int, mixed given.
+Parameter #1 $ids of method CallMethodsIterables\Uuid::bar() expects iterable<CallMethodsIterables\Uuid>, array<int, null> given.
+Parameter #1 $index (int) of method OverridingFinalMethod\FixedArrayOffsetExists::offsetExists() is not compatible with parameter #1 $index (mixed) of method SplFixedArray<mixed>::offsetExists().
+Parameter #1 $index (int) of method OverridingFinalMethod\FixedArrayOffsetExists::offsetExists() is not contravariant with parameter #1 $index (mixed) of method SplFixedArray<mixed>::offsetExists().
+Parameter #1 $input of function array_rand expects non-empty-array, array{} given.
+Parameter #1 $int of method CallVariadicMethods\Foo::doVariadicString() expects int, string given.
+Parameter #1 $intOrString of method Test\CheckDefaultArrayKeys::doLorem() expects int|string, int|stdClass|string given.
+Parameter #1 $intProp of class InstantiationPromotedProperties\PromotedPropertyNotNullable constructor expects int, null given.
+Parameter #1 $iterable of method CallMethodsIterables\Foo::acceptsSelfIterable() expects iterable<CallMethodsIterables\Foo>, iterable<CallMethodsIterables\Bar> given.
+Parameter #1 $iterable of method CallMethodsIterables\Foo::acceptsSelfIterable() expects iterable<CallMethodsIterables\Foo>, string given.
+Parameter #1 $iterableWithoutTypehint of method CallMethodsIterables\Foo::doFoo() expects iterable, int given.
+Parameter #1 $iterator of class RecursiveIteratorIterator constructor expects T of IteratorAggregate|RecursiveIterator, Generator<int, int, mixed, void> given.
+Parameter #1 $iterator of function iterator_apply expects Traversable, array<stdClass> given.
+Parameter #1 $iterator of function iterator_apply expects Traversable, array<stdClass>|Iterator<mixed, stdClass> given.
+Parameter #1 $j of method OverridingFinalMethod\Amet::doBar() is not variadic but parameter #1 $j of method OverridingFinalMethod\Sit::doBar() is variadic.
+Parameter #1 $j of method OverridingFinalMethod\Amet::doBaz() is variadic but parameter #1 $j of method OverridingFinalMethod\Sit::doBaz() is not variadic.
+Parameter #1 $keys of function array_combine expects an array of values castable to string, array<int, Bug3946\stdClass|float|int|list<string>|string> given.
+Parameter #1 $keys of function array_combine expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $keys of function array_combine expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter #1 $keys of function array_fill_keys expects an array of values castable to string, array<Bug11111\Language> given.
+Parameter #1 $keys of function array_fill_keys expects an array of values castable to string, array<int, Bug11111\Language::DUT|Bug11111\Language::ITA> given.
+Parameter #1 $keys of function array_fill_keys expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #1 $keys of function array_fill_keys expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter #1 $keys of function array_fill_keys expects an array of values castable to string, array<int|stdClass> given.
+Parameter #1 $lall of static method Bug3448\Foo::add() expects int, string given.
+Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, class-string> given.
+Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, literal-string> given.
+Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, non-falsy-string> given.
+Parameter #1 $members of method Test\ParameterTypeCheckVerbosity::doBar() expects array<array{id: string, code: string}>, array<array{code: string}> given.
+Parameter #1 $message of class Exception constructor expects string, int given.
+Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (-1).
+Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (int<-10, -1>).
+Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (int<-10, 10>).
+Parameter #1 $min (1) of function random_int expects lower number than parameter #2 $max (0).
+Parameter #1 $min (int<-10, 10>) of function random_int expects lower number than parameter #2 $max (0).
+Parameter #1 $min (int<-5, 0>) of function random_int expects lower number than parameter #2 $max (int<-1, 5>).
+Parameter #1 $min (int<-5, 1>) of function random_int expects lower number than parameter #2 $max (int<0, 5>).
+Parameter #1 $min (int<0, 10>) of function random_int expects lower number than parameter #2 $max (int<0, 10>).
+Parameter #1 $min (int<1, 10>) of function random_int expects lower number than parameter #2 $max (0).
+Parameter #1 $n of method MethodsDynamicCall\Foo::doFoo() expects int, int|string given.
+Parameter #1 $n of method MethodsDynamicCall\Foo::doFoo() expects int, string given.
+Parameter #1 $name of attribute class Bug12011Trait\Table constructor expects string|null, int given.
+Parameter #1 $name of attribute class Bug12011\Table constructor expects string|null, int given.
+Parameter #1 $namespaceOrPrefix of method SimpleXMLElement::children() expects string|null, int given.
+Parameter #1 $newThis of method Closure::bindTo() expects stdClass, ClosureBindToParamClosureThis\Foo given.
+Parameter #1 $newThis of method Closure::call() expects object, int given.
+Parameter #1 $node (PhpParser\Node\Expr\StaticCall) of method MethodSignature\Rule::processNode() should be contravariant with parameter $node (PhpParser\Node) of method MethodSignature\GenericRule<PhpParser\Node>::processNode()
+Parameter #1 $nonEmpty of method AcceptNonEmptyArray\Foo::requireNonEmpty() expects non-empty-array<int>, array<int> given.
+Parameter #1 $nonEmpty of method AcceptNonEmptyArray\Foo::requireNonEmpty() expects non-empty-array<int>, array{} given.
+Parameter #1 $num of function dechex expects int, float|int given.
+Parameter #1 $o of method ObjectShapesAcceptance\Bar::doBar() expects object{a: string}, ObjectShapesAcceptance\Bar given.
+Parameter #1 $o of method ObjectShapesAcceptance\Baz::doBar() expects object{a: int}, $this(ObjectShapesAcceptance\Baz) given.
+Parameter #1 $o of method ObjectShapesAcceptance\Baz::doBaz() expects object{b: int}, $this(ObjectShapesAcceptance\Baz) given.
+Parameter #1 $o of method ObjectShapesAcceptance\Baz::doIpsum() expects object{d: array{foo: string}}, $this(ObjectShapesAcceptance\Baz) given.
+Parameter #1 $o of method ObjectShapesAcceptance\Baz::doLorem() expects object{c: int}, $this(ObjectShapesAcceptance\Baz) given.
+Parameter #1 $o of method ObjectShapesAcceptance\Foo::doBar() expects object{foo: int, bar: string}, Exception given.
+Parameter #1 $o of method ObjectShapesAcceptance\Foo::doBar() expects object{foo: int, bar: string}, object given.
+Parameter #1 $o of method ObjectShapesAcceptance\Foo::doBar() expects object{foo: int, bar: string}, object{foo: string, bar: int} given.
+Parameter #1 $o of method ObjectShapesAcceptance\Foo::doBar() expects object{foo: int, bar: string}, object{foo: string, bar: int}&stdClass given.
+Parameter #1 $o of method ObjectShapesAcceptance\Foo::doBar() expects object{foo: int, bar: string}, object{foo?: int, bar: string} given.
+Parameter #1 $o of method ObjectShapesAcceptance\Foo::doBar() expects object{foo: int, bar: string}, stdClass given.
+Parameter #1 $o of method ObjectShapesAcceptance\OptionalProperty::doBar() expects object{foo?: int}, object{foo?: string} given.
+Parameter #1 $o of method ObjectShapesAcceptance\OptionalProperty::doBaz() expects object{foo: int}, object{foo?: string} given.
+Parameter #1 $o of method ObjectShapesAcceptance\TestAcceptance::doFoo() expects object{foo: int}, ObjectShapesAcceptance\FinalClass given.
+Parameter #1 $o of method ObjectShapesAcceptance\TestAcceptance::doFoo() expects object{foo: int}, Traversable given.
+Parameter #1 $object of function get_class expects object, null given.
+Parameter #1 $object of function get_class expects object, object|null given.
+Parameter #1 $object of static method Bug12558\Foo::assertStatic() expects Bug12558\Foo, Bug12558\Foo|null given.
+Parameter #1 $object of static method Bug12558\Foo::assertStatic() expects Bug12558\Foo, bool|Bug12558\Foo given.
+Parameter #1 $object_or_class of function is_a expects object, string given.
+Parameter #1 $object_or_class of function is_subclass_of expects object, string given.
+Parameter #1 $objects of static method Bug8296\VerifyLoginTask::continueDump() expects array<string, object>, array<string, Bug8296\stdClass|true> given.
+Parameter #1 $offset (TOffset of key-of<TArray of array>) of method Bug7652\Options::offsetSet() should be contravariant with parameter $offset (key-of<array>|null) of method ArrayAccess<key-of<TArray of array>,value-of<TArray of array>>::offsetSet()
+Parameter #1 $one of method CallMethodInEnum\TestPassingEnums::requireOne() expects CallMethodInEnum\TestPassingEnums::ONE, $this(CallMethodInEnum\TestPassingEnums)&CallMethodInEnum\TestPassingEnums given.
+Parameter #1 $one of method CallMethodsPhpDocMergeParamInherited\ChildClass::method() expects CallMethodsPhpDocMergeParamInherited\C, CallMethodsPhpDocMergeParamInherited\B given.
+Parameter #1 $other of method Test\CollectionWithStaticParam::add() expects static(Test\AppleCollection), Test\AppleCollection given.
+Parameter #1 $param is passed by reference so it does not accept readonly property ReadonlyPropertyPassedByRef\Foo::$bar.
+Parameter #1 $param of method GenericVarianceCall\Foo::contravariant() expects GenericVarianceCall\Contravariant<GenericVarianceCall\B>, GenericVarianceCall\Contravariant<GenericVarianceCall\C> given.
+Parameter #1 $param of method GenericVarianceCall\Foo::covariant() expects GenericVarianceCall\Covariant<GenericVarianceCall\B>, GenericVarianceCall\Covariant<GenericVarianceCall\A> given.
+Parameter #1 $param of method GenericVarianceCall\Foo::invariant() expects GenericVarianceCall\Invariant<GenericVarianceCall\B>, GenericVarianceCall\Invariant<GenericVarianceCall\A> given.
+Parameter #1 $param of method GenericVarianceCall\Foo::invariant() expects GenericVarianceCall\Invariant<GenericVarianceCall\B>, GenericVarianceCall\Invariant<GenericVarianceCall\C> given.
+Parameter #1 $param of method GenericVarianceCall\Foo::invariantArray() expects array{GenericVarianceCall\Invariant<GenericVarianceCall\B>}, array{GenericVarianceCall\Invariant<GenericVarianceCall\C>} given.
+Parameter #1 $param of method Test\IncompatiblePhpDocNullableTypeIssue::doFoo() expects string|null, int given.
+Parameter #1 $param of static method Bug5781\Foo::bar() expects array{a: bool, b: bool, c: bool, d: bool, e: bool, f: bool, g: bool, h: bool, ...}, array{} given.
+Parameter #1 $parameter of method Test\SubtractedMixed::requireIntOrString() expects int|string, mixed given.
+Parameter #1 $params of static method TemplateTypeInOneBranchOfConditional\DriverManager::getConnection() expects array{wrapperClass?: class-string<TemplateTypeInOneBranchOfConditional\Connection>}, array{wrapperClass: 'stdClass'} given.
+Parameter #1 $passedByRef of method NullsafeMethodCall\Foo::doBaz() is passed by reference, so it expects variables only.
+Parameter #1 $query of method Bug3922\FooQueryHandler::handle() expects Bug3922\FooQuery, Bug3922\BarQuery given.
+Parameter #1 $s (string) of method OverridingFinalMethod\Dolor::__construct() is not compatible with parameter #1 $i (int) of method OverridingFinalMethod\Ipsum::__construct().
+Parameter #1 $s (string) of method OverridingFinalMethod\Dolor::__construct() is not contravariant with parameter #1 $i (int) of method OverridingFinalMethod\Ipsum::__construct().
+Parameter #1 $s of function Bug757\useString is passed by reference, so it expects variables only.
+Parameter #1 $s of function Bug7823\sayHello expects literal-string, class-string given.
+Parameter #1 $s of function PassedByReference\bar expects string, int given.
+Parameter #1 $s of method LiteralStringMethod\Foo::requireLiteralString() expects literal-string, 1 given.
+Parameter #1 $s of method LiteralStringMethod\Foo::requireLiteralString() expects literal-string, array<mixed> given.
+Parameter #1 $s of method LiteralStringMethod\Foo::requireLiteralString() expects literal-string, int given.
+Parameter #1 $s of method LiteralStringMethod\Foo::requireLiteralString() expects literal-string, mixed given.
+Parameter #1 $s of method LiteralStringMethod\Foo::requireLiteralString() expects literal-string, string given.
+Parameter #1 $s of method LowercaseString\Bar::acceptLowercaseString() expects lowercase-string, 'NotLowerCase' given.
+Parameter #1 $s of method LowercaseString\Bar::acceptLowercaseString() expects lowercase-string, numeric-string given.
+Parameter #1 $s of method LowercaseString\Bar::acceptLowercaseString() expects lowercase-string, string given.
+Parameter #1 $s of method MethodsDynamicCall\Foo::doQux() expects string, int given.
+Parameter #1 $s of method TestStringables\Dolor::doFoo() expects string, TestStringables\Bar given.
+Parameter #1 $s of method Test\ClassStringWithUpperBounds::doFoo() expects class-string<Exception>, string given.
+Parameter #1 $s of method Test\ForeachSituation::takesInt() expects int|null, string|null given.
+Parameter #1 $s of method Test\IssetCumulativeArray::doBar() expects string, int given.
+Parameter #1 $s of method Test\IssetCumulativeArray::doBar() expects string, int<0, max> given.
+Parameter #1 $s of method Test\IssetCumulativeArray::doBar() expects string, int<1, max> given.
+Parameter #1 $s of method UppercaseString\Bar::acceptUppercaseString() expects uppercase-string, 'NotUpperCase' given.
+Parameter #1 $s of method UppercaseString\Bar::acceptUppercaseString() expects uppercase-string, numeric-string given.
+Parameter #1 $s of method UppercaseString\Bar::acceptUppercaseString() expects uppercase-string, string given.
+Parameter #1 $s of static method MethodsDynamicCall\Foo::doQux() expects string, int given.
+Parameter #1 $separator of function explode expects non-empty-string, '' given.
+Parameter #1 $separator of function explode expects non-empty-string, 1 given.
+Parameter #1 $separator of function explode expects non-empty-string, string given.
+Parameter #1 $separator of function implode expects array, array<string>|string given.
+Parameter #1 $separator of function implode expects array, list<int>|null given.
+Parameter #1 $separator of function implode expects string, array given.
+Parameter #1 $separator of function join expects array, array<string>|string given.
+Parameter #1 $separator of function join expects array, list<int>|null given.
+Parameter #1 $someValue of method MethodWithPhpDocsImplicitInheritance\TestArrayObject3::append() expects stdClass, Exception given.
+Parameter #1 $something of class Bug6370\A constructor expects string, int given.
+Parameter #1 $state (int) of method OverridingParle\Foo::pushState() is not compatible with parameter #1 $state (string) of method Parle\RLexer::pushState().
+Parameter #1 $state (int) of method OverridingParle\Foo::pushState() is not contravariant with parameter #1 $state (string) of method Parle\RLexer::pushState().
+Parameter #1 $std of method ObjectShapesAcceptance\Foo::requireStdClass() expects stdClass, object{foo: string, bar: int} given.
+Parameter #1 $std of method Test\CheckDefaultArrayKeys::doAmet() expects stdClass, (int|string) given.
+Parameter #1 $std of method Test\CheckDefaultArrayKeys::doAmet() expects stdClass, int|stdClass|string given.
+Parameter #1 $stdOrInt of method Test\CheckDefaultArrayKeys::doIpsum() expects int|stdClass, int|stdClass|string given.
+Parameter #1 $stdOrString of method Test\CheckDefaultArrayKeys::doDolor() expects stdClass|string, int|stdClass|string given.
+Parameter #1 $str of callable class@anonymous/tests/PHPStan/Rules/Functions/data/callables.php:75 expects string, int given.
+Parameter #1 $str of method MethodWithInheritDocWithoutCurlyBraces\Foo::doBar() expects string, int given.
+Parameter #1 $str of method MethodWithInheritDoc\Foo::doBar() expects string, int given.
+Parameter #1 $str of method MethodWithPhpDocsImplicitInheritance\Foo::doBar() expects string, int given.
+Parameter #1 $str of method TestMethodsIsCallable\CheckIsCallable::test() expects callable(): mixed, 'Test…' given.
+Parameter #1 $str of method Test\CheckDefaultArrayKeys::doBaz() expects string, int|stdClass|string given.
+Parameter #1 $str of method Test\CheckDefaultArrayKeys::doBaz() expects string, int|string given.
+Parameter #1 $str of method Test\CheckIsCallable::test() expects callable(): mixed, 'Test…' given.
+Parameter #1 $str of method Test\CheckIsCallable::test() expects callable(): mixed, 'nonexistentFunction' given.
+Parameter #1 $str of method Test\LiteralArrayTypeCheck::test() expects string, int given.
+Parameter #1 $str of method Test\LiteralArrayTypeCheck::test() expects string, true given.
+Parameter #1 $string of function strlen expects string, int given.
+Parameter #1 $string of method Test\NonFalsyString::acceptsNonFalsyString() expects non-falsy-string, '0' given.
+Parameter #1 $string of method Test\NonFalsyString::acceptsNonFalsyString() expects non-falsy-string, int given.
+Parameter #1 $string of method Test\NonFalsyString::acceptsNonFalsyString() expects non-falsy-string, literal-string given.
+Parameter #1 $string of method Test\NonFalsyString::acceptsNonFalsyString() expects non-falsy-string, non-empty-string given.
+Parameter #1 $string of method Test\NonFalsyString::acceptsNonFalsyString() expects non-falsy-string, numeric-string given.
+Parameter #1 $string of method Test\NonFalsyString::acceptsNonFalsyString() expects non-falsy-string, string given.
+Parameter #1 $string of static method Bug8296\VerifyLoginTask::stringByRef() expects string, int given.
+Parameter #1 $string1 of function strnatcasecmp expects string, Bug11619Strict\Foo given.
+Parameter #1 $t of method Bug6371\HelloWorld<int,string>::compare() expects int, true given.
+Parameter #1 $test (string) of method Bug4003\Ipsum::doFoo() should be compatible with parameter $test (int) of method Bug4003\Lorem::doFoo()
+Parameter #1 $test of closure expects string|null, int given.
+Parameter #1 $test of method Bug3445\Foo::doFoo() expects Bug3445\Foo, $this(Bug3445\Bar) given.
+Parameter #1 $test of method Test\NullableInPhpDoc::doFoo() expects string, null given.
+Parameter #1 $test of method Test\NumericStringParam::sayHello() expects numeric-string, 'abc' given.
+Parameter #1 $test of method Test\NumericStringParam::sayHello() expects numeric-string, 123 given.
+Parameter #1 $type of function filter_input expects 0|1|2|4|5, -1 given.
+Parameter #1 $type of function filter_input expects 0|1|2|4|5, int given.
+Parameter #1 $type of function filter_input_array expects 0|1|2|4|5, -1 given.
+Parameter #1 $type of function filter_input_array expects 0|1|2|4|5, int given.
+Parameter #1 $uno of method CallMethodsPhpDocMergeParamInherited\ParentClass::method() expects CallMethodsPhpDocMergeParamInherited\A, CallMethodsPhpDocMergeParamInherited\D given.
+Parameter #1 $val of closure expects int, int|null given.
+Parameter #1 $val of function Bug7082\takesStr expects string, mixed given.
+Parameter #1 $value (string) of method MethodSignature\Bar::doFoo() should be compatible with parameter $value (int) of method MethodSignature\Foo::doFoo()
+Parameter #1 $value of class InstantiationNewStaticConsistentConstructor\ChildClass3 constructor expects string, int given.
+Parameter #1 $value of function Bug10626\intByReference expects int, string given.
+Parameter #1 $value of function Bug10626\intByValue expects int, string given.
+Parameter #1 $value of function Bug9133\assertNever expects never, int given.
+Parameter #1 $value of function count expects array|Countable, array<mixed>|false given.
+Parameter #1 $value of function floatval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, Stringable@anonymous/tests/PHPStan/Rules/Functions/data/bug-6560-strict.php:13 given.
+Parameter #1 $value of function floatval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, Stringable@anonymous/tests/PHPStan/Rules/Functions/data/bug-6560.php:13 given.
+Parameter #1 $value of function floatval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, mixed given.
+Parameter #1 $value of function floatval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, stdClass given.
+Parameter #1 $value of function intval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, Stringable@anonymous/tests/PHPStan/Rules/Functions/data/bug-6560-strict.php:13 given.
+Parameter #1 $value of function intval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, Stringable@anonymous/tests/PHPStan/Rules/Functions/data/bug-6560.php:13 given.
+Parameter #1 $value of function intval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, mixed given.
+Parameter #1 $value of function intval expects array|bool|float|GMP|int|resource|SimpleXMLElement|string|null, stdClass given.
+Parameter #1 $value of function strval expects bool|float|GMP|int|resource|string|null, array given.
+Parameter #1 $value of function strval expects bool|float|GMP|int|resource|string|null, mixed given.
+Parameter #1 $value of function strval expects bool|float|GMP|int|resource|string|null, stdClass given.
+Parameter #1 $value of method ArrayObject<int,stdClass>::append() expects stdClass, Exception given.
+Parameter #1 $value of method Fiber<void,void,void,void>::resume() expects void, int given.
+Parameter #1 $x of method Bug9487\HelloWorld::sayHello() expects list<string>, array<int<1, max>, string> given.
+Parameter #1 $x of method MethodWithPhpDocsImplicitInheritance\Ipsum::doLorem() expects MethodWithPhpDocsImplicitInheritance\A, int given.
+Parameter #1 ('string'|array{'string'}) of echo cannot be converted to string.
+Parameter #1 (Closure(): void) of echo cannot be converted to string.
+Parameter #1 (array<int>|null) of echo cannot be converted to string.
+Parameter #1 (array{}) of echo cannot be converted to string.
+Parameter #1 (stdClass) of echo cannot be converted to string.
+Parameter #1 ...$arg1 of function max expects non-empty-array, array{} given.
+Parameter #1 ...$arg1 of function min expects non-empty-array, array{} given.
+Parameter #1 ...$everything (int) of method LessParametersVariadics\Baz::doFoo() is not contravariant with parameter #2 $parameters (string) of method LessParametersVariadics\Foo::doFoo().
+Parameter #1 ...$everything (int) of method LessParametersVariadics\Baz::doFoo() is not contravariant with parameter #3 $here (string) of method LessParametersVariadics\Foo::doFoo().
+Parameter #1 ...$foo of closure expects CallCallables\Foo, array<CallCallables\Foo> given.
+Parameter #1 ...$strings of method CallVariadicMethods\Bar::anotherVariadicStrings() expects string, int given.
+Parameter #1 ...$strings of method CallVariadicMethods\Bar::variadicStrings() expects string, int given.
+Parameter #1 of closure expects DateTime, DateTimeImmutable given.
+Parameter #1 of closure expects int, TMemberType given.
+Parameter #1 of closure expects never, TBlockType of Bug6485\Block given.
+Parameter #10 $mixeds of method CallMethodsIterables\Foo::doFoo() expects iterable, int given.
+Parameter #2 $arr2 of function array_udiff expects array<(int&TK)|(string&TK), string>, null given.
+Parameter #2 $array of function array_map expects array, mixed given.
+Parameter #2 $array of function implode expects array, array<string>|string given.
+Parameter #2 $array of function implode expects array, list<int>|null given.
+Parameter #2 $array of function implode expects array, string given.
+Parameter #2 $array of function implode expects array<string>, array<int, ImplodeParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #2 $array of function implode expects array<string>, array<int, array<int, string>> given.
+Parameter #2 $array of function implode expects array<string>, array<int, list<string>|string> given.
+Parameter #2 $array of function implode expects array<string>, array<int|stdClass> given.
+Parameter #2 $array of function join expects array, array<string>|string given.
+Parameter #2 $array of function join expects array, list<int>|null given.
+Parameter #2 $array of function join expects array<string>, array<int, array<int, string>> given.
+Parameter #2 $arrays of function array_diff expects an array of values castable to string, array<int, Bug11141\Language::DAN> given.
+Parameter #2 $arrays of function array_diff expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #2 $arrays of function array_diff expects an array of values castable to string, array<int, ParamCastableToStringFunctions\ClassWithoutToString> given.
+Parameter #2 $arrays of function array_diff expects an array of values castable to string, array<int, stdClass> given.
+Parameter #2 $arrays of function array_diff_assoc expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #2 $arrays of function array_diff_assoc expects an array of values castable to string, array<int, ParamCastableToStringFunctions\ClassWithoutToString> given.
+Parameter #2 $arrays of function array_intersect expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #2 $arrays of function array_intersect expects an array of values castable to string, array<int, ParamCastableToStringFunctions\ClassWithoutToString> given.
+Parameter #2 $b of method Test\ExpectsExceptionGenerics::expectsExceptionUpperBound() expects Exception, Throwable given.
+Parameter #2 $bar of class InstantiationPromotedProperties\Bar constructor expects array<string>, array<int, int> given.
+Parameter #2 $bar of class InstantiationPromotedProperties\Foo constructor expects array<string>, array<int, int> given.
+Parameter #2 $bar of method CallVariadicMethods\Foo::doIntegerParameters() expects int, string given.
+Parameter #2 $callback of function array_filter expects (callable('bar'|'baz'|'foo'|'quux'|'qux'): bool)|null, Closure(string): stdClass given.
+Parameter #2 $callback of function array_filter expects (callable(int): bool)|null, Closure(string): true given.
+Parameter #2 $callback of function array_filter expects (callable(mixed): bool)|null, Closure(int): true given.
+Parameter #2 $callback of function array_find expects callable(1|2, 'bar'|'foo'): bool, Closure(int, string): ('bar'|'foo') given.
+Parameter #2 $callback of function array_find expects callable(1|2, 'bar'|'foo'): bool, Closure(string, int): bool given.
+Parameter #2 $callback of function array_find expects callable(mixed, int|string): bool, Closure(string, array): false given.
+Parameter #2 $callback of function array_find expects callable(mixed, int|string): bool, Closure(string, int): array{} given.
+Parameter #2 $callback of function array_find_key expects callable(1|2, 'bar'|'foo'): bool, Closure(int, string): ('bar'|'foo') given.
+Parameter #2 $callback of function array_find_key expects callable(1|2, 'bar'|'foo'): bool, Closure(string, int): bool given.
+Parameter #2 $callback of function array_find_key expects callable(mixed, int|string): bool, Closure(string, array): false given.
+Parameter #2 $callback of function array_find_key expects callable(mixed, int|string): bool, Closure(string, int): array{} given.
+Parameter #2 $callback of function array_reduce expects callable(non-falsy-string|null, 1|2|3): (non-falsy-string|null), Closure(string, int): non-falsy-string given.
+Parameter #2 $callback of function array_reduce expects callable(string, 1|2|3): string, Closure(string, string): string given.
+Parameter #2 $callback of function array_walk expects callable(1|2, 'bar'|'foo'): mixed, Closure(int, string, int): '' given.
+Parameter #2 $callback of function array_walk expects callable(1|2, 'bar'|'foo'): mixed, Closure(stdClass, float): '' given.
+Parameter #2 $callback of function array_walk expects callable(1|2, 'bar'|'foo', 'extra'): mixed, Closure(int, string, int): '' given.
+Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(): void given.
+Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(array): void given.
+Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(string): string given.
+Parameter #2 $callback of function preg_replace_callback expects callable(array<string>): string, Closure(): void given.
+Parameter #2 $callback of function preg_replace_callback expects callable(array<string>): string, Closure(array): void given.
+Parameter #2 $callback of function preg_replace_callback expects callable(array<string>): string, Closure(string): string given.
+Parameter #2 $callback of function uasort expects callable(1|2|3, 1|2|3): int, Closure(string, string): 1 given.
+Parameter #2 $callback of function uksort expects callable('one'|'three'|'two', 'one'|'three'|'two'): int, Closure(stdClass, stdClass): 1 given.
+Parameter #2 $callback of function uksort expects callable(int, int): int, Closure(string, string): 1 given.
+Parameter #2 $callback of function usort expects callable(1|2|3, 1|2|3): int, Closure(string, string): 1 given.
+Parameter #2 $callback of function usort expects callable(stdClass, stdClass): int, Closure(int, int): (-1|1) given.
+Parameter #2 $code of class Exception constructor expects int, string given.
+Parameter #2 $depth of function json_validate expects int<1, max>, 0 given.
+Parameter #2 $dos of method CallMethodsPhpDocMergeParamInherited\ParentClass::method() expects CallMethodsPhpDocMergeParamInherited\B, CallMethodsPhpDocMergeParamInherited\D given.
+Parameter #2 $everything of method LessParametersVariadics\Lorem::doFoo() is variadic but parameter #2 $parameters of method LessParametersVariadics\Foo::doFoo() is not variadic.
+Parameter #2 $f of function Bug11619Strict\customUsort expects callable(Stringable, Stringable): int, 'strnatcasecmp' given.
+Parameter #2 $fields of function fputcsv expects array<int|string, bool|float|int|string|null>, array<int, Fputcsv\Person> given.
+Parameter #2 $flags of function file expects 0|1|2|3|4|5|6|7|16|17|18|19|20|21|22|23, 8 given.
+Parameter #2 $h of method MethodWithPhpDocsImplicitInheritance\Dolor::doLorem() expects MethodWithPhpDocsImplicitInheritance\B, int given.
+Parameter #2 $iterableWithIterableTypehint of method CallMethodsIterables\Foo::doFoo() expects iterable, int given.
+Parameter #2 $j of method OverridingFinalMethod\Consecteur::doFoo() is required but parameter #2 $j of method OverridingFinalMethod\Sit::doFoo() is optional.
+Parameter #2 $j of method OverridingFinalMethod\FooFoo::doFoo() is not optional.
+Parameter #2 $j of method OverridingFinalMethod\Lacus::doFoo() is passed by reference but parameter #2 $j of method OverridingFinalMethod\Etiam::doFoo() is not passed by reference.
+Parameter #2 $k of method Bug6371\HelloWorld<int,string>::compare() expects string, false given.
+Parameter #2 $lang of method OverridingVariadics\AnotherTranslator::translate() is not optional.
+Parameter #2 $lang of method OverridingVariadics\OtherTranslator::translate() is not optional.
+Parameter #2 $lang of method OverridingVariadics\YetAnotherTranslator::translate() is not variadic.
+Parameter #2 $message_type of function error_log expects 0|1|3|4, 2 given.
+Parameter #2 $newScope of method Closure::bindTo() expects 'static'|class-string|object|null, 'CallClosureBind\\Bar3' given.
+Parameter #2 $newThis of static method Closure::bind() expects stdClass, ClosureBindParamClosureThis\Foo given.
+Parameter #2 $num of method Random\Randomizer::pickArrayKeys() expects int<1, max>, 0 given.
+Parameter #2 $num_req of function array_rand expects int<1, max>, -5 given.
+Parameter #2 $num_req of function array_rand expects int<1, max>, 0 given.
+Parameter #2 $num_req of function array_rand expects int<1, max>, int given.
+Parameter #2 $object of method Test\ClassStringWithUpperBounds::doFoo() expects Exception, Throwable given.
+Parameter #2 $operation of function flock expects int<0, 7>, 8 given.
+Parameter #2 $options of function curl_setopt_array expects array{10022?: non-empty-string}, array{}|array{10022: 123} given.
+Parameter #2 $options of function curl_setopt_array expects array{19913: bool, 10102: string, 68: int, 13: int, 84: int, 10036: non-empty-string|null}, array{19913: true, 10102: '', 68: 10, 13: 30, 84: 2, 10036: CurlSetOptArray\BackedRequestMethod::POST} given.
+Parameter #2 $options of function curl_setopt_array expects array{19913: bool, 10102: string, 68: int, 13: int, 84: int, 10036: non-empty-string|null}, array{19913: true, 10102: '', 68: 10, 13: 30, 84: 2, 10036: CurlSetOptArray\RequestMethod::POST} given.
+Parameter #2 $options of function curl_setopt_array expects array{19913: bool, 10102: string, 68: int, 13: int, 84: int}, array{19913: '123', 10102: '', 68: 10, 13: 30, 84: false} given.
+Parameter #2 $param2 of function Bug11534\hello expects int, mixed given.
+Parameter #2 $str of method Test\PreIncString::doFoo() expects string, int given.
+Parameter #2 $string of class SoapFault constructor expects string, int given.
+Parameter #2 $string2 of function strnatcasecmp expects string, Bug11619Strict\Foo given.
+Parameter #2 $thing of method Closure::call() expects object, int given.
+Parameter #2 $two of method CallMethodsPhpDocMergeParamInherited\ChildClass::method() expects CallMethodsPhpDocMergeParamInherited\B, CallMethodsPhpDocMergeParamInherited\D given.
+Parameter #2 $v of method UnresolvableParameter\HelloWorld::foo() contains unresolvable type.
+Parameter #2 $v of method UnresolvableParameter\HelloWorld::foo() expects 1, 0 given.
+Parameter #2 $value of method Bug12219\Bug3::foo() contains unresolvable type.
+Parameter #2 $y of method MethodWithPhpDocsImplicitInheritance\Ipsum::doLorem() expects MethodWithPhpDocsImplicitInheritance\B, int given.
+Parameter #2 (stdClass) of echo cannot be converted to string.
+Parameter #2 ...$foo of function FunctionWithVariadicParameters\foo expects int, string given.
+Parameter #2 ...$strings of method CallVariadicMethods\Bar::anotherVariadicStrings() expects string, int given.
+Parameter #2 ...$strings of method CallVariadicMethods\Bar::variadicStrings() expects string, int given.
+Parameter #2 ...$strings of method CallVariadicMethods\Foo::doVariadicString() expects string, int given.
+Parameter #2 ...$values of function printf expects bool|float|int|string|null, UnpackOperator\Foo given.
+Parameter #2 ...$values of function sprintf expects bool|float|int|string|null, UnpackOperator\Foo given.
+Parameter #2 ...$values of function sprintf expects bool|float|int|string|null, array<int, string> given.
+Parameter #2 ...$values of function sprintf expects bool|float|int|string|null, array<string> given.
+Parameter #2 of function printf is expected to be castable to float by placeholder #1 ("%1$-'X10.2f"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be castable to float by placeholder #1 ("%1$f"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be castable to float by placeholder #1 ("%f"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be castable to float by placeholder #2 ("%1$*.*f" (value)), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be castable to int by placeholder #1 ("%d"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be castable to int by placeholder #1 ("%d"), int|PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be castable to int by placeholder #2 ("%1$d"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be float by placeholder #1 ("%1$-'X10.2f"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be float by placeholder #1 ("%1$f"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), SimpleXMLElement given.
+Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), null given.
+Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), true given.
+Parameter #2 of function printf is expected to be float by placeholder #2 ("%1$*.*f" (value)), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), SimpleXMLElement given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), float given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), null given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), string given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), true given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%.*s" (precision)), string given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%1$*d" (value)), float given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%1$*d" (width)), float given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), SimpleXMLElement given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), float given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), float|int given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), int|PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), null given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), string given.
+Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), true given.
+Parameter #2 of function printf is expected to be int by placeholder #2 ("%1$d"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function printf is expected to be int by placeholder #2 ("%3$.*s" (precision)), string given.
+Parameter #2 of function printf is expected to be string by placeholder #1 ("%s"), true given.
+Parameter #2 of function sprintf is expected to be castable to int by placeholder #1 ("%d"), PrintfParamTypes\FooStringable given.
+Parameter #2 of function sprintf is expected to be int by placeholder #1 ("%d"), PrintfParamTypes\FooStringable given.
+Parameter #3 $data_comp_func of function array_diff_uassoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(int, int): ('11'|'12'|'13'|'14'|'15'|'16'|'21'|'22'|'23'|'24'|'25'|'26'|'31'|'32'|'33'|'34'|'35'|'36'|'41'|'42'|'43'|'44'|'45'|'46'|'51'|'52'|'53'|'54'|'55'|'56'|'61'|'62'|'63'|'64'|'65'|'66') given.
+Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(string, string): string given.
+Parameter #3 $data_comp_func of function array_udiff expects callable(string, string): int, Closure(string, int): non-empty-string given.
+Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $data_compare_func of function array_uintersect expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4, 1|2|3|4): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(1|2|3|4, 1|2|3|4): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $end of class DatePeriod constructor expects int|TEnd of DateTimeInterface, string given.
+Parameter #3 $flags of class RecursiveIteratorIterator constructor expects 0|16, 2 given.
+Parameter #3 $flags of function json_validate expects 0|1048576, 2 given.
+Parameter #3 $i of method MethodWithPhpDocsImplicitInheritance\Dolor::doLorem() expects MethodWithPhpDocsImplicitInheritance\C, int given.
+Parameter #3 $iterableWithConcreteTypehint of method CallMethodsIterables\Foo::doFoo() expects iterable<CallMethodsIterables\Bar>, int given.
+Parameter #3 $key_comp_func of function array_diff_ukey expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $key_comp_func of function array_diff_ukey expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2, 1|2): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2|3|4|5, 1|2|3|4|5): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $key_compare_func of function array_intersect_ukey expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.
+Parameter #3 $newScope of static method Closure::bind() expects 'static'|class-string|object|null, 'CallClosureBind\\Bar3' given.
+Parameter #3 $parameters of method OverridingVariadics\AnotherTranslator::translate() is not variadic.
+Parameter #3 $value of function curl_setopt expects 0|2, bool given.
+Parameter #3 $value of function curl_setopt expects CurlShareHandle, string given.
+Parameter #3 $value of function curl_setopt expects array, string given.
+Parameter #3 $value of function curl_setopt expects array<int, string>, array<string, string> given.
+Parameter #3 $value of function curl_setopt expects array<int, string>, int given.
+Parameter #3 $value of function curl_setopt expects array|string, int given.
+Parameter #3 $value of function curl_setopt expects bool, int given.
+Parameter #3 $value of function curl_setopt expects bool, string given.
+Parameter #3 $value of function curl_setopt expects bool|int, int|string given.
+Parameter #3 $value of function curl_setopt expects int, string given.
+Parameter #3 $value of function curl_setopt expects non-empty-string, '' given.
+Parameter #3 $value of function curl_setopt expects non-empty-string, int given.
+Parameter #3 $value of function curl_setopt expects non-empty-string, null given.
+Parameter #3 $value of function curl_setopt expects non-empty-string|null, '' given.
+Parameter #3 $value of function curl_setopt expects resource, string given.
+Parameter #3 $value of function curl_setopt expects string, int given.
+Parameter #3 $z of method MethodWithPhpDocsImplicitInheritance\Ipsum::doLorem() expects MethodWithPhpDocsImplicitInheritance\C, int given.
+Parameter #3 ...$args of method NamedArgumentsMethod\Foo::doIpsum() expects string, int given.
+Parameter #3 ...$foo of function FunctionWithVariadicParameters\foo expects int, null given.
+Parameter #3 ...$strings of method CallVariadicMethods\Foo::doVariadicString() expects string, int given.
+Parameter #3 of function array_intersect expects an array of values castable to string, array<int, ParamCastableToStringFunctionsEnum\FooEnum::A> given.
+Parameter #3 of function array_intersect expects an array of values castable to string, array<int, ParamCastableToStringFunctions\ClassWithoutToString> given.
+Parameter #3 of function fprintf is expected to be castable to float by placeholder #1 ("%f"), PrintfParamTypes\FooStringable given.
+Parameter #3 of function fprintf is expected to be float by placeholder #1 ("%f"), PrintfParamTypes\FooStringable given.
+Parameter #4 $arrayWithIterableTypehint of method CallMethodsIterables\Foo::doFoo() expects array, int given.
+Parameter #4 $d of method MethodWithPhpDocsImplicitInheritance\Dolor::doLorem() expects MethodWithPhpDocsImplicitInheritance\D, int given.
+Parameter #4 $d of method MethodWithPhpDocsImplicitInheritance\Ipsum::doLorem() expects MethodWithPhpDocsImplicitInheritance\D, int given.
+Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.
+Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable('a'|'b'|'c'|'d', 'a'|'b'|'c'|'d'): int, Closure(int, int): int<-1, 1> given.
+Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.
+Parameter #4 ...$strings of method CallVariadicMethods\Foo::doVariadicString() expects string, int given.
+Parameter #4 of function printf is expected to be castable to float by placeholder #1 ("%3$f"), PrintfParamTypes\FooStringable given.
+Parameter #4 of function printf is expected to be float by placeholder #1 ("%3$f"), PrintfParamTypes\FooStringable given.
+Parameter #5 $unionIterableType of method CallMethodsIterables\Foo::doFoo() expects CallMethodsIterables\Collection&iterable<CallMethodsIterables\Bar>, int given.
+Parameter #5 ...$strings of method CallVariadicMethods\Foo::doVariadicString() expects string, int given.
+Parameter #6 $mixedUnionIterableType of method CallMethodsIterables\Foo::doFoo() expects array, int given.
+Parameter #6 ...$strings of method CallVariadicMethods\Foo::doVariadicString() expects string, int given.
+Parameter #7 $unionIterableIterableType of method CallMethodsIterables\Foo::doFoo() expects CallMethodsIterables\Collection&iterable<CallMethodsIterables\Bar>, int given.
+Parameter #9 $integers of method CallMethodsIterables\Foo::doFoo() expects iterable<int>, int given.
+Parameter $a of anonymous function has unresolvable native type.
+Parameter $a of function FunctionIntersectionTypes\doBar() has unresolvable native type.
+Parameter $a of function FunctionIntersectionTypes\doBaz() has unresolvable native type.
+Parameter $a of function ParamClosureThisClassesFunctions\doFoo() has invalid type ParamClosureThisClassesFunctions\Nonexistent.
+Parameter $a of method MethodIntersectionTypes\FooClass::doBar() has unresolvable native type.
+Parameter $a of method MethodIntersectionTypes\FooClass::doBaz() has unresolvable native type.
+Parameter $a of method ParamClosureThisClasses\Bar::doFoo() has invalid type ParamClosureThisClasses\Nonexistent.
+Parameter $array of function array_product expects an array of values castable to number, array<int, array<int, int>> given.
+Parameter $array of function array_sum expects an array of values castable to number, array<int, array<int, int>> given.
+Parameter $array of function array_unique expects an array of values castable to string, array<int, list<string>> given.
+Parameter $array of function arsort expects an array of values castable to string, array<int, list<string>> given.
+Parameter $array of function asort expects an array of values castable to string, list<array<int, string>> given.
+Parameter $array of function implode expects array<string>, array<int, array<int, string>> given.
+Parameter $array of function rsort expects an array of values castable to string, list<array<int, string>> given.
+Parameter $array of function sort expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter $array of method TestMethodTypehints\FooMethodTypehints::unknownTypesInArrays() has invalid type TestMethodTypehints\AnotherNonexistentClass.
+Parameter $b of function ParamClosureThisClassesFunctions\doFoo() has invalid type ParamClosureThisClassesFunctions\FooTrait.
+Parameter $b of method NamedArgumentsMethod\Foo::doIpsum() expects int, string given.
+Parameter $b of method ParamClosureThisClasses\Bar::doFoo() has invalid type ParamClosureThisClasses\FooTrait.
+Parameter $bar of anonymous function has invalid type ArrowFunctionExistingClassesInTypehints\Bar.
+Parameter $bar of anonymous function has invalid type TestClosureFunctionTypehintsPhp71\NonexistentClass.
+Parameter $bar of anonymous function has invalid type TestClosureFunctionTypehints\BarFunctionTypehints.
+Parameter $bar of function TestFunctionTypehints\bar() has invalid type TestFunctionTypehints\BarFunctionTypehints.
+Parameter $bar of function barWithoutNamespace() has invalid type BarFunctionTypehints.
+Parameter $bar of method TestMethodTypehints\FooMethodTypehints::bar() has invalid type TestMethodTypehints\BarMethodTypehints.
+Parameter $bars of method TestMethodTypehints\FooMethodTypehints::dolor() has invalid type TestMethodTypehints\BarMethodTypehints.
+Parameter $bars of method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid type TestMethodTypehints\BarMethodTypehints.
+Parameter $bars of method TestMethodTypehints\FooMethodTypehints::lorem() has invalid type TestMethodTypehints\BarMethodTypehints.
+Parameter $callback of function array_map expects (callable(Bug12317\Uuid): mixed)|null, Closure(string): string given.
+Parameter $cb of method TestMethodTypehints\CallableTypehints::doFoo() has invalid type TestMethodTypehints\Bla.
+Parameter $cb of method TestMethodTypehints\CallableTypehints::doFoo() has invalid type TestMethodTypehints\Ble.
+Parameter $end of class DatePeriod constructor expects int|TEnd of DateTimeInterface, string given.
+Parameter $i for PHPDoc tag @param-out is not passed by reference.
+Parameter $i of callable passed to call_user_func() expects int, string given.
+Parameter $i of callable passed to call_user_func_array() expects int, string given.
+Parameter $i of method NamedArgumentsMethod\Foo::doBaz() is passed by reference, so it expects variables only.
+Parameter $int of method EnumsTypehints\Foo::doFoo() has invalid type EnumsTypehints\intt.
+Parameter $iterable of method TestMethodTypehints\IterableTypehints::doFoo() has invalid type TestMethodTypehints\AnotherNonexistentClass.
+Parameter $iterable of method TestMethodTypehints\IterableTypehints::doFoo() has invalid type TestMethodTypehints\NonexistentClass.
+Parameter $j of method NamedArgumentsMethod\Foo::doFoo() expects int, string given.
+Parameter $keys of function array_combine expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter $keys of function array_fill_keys expects an array of values castable to string, array<int, array<int, string>> given.
+Parameter $p of function ParamOutClasses\doFoo() has invalid type ParamOutClasses\Nonexistent.
+Parameter $p of method ParamOutClassesMethods\Bar::doFoo() has invalid type ParamOutClassesMethods\Nonexistent.
+Parameter $param is passed by reference so it does not accept readonly property ReadonlyPropertyPassedByRef\Foo::$bar.
+Parameter $param of anonymous function has invalid type void.
+Parameter $param of function VoidParameterTypehint\doFoo() has invalid type void.
+Parameter $param of method VoidParameterTypehintMethod\Foo::doFoo() has invalid type void.
+Parameter $parent of method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.
+Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.
+Parameter $q of function ParamOutClasses\doFoo() has invalid type ParamOutClasses\FooTrait.
+Parameter $q of method ParamOutClassesMethods\Bar::doFoo() has invalid type ParamOutClassesMethods\FooTrait.
+Parameter $repositoryClass of attribute class Bug7171\Entity constructor expects class-string<Bug7171\EntityRepository<T of object>>|null, 'stdClass' given.
+Parameter $separator of function implode expects array<string>, array<int, array<int, string>> given.
+Parameter $string of function TestFunctionTypehints\genericClassString() has invalid type TestFunctionTypehints\SomeNonexistentClass.
+Parameter $string of function TestFunctionTypehints\genericTemplateClassString() has invalid type TestFunctionTypehints\SomeNonexistentClass.
+Parameter $trait of anonymous function has invalid type TestClosureFunctionTypehints\SomeTrait.
+Parameter $trait of function TestFunctionTypehints\referencesTraitsInNative() has invalid type TestFunctionTypehints\SomeTrait.
+Parameter $trait of function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid type TestFunctionTypehints\SomeTrait.
+Parameter $trait of function referencesTraitsInNativeWithoutNamespace() has invalid type SomeTraitWithoutNamespace.
+Parameter $trait of function referencesTraitsInPhpDocWithoutNamespace() has invalid type SomeTraitWithoutNamespace.
+Parameter &$p @param-out type of function ParameterOutAssignedType\foo() expects int, string given.
+Parameter &$p @param-out type of function ParameterOutCatchVariable\foo() expects int, Exception given.
+Parameter &$p @param-out type of function ParameterOutExecutionEnd\foo2() expects string, string|null given.
+Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBar() expects string, int given.
+Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBaz() expects list<int>, array<0|int<2, max>, int> given.
+Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBaz2() expects list<int>, non-empty-list<'str'|int> given.
+Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBaz3() expects list<list<int>>, list<array<int<0, max>, int>> given.
+Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doFoo() expects int, string given.
+Parameter &$p @param-out type of method ParameterOutExecutionEnd\Foo::foo2() expects string, string|null given.
+Parameter &$p @param-out type of method ParameterOutExecutionEnd\Foo::foo3() expects string, string|null given.
+Parameter &$p @param-out type of method ParameterOutExecutionEnd\Foo::foo4() expects string, string|null given.
+Parameter &$p @param-out type of method ParameterOutExecutionEnd\Foo::foo6() expects int, string given.
+Parameter &$p by-ref type of function ParameterOutCatchVariable\bar() expects int, Exception given.
+Parameter &$p by-ref type of method ParameterOutAssignedType\Foo::doNoParamOut() expects string, int given.
+Parameter 'string'|array{'string'} of print cannot be converted to string.
+Parameter Closure(): void of print cannot be converted to string.
+Parameter array<int>|null of print cannot be converted to string.
+Parameter array{} of print cannot be converted to string.
+Parameter stdClass of print cannot be converted to string.
+Parse error in @phpstan-ignore: Unexpected T_CLOSE_PARENTHESIS after identifier, expected comma (,) or end or T_OPEN_PARENTHESIS
+Parse error in @phpstan-ignore: Unexpected T_OTHER 'čičí' after @phpstan-ignore, expected identifier
+Parse error in @phpstan-ignore: Unexpected comma (,) after comma (,), expected identifier
+Parse error in @phpstan-ignore: Unexpected end after @phpstan-ignore, expected identifier
+Parse error in @phpstan-ignore: Unexpected end, unclosed opening parenthesis
+Part $bar?->obj (stdClass|null) of encapsed string cannot be cast to string.
+Part $std (stdClass) of encapsed string cannot be cast to string.
+Path in include() "a-file-that-does-not-exist.php" is not a file or it does not exist.
+Path in include() "data/include-me-to-prove-you-work.txt" is not a file or it does not exist.
+Path in include_once() "a-file-that-does-not-exist.php" is not a file or it does not exist.
+Path in include_once() "data/include-me-to-prove-you-work.txt" is not a file or it does not exist.
+Path in require() "a-file-that-does-not-exist.php" is not a file or it does not exist.
+Path in require() "data/include-me-to-prove-you-work.txt" is not a file or it does not exist.
+Path in require_once() "../bug-12203-sure-does-not-exist.php" is not a file or it does not exist.
+Path in require_once() "/tmp/phpstan-src-2.2.x/tests/PHPStan/Rules/Keywords/data/../bug-12203-sure-does-not-exist.php" is not a file or it does not exist.
+Path in require_once() "a-file-that-does-not-exist.php" is not a file or it does not exist.
+Path in require_once() "data/include-me-to-prove-you-work.txt" is not a file or it does not exist.
+Possibly impure call to a Closure in pure function PureFunction\callsClosures().
+Possibly impure call to a callable in pure function FirstClassCallablePureFunction\callCallbackImmediately().
+Possibly impure call to a callable in pure function PureFunction\testThese().
+Possibly impure call to a callable in pure method PureMethod\MaybeCallableFromUnion::doFoo().
+Possibly impure call to function PureFunction\possiblyImpureFunction() in pure function PureFunction\testThese().
+Possibly impure call to method PureMethod\Foo::returningMethod() in pure method PureMethod\Foo::doFoo4().
+Possibly impure call to method PureMethod\Foo::returningMethod() in pure method PureMethod\Foo::doFoo5().
+Possibly impure call to method PureMethod\MaybePureMagicMethods::__toString() in pure method PureMethod\TestMagicMethods::doFoo().
+Possibly impure call to unknown function in pure function PureFunction\testThese().
+Possibly impure call to unknown method in pure method PureMethod\Foo::doFoo4().
+Possibly impure call to unknown method in pure method PureMethod\Foo::doFoo5().
+Possibly impure instantiation of class PureMethod\PossiblyImpureConstructor in pure method PureMethod\TestConstructors::doFoo().
+Possibly impure instantiation of unknown class in pure method PureMethod\TestConstructors::doFoo().
+Possibly impure property assignment by reference in pure method ImpureAssignRef\HelloWorld::bar6().
+Possibly invalid array key type Tk of mixed.
+Possibly invalid array key type array<int, int|string>|int|string.
+Possibly invalid array key type mixed.
+Possibly invalid array key type stdClass|string.
+Private constant ConflictingTraitConstants\Bar2::PUBLIC_CONSTANT overriding public constant ConflictingTraitConstants\Foo::PUBLIC_CONSTANT should also be public.
+Private constant ConflictingTraitConstants\Bar4::PROTECTED_CONSTANT overriding protected constant ConflictingTraitConstants\Foo::PROTECTED_CONSTANT should also be protected.
+Private constant FinalPrivateConstants\User::FINAL_PRIVATE() cannot be final as it is never overridden by other classes.
+Private constant OverridingFinalConstant\PrivateDolor::ANOTHER_PUBLIC_CONST overriding public constant OverridingFinalConstant\Dolor::ANOTHER_PUBLIC_CONST should also be public.
+Private constant OverridingFinalConstant\PrivateDolor::PROTECTED_CONST overriding protected constant OverridingFinalConstant\Dolor::PROTECTED_CONST should be protected or public.
+Private constant OverridingFinalConstant\PrivateDolor::PUBLIC_CONST overriding public constant OverridingFinalConstant\Dolor::PUBLIC_CONST should also be public.
+Private constructor cannot be enforced as consistent for child classes.
+Private method Bug12137\ChildClass::__construct() overriding protected method Bug12137\ParentClass::__construct() should be protected or public.
+Private method FinalPrivateMethodConfigPhpVersions\PhpVersionViaNEONConfg::foo() cannot be final as it is never overridden by other classes.
+Private method FinalPrivateMethodPhpVersions\FooBarBaz::foo() cannot be final as it is never overridden by other classes.
+Private method FinalPrivateMethodPhpVersions\FooBarPhp74OrHigher::foo() cannot be final as it is never overridden by other classes.
+Private method FinalPrivateMethodPhpVersions\FooBarPhp8orHigher::foo() cannot be final as it is never overridden by other classes.
+Private method OverridingFinalMethod\Bar::doBar() overriding public method OverridingFinalMethod\Foo::doBar() should also be public.
+Private method OverridingFinalMethod\Bar::doLorem() overriding protected method OverridingFinalMethod\Foo::doLorem() should be protected or public.
+Private method PrivateAbstractMethod\HelloWorld::sayPrivate() cannot be abstract.
+Private method PrivateAbstractMethod\fooInterface::sayPrivate() cannot be abstract.
+Private property OverridingProperty\PrivateDolor::$anotherPublicFoo overriding public property OverridingProperty\Dolor::$anotherPublicFoo should also be public.
+Private property OverridingProperty\PrivateDolor::$protectedFoo overriding protected property OverridingProperty\Dolor::$protectedFoo should be protected or public.
+Private property OverridingProperty\PrivateDolor::$publicFoo overriding public property OverridingProperty\Dolor::$publicFoo should also be public.
+Promoted properties are not allowed in abstract constructors.
+Promoted properties are supported only on PHP 8.0 and later.
+Promoted properties can be in constructor only.
+Promoted property parameter $i can not be variadic.
+Property AppendedArrayItem\Bar::$stringCallables (array<callable(): string>) does not accept non-empty-array<(callable(): string)|(Closure(): 1)>.
+Property AppendedArrayItem\Baz::$staticProperty (array<AppendedArrayItem\Lorem>) does not accept array<AppendedArrayItem\Baz|AppendedArrayItem\Lorem>.
+Property AppendedArrayItem\Foo::$callables (array<callable(): mixed>) does not accept non-empty-array<array{'AppendedArrayItem\\Foo', 'classMethod'}|(callable(): mixed)>.
+Property AppendedArrayItem\Foo::$callables (array<callable(): mixed>) does not accept non-empty-array<array{'Foo', 'Hello world'}|(callable(): mixed)>.
+Property AppendedArrayItem\Foo::$callables (array<callable(): mixed>) does not accept non-empty-array<array{1, 2, 3}|(callable(): mixed)>.
+Property AppendedArrayItem\Foo::$integers (array<int>) does not accept array<int|string>.
+Property AppendedArrayKey\Foo::$intArray (array<int, mixed>) does not accept array<int|string, mixed>.
+Property AppendedArrayKey\Foo::$stringArray (array<string, mixed>) does not accept array<int|string, mixed>.
+Property AppendedArrayKey\MorePreciseKey::$test (array<1|2|3, string>) does not accept non-empty-array<1|2|3|4, string>.
+Property AppendedArrayKey\MorePreciseKey::$test (array<1|2|3, string>) does not accept non-empty-array<int, string>.
+Property Bug11241\ActualProp::$id is not writable.
+Property Bug11241\MagicProp::$id is not writable.
+Property Bug11241b\HelloWorld::$property1 (bool) does not accept string.
+Property Bug11275\D::$b (list<Bug11275\B>) does not accept array<int|string, Bug11275\B>.
+Property Bug11617\HelloWorld::$params (array<string, string>) does not accept array<int|string, array<mixed>|string>.
+Property Bug11802\HelloWorld::$isFinal is never read, only written.
+Property Bug12131\Test::$array (non-empty-list<int>) does not accept non-empty-array<int<0, max>, int>.
+Property Bug1216PropertyTest\Baz::$untypedBar (string) does not accept int.
+Property Bug1216PropertyTest\Dummy::$foo (Exception) does not accept stdClass.
+Property Bug13438\Test::$queue (non-empty-list<int>) does not accept list<int>.
+Property Bug13438b\Test::$queue (non-empty-list<int>) does not accept list<int>.
+Property Bug13438d\Test::$queue (array{}) does not accept array{1}.
+Property Bug13438e\Test::$queue (array{}) does not accept array{1}.
+Property Bug13438f\Test::$queue (array<int, non-empty-list<int>>) does not accept non-empty-array<int, list<int>>.
+Property Bug14150Properties\HelloWorld::$x (int) does not accept null.
+Property Bug14393\MyClass::$i (int) in isset() is not nullable.
+Property Bug14393\MyClass::$i (int) on left side of ?? is not nullable.
+Property Bug14393\MyClassPhpDoc::$i (int) in isset() is not nullable.
+Property Bug14393\MyClassPhpDoc::$i (int) on left side of ?? is not nullable.
+Property Bug2888\MyClass::$prop (array<int>) does not accept array<int|string>.
+Property Bug3311b\Foo::$bar (list<string>) does not accept non-empty-array<int<0, max>, string>.
+Property Bug3636\Bar::$date is never written, only read.
+Property Bug3703\Foo::$bar (array<string, array<string, array<int>>>) does not accept array<string, array<string, array<int>>|string>.
+Property Bug3703\Foo::$bar (array<string, array<string, array<int>>>) does not accept array<string, array<string, array<int|string>>>.
+Property Bug3703\Foo::$bar (array<string, array<string, array<int>>>) does not accept array<string, array<string, array<int|string>|int>>.
+Property Bug3777\Bar::$foo (Bug3777\Foo<stdClass>) does not accept Bug3777\Fooo<object>.
+Property Bug3777\Ipsum2::$ipsum2 (Bug3777\Lorem2<stdClass, Exception>) does not accept Bug3777\Lorem2<Exception, object>.
+Property Bug3777\Ipsum2::$lorem2 (Bug3777\Lorem2<stdClass, Exception>) does not accept Bug3777\Lorem2<stdClass, object>.
+Property Bug3777\Ipsum3::$ipsum3 (Bug3777\Lorem3<stdClass, Exception>) does not accept Bug3777\Lorem3<Exception, stdClass>.
+Property Bug3777\Ipsum::$ipsum (Bug3777\Lorem<stdClass, Exception>) does not accept Bug3777\Lorem<Exception, stdClass>.
+Property Bug4846\Foo::$alwaysString (string) on left side of ?? is not nullable.
+Property Bug5298\WorldProviderManager::$providers (array<string, Bug5298\WorldProviderManagerEntry<Bug5298\WorldProvider>>) does not accept non-empty-array<string, Bug5298\WorldProviderManagerEntry<Bug5298\WorldProvider>|Bug5298\WorldProviderManagerEntry<T of Bug5298\WorldProvider>>.
+Property Bug5607\Cl::$u (Bug5607\A|null) does not accept default value of type array<int|string, string>.
+Property Bug5804\Blah::$value (array<int>|null) does not accept array<Bug5804\Blah|int>.
+Property Bug5804\Blah::$value (array<int>|null) does not accept array<int|string>.
+Property Bug6286\HelloWorld::$details (array{name: string, age: int}) does not accept array{name: string, age: 'Forty-two'}.
+Property Bug6286\HelloWorld::$nestedDetails (array<array{name: string, age: int}>) does not accept non-empty-array<array{name: string, age: 'Eleventy-one'|int}>.
+Property Bug6356b\HelloWorld2::$details (array{name: string, age: int}) does not accept array{name: string, age: 'Forty-two'}.
+Property Bug6356b\HelloWorld2::$nestedDetails (array<array{name: string, age: int}>) does not accept non-empty-array<array{name: string, age: 'Eleventy-one'|int}>.
+Property Bug6356b\HelloWorld2::$nestedDetails (array<array{name: string, age: int}>) does not accept non-empty-array<array{name: string, age: 'Twelve'|int}>.
+Property Bug7074\SomeModel2::$primaryKey (array<int, string>|string) does not accept default value of type array<int, float>.
+Property Bug7912\A::$has (int<0, 1>) does not accept 999.
+Property CoalesceAssignRule\FooCoalesce::$alwaysNull (null) on left side of ??= is always null.
+Property CoalesceAssignRule\FooCoalesce::$string (string) on left side of ??= is not nullable.
+Property CoalesceRule\FooCoalesce::$alwaysNull (null) on left side of ?? is always null.
+Property CoalesceRule\FooCoalesce::$string (string) on left side of ?? is not nullable.
+Property DefaultValueForNativePropertyType\Foo::$foo (DateTime) does not accept default value of type null.
+Property GenericObjectUnspecifiedTemplateTypes\Bar::$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, string>.
+Property GenericObjectUnspecifiedTemplateTypes\Foo::$obj (GenericObjectUnspecifiedTemplateTypes\MyObject<int, string>) does not accept GenericObjectUnspecifiedTemplateTypes\MyObject<(int|string), mixed>.
+Property IntegerRangesAndConstants\HelloWorld::$i (0|1|3) does not accept int<0, 3>.
+Property IntegerRangesAndConstants\HelloWorld::$x (int<0, 3>) does not accept 0|1|2|3|bool.
+Property IntegerRangesAndConstants\HelloWorld::$x (int<0, 3>) does not accept 0|1|2|3|string.
+Property IntegerRangesAndConstants\HelloWorld::$x (int<0, 3>) does not accept 0|1|3|4.
+Property IntegerRangesAndConstants\HelloWorld::$x (int<0, 3>) does not accept 0|1|3|bool.
+Property InvalidCallablePropertyType\HelloWorld::$a cannot have callable in its type declaration.
+Property InvalidCallablePropertyType\HelloWorld::$b cannot have callable in its type declaration.
+Property InvalidCallablePropertyType\HelloWorld::$c cannot have callable in its type declaration.
+Property InvalidCallablePropertyType\HelloWorld::$callback cannot have callable in its type declaration.
+Property IssetNativePropertyTypes\Foo::$hasDefaultValue (int) in isset() is not nullable.
+Property IssetNativePropertyTypes\Foo::$isAssignedBefore (int) in isset() is not nullable.
+Property IssetOrCoalesceOnNonNullableInitializedProperty\MoreEmptyCases::$false in empty() is always falsy and initialized.
+Property IssetOrCoalesceOnNonNullableInitializedProperty\MoreEmptyCases::$true in empty() is not falsy nor uninitialized.
+Property IssetOrCoalesceOnNonNullableInitializedProperty\User::$string in isset() is not nullable nor uninitialized.
+Property IssetOrCoalesceOnNonNullableInitializedProperty\User::$string on left side of ?? is not nullable nor uninitialized.
+Property IssetRule\FooCoalesce::$alwaysNull (null) in isset() is always null.
+Property IssetRule\FooCoalesce::$string (string) in isset() is not nullable.
+Property MissingPropertyTypehint\Bar::$baz with generic class MissingPropertyTypehint\GenericClass does not specify its types: A, B
+Property MissingPropertyTypehint\Bar::$foo with generic interface MissingPropertyTypehint\GenericInterface does not specify its types: T, U
+Property MissingPropertyTypehint\Baz::$bar with generic class MissingPropertyTypehint\GenericClassWithSomeDefaults does not specify its types: T, U (1-2 required)
+Property MissingPropertyTypehint\CallableSignature::$cb type has no signature specified for callable.
+Property MissingPropertyTypehint\ChildClass::$unionProp type has no value type specified in iterable type array.
+Property MissingPropertyTypehint\MyClass::$prop1 has no type specified.
+Property MissingPropertyTypehint\MyClass::$prop2 has no type specified.
+Property MissingPropertyTypehint\MyClass::$prop3 has no type specified.
+Property MissingPropertyTypehint\NestedArrayInProperty::$args type has no value type specified in iterable type array.
+Property OverridingProperty\TypeChild::$withType overriding property OverridingProperty\Typed::$withType (int) should also have native type int.
+Property OverridingProperty\TypeChild::$withoutType (int) overriding property OverridingProperty\Typed::$withoutType should not have a native type.
+Property PrivatePropertyTagRead\Foo::$foo is not writable.
+Property PrivatePropertyTagWrite\Foo::$foo is not readable.
+Property PrivatePropertyWithTags\Foo::$text is never written, only read.
+Property PrivatePropertyWithTags\Foo::$title is never read, only written.
+Property PromotedPropertiesExistingClasses\Foo::$baz has invalid type PromotedPropertiesExistingClasses\SomeTrait.
+Property PromotedPropertiesExistingClasses\Foo::$dolor has unknown class PromotedPropertiesExistingClasses\Bar as its type.
+Property PromotedPropertiesExistingClasses\Foo::$ipsum has unknown class PromotedPropertiesExistingClasses\Bar as its type.
+Property PromotedPropertiesExistingClasses\Foo::$lorem has invalid type PromotedPropertiesExistingClasses\SomeTrait.
+Property PropertiesAssignedDefaultValuesTypes\Foo::$stringPropertyWithWrongDefaultValue (string) does not accept default value of type int.
+Property PropertiesAssignedTypes\AppendToArrayAccess::$collection2 (ArrayAccess<int, string>&Countable) does not accept Countable.
+Property PropertiesAssignedTypes\AssignRefFoo::$stringProperty (string) does not accept int.
+Property PropertiesAssignedTypes\Foo::$fooProperty (PropertiesAssignedTypes\Foo) does not accept PropertiesAssignedTypes\Bar.
+Property PropertiesAssignedTypes\Foo::$intProperty (int) does not accept string.
+Property PropertiesAssignedTypes\Foo::$stringProperty (string) does not accept int.
+Property PropertiesAssignedTypes\Foo::$unionPropertySelf (array<PropertiesAssignedTypes\Foo>|(iterable<PropertiesAssignedTypes\Foo>&PropertiesAssignedTypes\Collection)) does not accept PropertiesAssignedTypes\Bar.
+Property PropertiesAssignedTypes\Foo::$unionPropertySelf (array<PropertiesAssignedTypes\Foo>|(iterable<PropertiesAssignedTypes\Foo>&PropertiesAssignedTypes\Collection)) does not accept PropertiesAssignedTypes\Foo.
+Property PropertiesAssignedTypes\Foo::$unionPropertySelf (array<PropertiesAssignedTypes\Foo>|(iterable<PropertiesAssignedTypes\Foo>&PropertiesAssignedTypes\Collection)) does not accept array<int, PropertiesAssignedTypes\Bar>.
+Property PropertiesAssignedTypes\Ipsum::$foo (PropertiesAssignedTypes\Ipsum) does not accept PropertiesAssignedTypes\Bar.
+Property PropertiesAssignedTypes\Ipsum::$parentStringProperty (string) does not accept int.
+Property PropertiesAssignedTypes\ListAssign::$foo (string) does not accept int.
+Property PropertiesAssignedTypes\ParamOutAssign::$foo (list<string>) does not accept string.
+Property PropertiesAssignedTypes\ParamOutAssign::$foo2 (list<list<string>>) does not accept non-empty-list<list<string>|string>.
+Property PropertiesAssignedTypes\ParamOutAssign::$foo2 (list<list<string>>) does not accept string.
+Property PropertiesAssignedTypes\PostInc::$bar (int<3, max>) does not accept int<2, max>.
+Property PropertiesAssignedTypes\PostInc::$foo (int<min, 3>) does not accept int<min, 4>.
+Property PropertiesFromArrayIntoObject\Foo::$foo (string) does not accept float.
+Property PropertiesFromArrayIntoObject\Foo::$foo (string) does not accept float|int|string.
+Property PropertiesFromArrayIntoObject\Foo::$lall (int) does not accept string.
+Property PropertiesFromArrayIntoObject\Foo::$test (int|null) does not accept stdClass.
+Property PropertiesFromArrayIntoObject\FooBar::$foo (string) does not accept float.
+Property PropertiesNativeTypes\Foo::$bar has unknown class PropertiesNativeTypes\Bar as its type.
+Property PropertiesNativeTypes\Foo::$baz has unknown class PropertiesNativeTypes\Baz as its type.
+Property PropertiesTypes\Foo::$bar has unknown class PropertiesTypes\Bar as its type.
+Property PropertiesTypes\Foo::$bars has unknown class PropertiesTypes\Bar as its type.
+Property PropertiesTypes\Foo::$dolors has unknown class PropertiesTypes\Dolor as its type.
+Property PropertiesTypes\Foo::$dolors has unknown class PropertiesTypes\Ipsum as its type.
+Property PropertiesTypes\Foo::$fooWithWrongCase has unknown class PropertiesTypes\BAR as its type.
+Property PropertiesTypes\Foo::$fooWithWrongCase has unknown class PropertiesTypes\Fooo as its type.
+Property PropertiesTypes\Foo::$nonexistentClassInGenericObjectType has unknown class PropertiesTypes\Barrrr as its type.
+Property PropertiesTypes\Foo::$nonexistentClassInGenericObjectType has unknown class PropertiesTypes\Foooo as its type.
+Property PropertiesTypes\Foo::$withTrait has invalid type PropertiesTypes\SomeTrait.
+Property PropertyIntersectionTypes\Test::$prop2 has unresolvable native type.
+Property PropertyIntersectionTypes\Test::$prop3 has unresolvable native type.
+Property PropertyOverrideAttr\Bar::$bar has #[\Override] attribute but does not override any property.
+Property PropertyOverrideAttr\Baz::$bar has #[\Override] attribute but does not override any property.
+Property PropertyOverrideAttr\Lorem::$foo overrides property PropertyOverrideAttr\Foo::$foo but is missing the #[\Override] attribute.
+Property PropertyTypeAfterUnset\Foo::$listProp (list<int>) does not accept array<int<0, max>, int>.
+Property PropertyTypeAfterUnset\Foo::$nestedListProp (array<list<int>>) does not accept array<array<int<0, max>, int>>.
+Property PropertyTypeAfterUnset\Foo::$nonEmpty (non-empty-array<int>) does not accept array<int>.
+Property ReadingWriteOnlyProperties\Foo::$writeOnlyProperty is not readable.
+Property TooWidePropertyType\Bar::$c (int|null) is never assigned int so it can be removed from the property type.
+Property TooWidePropertyType\Bar::$d (int|null) is never assigned null so it can be removed from the property type.
+Property TooWidePropertyType\Foo::$barr (int|null) is never assigned null so it can be removed from the property type.
+Property TooWidePropertyType\Foo::$baz (int|null) is never assigned null so it can be removed from the property type.
+Property TooWidePropertyType\Foo::$foo (int|string) is never assigned string so it can be removed from the property type.
+Property UnusedPrivatePromotedProperty\Foo::$lorem is never read, only written.
+Property UnusedPrivateProperty\ArrayAssign::$foo is never read, only written.
+Property UnusedPrivateProperty\Bar::$baz is never written, only read.
+Property UnusedPrivateProperty\DolorWithAnonymous::$foo is unused.
+Property UnusedPrivateProperty\Foo::$bar is never read, only written.
+Property UnusedPrivateProperty\Foo::$baz is unused.
+Property UnusedPrivateProperty\Foo::$lorem is never written, only read.
+Property UnusedPrivateProperty\ListAssign::$foo is never read, only written.
+Property UnusedPrivateProperty\Lorem::$baz is never read, only written.
+Property UnusedPrivateProperty\TestExtension::$read is never written, only read.
+Property UnusedPrivateProperty\TestExtension::$unused is unused.
+Property UnusedPrivateProperty\TestExtension::$written is never read, only written.
+Property WritingToReadOnlyProperties\Foo::$readOnlyProperty is not writable.
+Property WritingToReadOnlyProperties\Foo::$usualProperty (int) does not accept string.
+Property WritingToReadOnlyProperties\Foo::$writeOnlyProperty (int) does not accept string.
+Property WritingToReadOnlyProperties\Foo::$writeOnlyProperty is not readable.
+Property class@anonymous/tests/PHPStan/Rules/DeadCode/data/unused-private-property.php:152::$bar is unused.
+Property hooks are supported only on PHP 8.4 and later.
+Property name for $this(DynamicStringableAccess\Foo) must be a string, but $this(DynamicStringableAccess\Foo) was given.
+Property name for $this(DynamicStringableAccess\Foo) must be a string, but array was given.
+Property name for $this(DynamicStringableNullsafeAccess\Foo) must be a string, but $this(DynamicStringableNullsafeAccess\Foo) was given.
+Property name for DynamicStringableAccess\Foo must be a string, but $this(DynamicStringableAccess\Foo) was given.
+Property name for DynamicStringableNullsafeAccess\Foo must be a string, but $this(DynamicStringableNullsafeAccess\Foo) was given.
+Property object{foo: int, bar?: string}::$foo is not writable.
+Property object{foo: int}|stdClass::$foo is not writable.
+Protected constant ConflictingTraitConstants\Bar5::PRIVATE_CONSTANT overriding private constant ConflictingTraitConstants\Foo::PRIVATE_CONSTANT should also be private.
+Protected constant ConflictingTraitConstants\Bar::PUBLIC_CONSTANT overriding public constant ConflictingTraitConstants\Foo::PUBLIC_CONSTANT should also be public.
+Protected constant OverridingFinalConstant\ProtectedDolor::ANOTHER_PUBLIC_CONST overriding public constant OverridingFinalConstant\Dolor::ANOTHER_PUBLIC_CONST should also be public.
+Protected constant OverridingFinalConstant\ProtectedDolor::PUBLIC_CONST overriding public constant OverridingFinalConstant\Dolor::PUBLIC_CONST should also be public.
+Protected method OverridingFinalMethod\Bar::doBaz() overriding public method OverridingFinalMethod\Foo::doBaz() should also be public.
+Protected property OverridingProperty\ProtectedDolor::$anotherPublicFoo overriding public property OverridingProperty\Dolor::$anotherPublicFoo should also be public.
+Protected property OverridingProperty\ProtectedDolor::$publicFoo overriding public property OverridingProperty\Dolor::$publicFoo should also be public.
+Public constant ConflictingTraitConstants\Bar3::PROTECTED_CONSTANT overriding protected constant ConflictingTraitConstants\Foo::PROTECTED_CONSTANT should also be protected.
+Public constant ConflictingTraitConstants\Bar6::PRIVATE_CONSTANT overriding private constant ConflictingTraitConstants\Foo::PRIVATE_CONSTANT should also be private.
+Readonly class ExtendsReadOnlyClass\Foo extends non-readonly class ExtendsReadOnlyClass\Nonreadonly.
+Readonly properties are supported only on PHP 8.1 and later.
+Readonly property Bug10523\MultipleWrites::$userAccount is already assigned.
+Readonly property Bug6773\Repository::$data is assigned outside of the constructor.
+Readonly property Bug8101\B::$myProp is already assigned.
+Readonly property Bug9863\ReadonlyChildWithoutIsset::$foo is already assigned.
+Readonly property Feature7648\Request::$offset is assigned outside of the constructor.
+Readonly property MissingReadOnlyPropertyAssign\AdditionalAssignOfReadonlyPromotedProperty::$x is already assigned.
+Readonly property MissingReadOnlyPropertyAssign\Foo::$doubleAssigned is already assigned.
+Readonly property MissingReadOnlyPropertyAssign\FooTraitClass::$doubleAssigned is already assigned.
+Readonly property OverridingProperty\ReadonlyChild2::$readWrite overrides readwrite property OverridingProperty\ReadonlyParent::$readWrite.
+Readonly property OverridingProperty\ReadonlyChild::$readWrite overrides readwrite property OverridingProperty\ReadonlyParent::$readWrite.
+Readonly property ReadOnlyPropertyAssignRef\Foo::$bar is assigned by reference.
+Readonly property ReadOnlyPropertyAssignRef\Foo::$foo is assigned by reference.
+Readonly property ReadonlyClassPropertyAssign\Foo::$foo is assigned outside of the constructor.
+Readonly property ReadonlyPropertyAssign\ArrayAccessPropertyFetch::$storage is assigned outside of the constructor.
+Readonly property ReadonlyPropertyAssign\Foo::$bar is assigned outside of its declaring class.
+Readonly property ReadonlyPropertyAssign\Foo::$baz is assigned outside of its declaring class.
+Readonly property ReadonlyPropertyAssign\Foo::$foo is assigned outside of the constructor.
+Readonly property ReadonlyPropertyAssign\FooArrays::$details is assigned outside of the constructor.
+Readonly property ReadonlyPropertyAssign\ListAssign::$foo is assigned outside of the constructor.
+Readonly property ReadonlyPropertyAssign\NotThis::$foo is not assigned on $this.
+Readonly property ReadonlyPropertyAssign\PostInc::$foo is assigned outside of the constructor.
+Readonly property RedeclarePropertyOfReadonlyClass\B1::$promotedProp is already assigned.
+Readonly property RedeclareReadonlyProperty\A@anonymous/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php:117::$myProp is already assigned.
+Readonly property RedeclareReadonlyProperty\B1::$myProp is already assigned.
+Readonly property RedeclareReadonlyProperty\B5::$myProp is already assigned.
+Readonly property RedeclareReadonlyProperty\B7::$myProp is already assigned.
+Readonly property cannot be static.
+Readonly property cannot have a default value.
+Readonly property must have a native type.
+Readwrite property OverridingProperty\ReadonlyChild2::$readOnly overrides readonly property OverridingProperty\ReadonlyParent::$readOnly.
+Readwrite property OverridingProperty\ReadonlyChild::$readOnly overrides readonly property OverridingProperty\ReadonlyParent::$readOnly.
+Redefinition of parameter $bar.
+Redefinition of parameter $baz.
+Redefinition of parameter $foo.
+Referencing prefixed Box class: _HumbugBox02f3b3909847\AClass.
+Referencing prefixed Doctrine class: App\GeneratedProxy\__CG__\App\TestDoctrineEntity.
+Referencing prefixed PHP-Scoper class: _PhpScoper19ae93be897e\AClass.
+Referencing prefixed PHPStan class: _PHPStan_156ee64ba\AClass.
+Referencing prefixed PHPStan class: _PHPStan_156ee64ba\PrefixedRuntimeException.
+Referencing prefixed PHPStan class: _PHPStan_15755dag8c\TestPhpStanEntity.
+Referencing prefixed PHPUnit class: PHPUnitPHAR\SebastianBergmann\Diff\Exception.
+Referencing prefixed Rector class: RectorPrefix202302\AClass.
+Regex pattern is invalid: Compilation failed: missing closing parenthesis at offset 1 in pattern: ~(~
+Regex pattern is invalid: Compilation failed: missing closing parenthesis at offset 7 in pattern: ~((?:.*)~
+Regex pattern is invalid: Delimiter must not be alphanumeric, backslash, or NUL in pattern: nok
+Regex pattern is invalid: Delimiter must not be alphanumeric, backslash, or NUL in pattern: nok(?:.*)
+Regex pattern is invalid: Delimiter must not be alphanumeric, backslash, or NUL in pattern: nok(?:.*)nono
+Regex pattern is invalid: Delimiter must not be alphanumeric, backslash, or NUL in pattern: nok(?:.*)nope
+Regex pattern is invalid: Unknown modifier 'y' in pattern: /(foo)(bar)(baz)/xyz
+Regular method call detected
+Regular property fetch detected
+Result of && is always false.
+Result of && is always true.
+Result of and is always false.
+Result of and is always true.
+Result of callable passed to call_user_func() (void) is used.
+Result of callable passed to call_user_func_array() (void) is used.
+Result of closure (void) is used.
+Result of match expression (void) is used.
+Result of method Closure::call() (void) is used.
+Result of method MatchExprVoidUsed\Foo::doBar() (void) is used.
+Result of method MatchExprVoidUsed\Foo::doLorem() (void) is used.
+Result of method Test\Bar::returnsVoid() (void) is used.
+Result of method Test\ReturningSomethingFromConstructor::__construct() (void) is used.
+Result of or is always true.
+Result of yield (void) is used.
+Result of yield from (void) is used.
+Result of || is always true.
+Return type (($p is int ? stdClass : string)) of method OverridenMethodWithConditionalReturnType\Bar2::doFoo() should be compatible with return type (($p is int ? int : string)) of method OverridenMethodWithConditionalReturnType\Foo::doFoo()
+Return type (Bug3523\Baz) of method Bug3523\Baz::deserialize() should be covariant with return type (static(Bug3523\FooInterface)) of method Bug3523\FooInterface::deserialize()
+Return type (MethodSignature\Animal) of method MethodSignature\SubClass::returnTypeTest4() should be covariant with return type (MethodSignature\Dog) of method MethodSignature\BaseClass::returnTypeTest4()
+Return type (MethodSignature\Animal) of method MethodSignature\SubClass::returnTypeTest4() should be covariant with return type (MethodSignature\Dog) of method MethodSignature\BaseInterface::returnTypeTest4()
+Return type (MethodSignature\Animal) of method MethodSignature\SubClassUsingTrait::returnTypeTest4() should be covariant with return type (MethodSignature\Dog) of method MethodSignature\BaseClass::returnTypeTest4()
+Return type (MethodSignature\Animal) of method MethodSignature\SubClassUsingTrait::returnTypeTest4() should be covariant with return type (MethodSignature\Dog) of method MethodSignature\BaseInterface::returnTypeTest4()
+Return type (MethodSignature\Cat) of method MethodSignature\SubClass::returnTypeTest5() should be compatible with return type (MethodSignature\Dog) of method MethodSignature\BaseClass::returnTypeTest5()
+Return type (MethodSignature\Cat) of method MethodSignature\SubClass::returnTypeTest5() should be compatible with return type (MethodSignature\Dog) of method MethodSignature\BaseInterface::returnTypeTest5()
+Return type (MethodSignature\Cat) of method MethodSignature\SubClassUsingTrait::returnTypeTest5() should be compatible with return type (MethodSignature\Dog) of method MethodSignature\BaseClass::returnTypeTest5()
+Return type (MethodSignature\Cat) of method MethodSignature\SubClassUsingTrait::returnTypeTest5() should be compatible with return type (MethodSignature\Dog) of method MethodSignature\BaseInterface::returnTypeTest5()
+Return type (array<PHPStan\Rules\IdentifierRuleError>) of method RuleErrorSignature\Dolor::processNode() should be covariant with return type (list<PHPStan\Rules\IdentifierRuleError>) of method PHPStan\Rules\Rule<PhpParser\Node>::processNode()
+Return type (array<PHPStan\Rules\RuleError>) of method RuleErrorSignature\Ipsum::processNode() should be covariant with return type (list<PHPStan\Rules\IdentifierRuleError>) of method PHPStan\Rules\Rule<PhpParser\Node>::processNode()
+Return type (array<PHPStan\Rules\RuleError|string>) of method RuleErrorSignature\Baz::processNode() should be covariant with return type (list<PHPStan\Rules\IdentifierRuleError>) of method PHPStan\Rules\Rule<PhpParser\Node>::processNode()
+Return type (array<int, string>) of method ListReturnTypeCovariance\ListChild::returnsList() should be covariant with return type (list<string>) of method ListReturnTypeCovariance\ListParent::returnsList()
+Return type (array<string>) of method RuleErrorSignature\Lorem::processNode() should be compatible with return type (list<PHPStan\Rules\IdentifierRuleError>) of method PHPStan\Rules\Rule<PhpParser\Node>::processNode()
+Return type (int) of method Bug3997\Baz::count() should be covariant with return type (int<0, max>) of method Countable::count()
+Return type (int) of method Bug3997\Lorem::count() should be covariant with return type (int<0, max>) of method Countable::count()
+Return type (list<Bug4707Covariant\Row2>) of method Bug4707Covariant\Block2::getChildren() should be covariant with return type (list<Bug4707Covariant\ChildNodeInterface<static(Bug4707Covariant\ParentNodeInterface)>>) of method Bug4707Covariant\ParentNodeInterface::getChildren()
+Return type (list<Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be compatible with return type (list<Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()
+Return type (string) of method Bug3997\Ipsum::count() should be compatible with return type (int<0, max>) of method Countable::count()
+Return type (string) of method Bug4003\Baz::foo() should be compatible with return type (int) of method Bug4003\Boo::foo()
+Return type Bug10153\MyClass2|null of method Bug10153\MyClass2::drc() is not covariant with return type Bug10153\MyClass2 of method Bug10153\MyTrait::drc().
+Return type Bug10166\ReturnTypeClass2|null of method Bug10166\ReturnTypeClass2::createSelf() is not covariant with return type Bug10166\ReturnTypeClass2 of method Bug10166\ReturnTypeTrait::createSelf().
+Return type Exception of method ReturnTypeCovariance\Bar::doLorem() is not compatible with return type InvalidArgumentException of method ReturnTypeCovariance\Foo::doLorem().
+Return type Exception of method ReturnTypeCovariance\Bar::doLorem() is not covariant with return type InvalidArgumentException of method ReturnTypeCovariance\Foo::doLorem().
+Return type InvalidArgumentException of method ReturnTypeCovariance\Bar::doBaz() is not compatible with return type Exception of method ReturnTypeCovariance\Foo::doBaz().
+Return type array<array{int, bool}> of function NestedTooWideFunctionReturnType\dataProvider() can be narrowed to array<array{int, false}>.
+Return type array<array{int, bool}> of method NestedTooWideMethodReturnType\Foo::dataProvider() can be narrowed to array<array{int, false}>.
+Return type array<array{int|null}> of method NestedTooWideMethodReturnType\Foo::dataProvider2() can be narrowed to array<array{int}>.
+Return type array<string, bool|int|string> of method NestedTooWideMethodReturnType\WebhookTest::dataTest() can be narrowed to array<string, int|string|true>.
+Return type iterable of method ReturnTypeCovariance\Bar::doBar() is not compatible with return type array of method ReturnTypeCovariance\Foo::doBar().
+Return type iterable of method ReturnTypeCovariance\Bar::doBar() is not covariant with return type array of method ReturnTypeCovariance\Foo::doBar().
+Return type mixed of method Bug10101\B::next() is not covariant with return type void of method Bug10101\A::next().
+Return type mixed of method Bug7652\Options::offsetGet() is not covariant with tentative return type mixed of method ArrayAccess<key-of<TArray of array>,value-of<TArray of array>>::offsetGet().
+Return type mixed of method Bug8081\three::foo() is not covariant with return type array of method Bug8081\two::foo().
+Return type mixed of method Bug8500\DBOHB::test() is not covariant with return type Bug8500\DBOA of method Bug8500\DBOHA::test().
+Return type mixed of method Bug9014\extended::renderForUser() is not covariant with return type string of method Bug9014\middle::renderForUser().
+Return type mixed of method Bug9615\ExpectComplaintsHere::accept() is not covariant with tentative return type bool of method FilterIterator<mixed,mixed,Traversable<mixed, mixed>>::accept().
+Return type mixed of method Bug9615\ExpectComplaintsHere::getChildren() is not covariant with tentative return type RecursiveIterator|null of method RecursiveIterator<mixed,mixed>::getChildren().
+Return type mixed of method OverridingIndirectPrototype\Baz::doFoo() is not covariant with return type string of method OverridingIndirectPrototype\Bar::doFoo().
+Return type mixed of method ReturnTypeCovariance\B::foo() is not compatible with return type stdClass|null of method ReturnTypeCovariance\A::foo().
+Return type mixed of method ReturnTypeCovariance\B::foo() is not covariant with return type stdClass|null of method ReturnTypeCovariance\A::foo().
+Return type mixed of method TentativeReturnTypes\Foo::getIterator() is not covariant with tentative return type Traversable of method IteratorAggregate<mixed,mixed>::getIterator().
+Return type mixed of method TentativeReturnTypes\UntypedIterator::current() is not covariant with tentative return type mixed of method Iterator<mixed,mixed>::current().
+Return type mixed of method TentativeReturnTypes\UntypedIterator::key() is not covariant with tentative return type mixed of method Iterator<mixed,mixed>::key().
+Return type mixed of method TentativeReturnTypes\UntypedIterator::next() is not covariant with tentative return type void of method Iterator<mixed,mixed>::next().
+Return type mixed of method TentativeReturnTypes\UntypedIterator::rewind() is not covariant with tentative return type void of method Iterator<mixed,mixed>::rewind().
+Return type mixed of method TentativeReturnTypes\UntypedIterator::valid() is not covariant with tentative return type bool of method Iterator<mixed,mixed>::valid().
+Return type of call to method GenericReturnTypeNever\Foo::doBar() contains unresolvable type.
+Return type of call to method GenericReturnTypeNever\Foo::doBazBaz() contains unresolvable type.
+Return type string of method OverridingParle\Foo::pushState() is not compatible with return type int of method Parle\RLexer::pushState().
+Return type string of method OverridingParle\Foo::pushState() is not covariant with return type int of method Parle\RLexer::pushState().
+Return type string of method TentativeReturnTypes\Lorem::getIterator() is not covariant with tentative return type Traversable of method IteratorAggregate<mixed,mixed>::getIterator().
+Return value of function print_r() is always true and the result is printed instead of being returned. Pass in true as parameter #2 $return to return the output instead.
+Return value of function var_export() is always null and the result is printed instead of being returned. Pass in true as parameter #2 $return to return the output instead.
+Right side of && is always false.
+Right side of && is always true.
+Right side of and is always false.
+Right side of and is always true.
+Right side of or is always false.
+Right side of or is always true.
+Right side of xor is always false.
+Right side of xor is always true.
+Right side of || is always false.
+Right side of || is always true.
+Scope is empty
+ScopeFunctionCallStack\NamedArgumentTest::testMethod
+ScopeFunctionCallStack\NamedArgumentTest::testMethod ($notImmediate)
+Self-out type IncompatibleSelfOutType\A|null of method IncompatibleSelfOutType\A::four is not subtype of IncompatibleSelfOutType\A.
+Self-out type int of method IncompatibleSelfOutType\A::three is not subtype of IncompatibleSelfOutType\A.
+Static access to instance property AccessWithStatic::$bar.
+Static access to instance property Bug8668Bis\Sample2::$sample.
+Static access to instance property Bug8668Bis\Sample::$sample.
+Static access to instance property ClassOrString::$instanceProperty.
+Static access to instance property FooAccessStaticProperties::$loremIpsum.
+Static access to instance property ParentClassWithInstanceProperty::$i.
+Static call to instance method CallStaticMethods\Foo::loremIpsum().
+Static call to instance method CallStaticMethods\InterfaceWithStaticMethod::doInstanceFoo().
+Static call to instance method StaticCallsToInstanceMethods\Bar::doBar().
+Static call to instance method StaticCallsToInstanceMethods\Foo::doFoo().
+Static call to instance method StaticMethodCallable\Foo::doBar().
+Static method Bug3641\Foo::bar() invoked with 1 parameter, 0 required.
+Static method CallStaticMethods\ClassOrString::calledMethod() invoked with 1 parameter, 0 required.
+Static method CallStaticMethods\Foo::test() invoked with 1 parameter, 0 required.
+Static method CallStaticMethods\Foo::test() invoked with 3 parameters, 0 required.
+Static method Locale::getDisplayLanguage() invoked with 3 parameters, 1-2 required.
+Static method OverridingFinalMethod\Bar::doDolor() overrides non-static method OverridingFinalMethod\Foo::doDolor().
+Static method OverridingTraitMethods\Ipsum::doBar() overrides non-static method OverridingTraitMethods\Foo::doBar().
+Static method UnusedPrivateMethod\Foo::unusedStaticMethod() is unused.
+Static property Bug13384Phpdoc\ShutdownHandlerPhpdocTypes::$registered (bool) is never assigned true so the property type can be changed to false.
+Static property Bug13384\ShutdownHandlerFalseDefault::$registered (bool) is never assigned true so the property type can be changed to false.
+Static property Bug13384\ShutdownHandlerTrueDefault::$registered (bool) is never assigned false so the property type can be changed to true.
+Static property Bug14393\MyClassStatic::$i (int) in isset() is not nullable.
+Static property Bug14393\MyClassStatic::$i (int) on left side of ?? is not nullable.
+Static property Bug3777Static\Bar::$foo (Bug3777Static\Foo<stdClass>) does not accept Bug3777Static\Fooo<object>.
+Static property Bug3777Static\Ipsum2::$ipsum2 (Bug3777Static\Lorem2<stdClass, Exception>) does not accept Bug3777Static\Lorem2<Exception, object>.
+Static property Bug3777Static\Ipsum2::$lorem2 (Bug3777Static\Lorem2<stdClass, Exception>) does not accept Bug3777Static\Lorem2<stdClass, object>.
+Static property Bug3777Static\Ipsum3::$ipsum3 (Bug3777Static\Lorem3<stdClass, Exception>) does not accept Bug3777Static\Lorem3<Exception, stdClass>.
+Static property Bug3777Static\Ipsum::$ipsum (Bug3777Static\Lorem<stdClass, Exception>) does not accept Bug3777Static\Lorem<Exception, stdClass>.
+Static property Bug9384\Deprecation::$type (int<0, 3>) does not accept 10|11.
+Static property CoalesceAssignRule\FooCoalesce::$staticAlwaysNull (null) on left side of ??= is always null.
+Static property CoalesceAssignRule\FooCoalesce::$staticString (string) on left side of ??= is not nullable.
+Static property CoalesceRule\FooCoalesce::$staticAlwaysNull (null) on left side of ?? is always null.
+Static property CoalesceRule\FooCoalesce::$staticString (string) on left side of ?? is not nullable.
+Static property IssetRule\FooCoalesce::$staticAlwaysNull (null) in isset() is always null.
+Static property IssetRule\FooCoalesce::$staticString (string) in isset() is not nullable.
+Static property OverridingProperty\Bar::$protectedFoo overrides non-static property OverridingProperty\Foo::$protectedFoo.
+Static property OverridingProperty\Bar::$publicFoo overrides non-static property OverridingProperty\Foo::$publicFoo.
+Static property PropertiesAssignedDefaultValuesTypes\Foo::$staticStringPropertyWithWrongDefaultValue (string) does not accept default value of type int.
+Static property PropertiesAssignedDefaultValuesTypes\Foo::$windowsNtVersions (array<string, string>) does not accept default value of type array<int|string, string>.
+Static property PropertiesAssignedTypes\Foo::$staticStringProperty (string) does not accept int.
+Static property PropertiesAssignedTypes\Ipsum::$fooStatic (PropertiesAssignedTypes\Ipsum) does not accept PropertiesAssignedTypes\Bar.
+Static property PropertiesAssignedTypes\Ipsum::$parentStaticStringProperty (string) does not accept int.
+Static property PropertiesFromArrayIntoStaticObject\Foo::$foo (string) does not accept float.
+Static property PropertiesFromArrayIntoStaticObject\Foo::$lall (stdClass|null) does not accept string.
+Static property PropertiesFromArrayIntoStaticObject\FooBar::$foo (string) does not accept float.
+Static property UnusedPrivateProperty\Baz::$bar is never read, only written.
+Static property UnusedPrivateProperty\Baz::$baz is unused.
+Static property UnusedPrivateProperty\Baz::$lorem is never written, only read.
+Static variable needs to be typed with PHPDoc @var tag.
+Strict comparison using !== between 'AB' and lowercase-string will always evaluate to true.
+Strict comparison using !== between 'Bug3633\\FinalClass' and 'Bug3633\\FinalClass' will always evaluate to false.
+Strict comparison using !== between 'ab' and uppercase-string will always evaluate to true.
+Strict comparison using !== between 1 and '1' will always evaluate to true.
+Strict comparison using !== between INF and INF will always evaluate to false.
+Strict comparison using !== between NAN and NAN will always evaluate to true.
+Strict comparison using !== between StrictComparison\Foo|null and 1 will always evaluate to true.
+Strict comparison using !== between StrictComparison\Node|null and false will always evaluate to true.
+Strict comparison using !== between array{1, mixed, 3} and array{int, null, int} will always evaluate to true.
+Strict comparison using !== between array{test: 1} and array{test: 1} will always evaluate to false.
+Strict comparison using !== between array{test: 1} and array{test: 5} will always evaluate to true.
+Strict comparison using !== between lowercase-string and 'aBc' will always evaluate to true.
+Strict comparison using !== between mixed and 1 will always evaluate to true.
+Strict comparison using !== between mixed and null will always evaluate to true.
+Strict comparison using !== between null and null will always evaluate to false.
+Strict comparison using !== between null and string will always evaluate to true.
+Strict comparison using !== between stdClass and null will always evaluate to true.
+Strict comparison using !== between string and null will always evaluate to true.
+Strict comparison using !== between uppercase-string and 'aBc' will always evaluate to true.
+Strict comparison using === between $this(Bug9142\MyEnum) and Bug9142\MyEnum::Three will always evaluate to false.
+Strict comparison using === between '/'|'\\' and '//' will always evaluate to false.
+Strict comparison using === between '0' and non-falsy-string will always evaluate to false.
+Strict comparison using === between '18446744073709551615' and '9223372036854775807' will always evaluate to false.
+Strict comparison using === between 'AB' and lowercase-string will always evaluate to false.
+Strict comparison using === between 'Bug3633\\FinalClass' and 'Bug3633\\FinalClass' will always evaluate to true.
+Strict comparison using === between 'Bug3633\\FinalClass' and 'Bug3633\\HelloWorld' will always evaluate to false.
+Strict comparison using === between 'Bug3633\\FinalClass' and 'Bug3633\\OtherClass' will always evaluate to false.
+Strict comparison using === between 'Bug3633\\HelloWorld' and 'Bug3633\\HelloWorld' will always evaluate to true.
+Strict comparison using === between 'Bug3633\\HelloWorld' and 'Bug3633\\OtherClass' will always evaluate to false.
+Strict comparison using === between 'Bug3633\\OtherClass' and 'Bug3633\\HelloWorld' will always evaluate to false.
+Strict comparison using === between 'Bug3633\\OtherClass' and 'Bug3633\\OtherClass' will always evaluate to true.
+Strict comparison using === between 'ab' and uppercase-string will always evaluate to false.
+Strict comparison using === between 'bar' and 'bar' will always evaluate to true.
+Strict comparison using === between 'bbb' and 'bbb' will always evaluate to true.
+Strict comparison using === between 'foo' and 'foo' will always evaluate to true.
+Strict comparison using === between 'foofoofoofoofoofoof…' and 'foofoofoofoofoofoof…' will always evaluate to true.
+Strict comparison using === between (int<min, 0>|int<2, max>|string) and 1.0 will always evaluate to false.
+Strict comparison using === between (int<min, 0>|int<2, max>|string) and stdClass will always evaluate to false.
+Strict comparison using === between (lowercase-string&non-falsy-string)|(non-falsy-string&numeric-string) and 'A' will always evaluate to false.
+Strict comparison using === between (lowercase-string&non-falsy-string)|false and 'ABC' will always evaluate to false.
+Strict comparison using === between *NEVER* and 'ccc' will always evaluate to false.
+Strict comparison using === between 0 and 0 will always evaluate to true.
+Strict comparison using === between 0 and 1|2 will always evaluate to false.
+Strict comparison using === between 1 and '1' will always evaluate to false.
+Strict comparison using === between 1 and 1 will always evaluate to true.
+Strict comparison using === between 1 and 1.0 will always evaluate to false.
+Strict comparison using === between 1 and 2 will always evaluate to false.
+Strict comparison using === between 1 and array<StrictComparison\Foo>|bool|StrictComparison\Collection will always evaluate to false.
+Strict comparison using === between 1 and null will always evaluate to false.
+Strict comparison using === between 1.0 and 1 will always evaluate to false.
+Strict comparison using === between 100 and 'foo' will always evaluate to false.
+Strict comparison using === between 1000 and 1000 will always evaluate to true.
+Strict comparison using === between 1|2|3 and null will always evaluate to false.
+Strict comparison using === between 2 and 2 will always evaluate to true.
+Strict comparison using === between Bug8485\E::c and Bug8485\E::c will always evaluate to true.
+Strict comparison using === between Bug8485\F and Bug8485\E will always evaluate to false.
+Strict comparison using === between Bug8485\F and Bug8485\E::c will always evaluate to false.
+Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.
+Strict comparison using === between Bug8485\FooEnum::C and Bug8485\FooEnum::C will always evaluate to true.
+Strict comparison using === between Bug9142\MyEnum and Bug9142\MyEnum::Three will always evaluate to false.
+Strict comparison using === between INF and INF will always evaluate to true.
+Strict comparison using === between NAN and NAN will always evaluate to false.
+Strict comparison using === between StrictComparisonEnumTips\SomeEnum::Two and StrictComparisonEnumTips\SomeEnum::Two will always evaluate to true.
+Strict comparison using === between StrictComparison\Bar and 1 will always evaluate to false.
+Strict comparison using === between array{X: 1, Y: 2} and array{X: 2, Y: 1} will always evaluate to false.
+Strict comparison using === between array{X: 1, Y: 2} and array{Y: 2, X: 1} will always evaluate to false.
+Strict comparison using === between array{X: 1} and array{X: 2} will always evaluate to false.
+Strict comparison using === between class-string<$this(Bug3633\FinalClass)> and 'Bug3633\\HelloWorld' will always evaluate to false.
+Strict comparison using === between class-string<$this(Bug3633\FinalClass)> and 'Bug3633\\OtherClass' will always evaluate to false.
+Strict comparison using === between class-string<$this(Bug3633\HelloWorld)> and 'Bug3633\\OtherClass' will always evaluate to false.
+Strict comparison using === between class-string<$this(Bug3633\OtherClass)> and 'Bug3633\\HelloWorld' will always evaluate to false.
+Strict comparison using === between false and true will always evaluate to false.
+Strict comparison using === between float and 'string' will always evaluate to false.
+Strict comparison using === between int<0, 1> and 100 will always evaluate to false.
+Strict comparison using === between int<0, max> and 'string' will always evaluate to false.
+Strict comparison using === between int<1, max> and 'string' will always evaluate to false.
+Strict comparison using === between int<1, max> and 0 will always evaluate to false.
+Strict comparison using === between int<10, max> and 'foo' will always evaluate to false.
+Strict comparison using === between lowercase-string and 'AB' will always evaluate to false.
+Strict comparison using === between lowercase-string and 'aBc' will always evaluate to false.
+Strict comparison using === between lowercase-string&non-falsy-string and 'ABC' will always evaluate to false.
+Strict comparison using === between lowercase-string|false and 'AB' will always evaluate to false.
+Strict comparison using === between mixed and 'foo' will always evaluate to false.
+Strict comparison using === between mixed and array{INF} will always evaluate to false.
+Strict comparison using === between mixed and null will always evaluate to false.
+Strict comparison using === between non-empty-array and null will always evaluate to false.
+Strict comparison using === between non-empty-list<string|null> and null will always evaluate to false.
+Strict comparison using === between non-empty-string and false will always evaluate to false.
+Strict comparison using === between non-empty-string and null will always evaluate to false.
+Strict comparison using === between null and null will always evaluate to true.
+Strict comparison using === between null and string will always evaluate to false.
+Strict comparison using === between string and false will always evaluate to false.
+Strict comparison using === between string and null will always evaluate to false.
+Strict comparison using === between string|null and 1 will always evaluate to false.
+Strict comparison using === between true and false will always evaluate to false.
+Strict comparison using === between uppercase-string and 'aBc' will always evaluate to false.
+Strict comparison using === between uppercase-string and 'ab' will always evaluate to false.
+Superglobal variable $GLOBALS cannot be used as a parameter.
+Superglobal variable $_COOKIE cannot be used as a parameter.
+Superglobal variable $_ENV cannot be used as a parameter.
+Superglobal variable $_FILES cannot be used as a parameter.
+Superglobal variable $_GET cannot be used as a parameter.
+Superglobal variable $_POST cannot be used as a parameter.
+Superglobal variable $_REQUEST cannot be used as a parameter.
+Superglobal variable $_SERVER cannot be used as a parameter.
+Superglobal variable $_SESSION cannot be used as a parameter.
+Template type A is declared as covariant, but occurs in contravariant position in parameter fn of method Bug10609\Collection::tap().
+Template type S of function ParamOutTemplate\uselessGeneric() is not referenced in a parameter.
+Template type T is declared as contravariant, but occurs in covariant position in extended type ClassAncestorsExtends\FooGeneric8<T, T> of class ClassAncestorsExtends\FooGeneric10.
+Template type T is declared as contravariant, but occurs in invariant position in extended type ClassAncestorsExtends\FooGeneric8<T, T> of class ClassAncestorsExtends\FooGeneric10.
+Template type T is declared as covariant, but occurs in contravariant position in parameter items of method Bug8880\IProcessor::processItems().
+Template type T is declared as covariant, but occurs in invariant position in extended type ClassAncestorsExtends\FooGeneric8<T, T> of class ClassAncestorsExtends\FooGeneric9.
+Template type T is declared as covariant, but occurs in invariant position in extended type InterfaceAncestorsExtends\FooGeneric9<T, T> of interface InterfaceAncestorsExtends\FooGeneric10.
+Template type T is declared as covariant, but occurs in invariant position in implemented type ClassAncestorsImplements\FooGeneric9<T, T> of class ClassAncestorsImplements\FooGeneric10.
+Template type T is declared as covariant, but occurs in invariant position in parameter thing of method Pr2465\UnitOfTest::foo().
+Template type T of function FunctionConditionalReturnType\notGet() is not referenced in a parameter.
+Template type T of function TestFunctionTypehints\templateTypeMissingInParameter() is not referenced in a parameter.
+Template type T of method MethodConditionalReturnType\Container::notGet() is not referenced in a parameter.
+Template type T of method ParamOutTemplate\FooBar::uselessLocalTemplate() is not referenced in a parameter.
+Template type U of method Bug4641\I::getRepository() is not referenced in a parameter.
+Template type U of method TestMethodTypehints\TemplateTypeMissingInParameter::doFoo() is not referenced in a parameter.
+Template type X is declared as contravariant, but occurs in covariant position in param-out type of parameter a of method MethodSignatureVariance\Contravariant\C::paramOut().
+Template type X is declared as contravariant, but occurs in covariant position in parameter b of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in covariant position in parameter b of method MethodSignatureVariance\StaticMethod\C::a().
+Template type X is declared as contravariant, but occurs in covariant position in parameter d of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in covariant position in parameter g of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\C::$a.
+Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\C::$c.
+Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\D::$a.
+Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::b().
+Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::d().
+Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::g().
+Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::i().
+Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\StaticMethod\C::b().
+Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\StaticMethod\C::d().
+Template type X is declared as contravariant, but occurs in invariant position in parameter e of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in invariant position in parameter i of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in invariant position in parameter j of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in invariant position in parameter k of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in invariant position in parameter l of method MethodSignatureVariance\Contravariant\C::a().
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$a.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$b.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$c.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$d.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$a.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$b.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$c.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$d.
+Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\ReadOnly\C::$d.
+Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::f().
+Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::j().
+Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::k().
+Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::l().
+Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::m().
+Template type X is declared as covariant, but occurs in contravariant position in parameter a of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in contravariant position in parameter a of method MethodSignatureVariance\StaticMethod\B::a().
+Template type X is declared as covariant, but occurs in contravariant position in parameter c of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in contravariant position in parameter c of method MethodSignatureVariance\StaticMethod\B::a().
+Template type X is declared as covariant, but occurs in contravariant position in parameter f of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in contravariant position in parameter h of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in contravariant position in property PropertyVariance\ReadOnly\B::$b.
+Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::c().
+Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::e().
+Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::h().
+Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\StaticMethod\B::c().
+Template type X is declared as covariant, but occurs in invariant position in parameter e of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in invariant position in parameter i of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in invariant position in parameter j of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in invariant position in parameter k of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in invariant position in parameter l of method MethodSignatureVariance\Covariant\C::a().
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$a.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$b.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$c.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$d.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$a.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$b.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$c.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$d.
+Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\ReadOnly\B::$d.
+Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::f().
+Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::j().
+Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::k().
+Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::l().
+Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::m().
+Ternary operator condition is always false.
+Ternary operator condition is always true.
+TestInstantiation\InstantiatingClass::doFoo() calls new parent but TestInstantiation\InstantiatingClass does not extend any class.
+The (unset) cast is no longer supported in PHP 8.0 and later.
+The (void) cast is supported only on PHP 8.5 and later.
+The @extends tag of class ClassAncestorsExtends\FooDuplicateExtendsTags describes ClassAncestorsExtends\FooGeneric2 but the class extends ClassAncestorsExtends\FooGeneric.
+The @extends tag of class ClassAncestorsExtends\FooWrongClassExtended describes ClassAncestorsExtends\FooGeneric2 but the class extends ClassAncestorsExtends\FooGeneric.
+The @extends tag of interface InterfaceAncestorsExtends\FooInvalidImplementsTags describes InterfaceAncestorsExtends\FooGeneric2 but the interface extends: InterfaceAncestorsExtends\FooGeneric
+The @extends tag of interface InterfaceAncestorsExtends\FooWrongClassImplemented describes InterfaceAncestorsExtends\FooGeneric2 but the interface extends: InterfaceAncestorsExtends\FooGeneric, InterfaceAncestorsExtends\FooGeneric3
+The @implements tag of class ClassAncestorsImplements\FooInvalidImplementsTags describes ClassAncestorsImplements\FooGeneric2 but the class implements: ClassAncestorsImplements\FooGeneric
+The @implements tag of class ClassAncestorsImplements\FooWrongClassImplemented describes ClassAncestorsImplements\FooGeneric2 but the class implements: ClassAncestorsImplements\FooGeneric, ClassAncestorsImplements\FooGeneric3
+The @use tag of trait UsedTraits\NestedTrait describes UsedTraits\NongenericTrait but the trait uses UsedTraits\GenericTrait.
+The example does not contain any PHP code. Did you forget the opening <?php tag?
+The overwriting return is on this line.
+This exit point is overwritten by a different one in the finally block below.
+This return is overwritten by a different one in the finally block below.
+This throw is overwritten by a different one in the finally block below.
+Throw expression is supported only on PHP 8.0 and later.
+Throwing object of an unknown class ThrowExprValues\NonexistentClass.
+Trait Bug10302ExtendedImplementsTrait\Foo requires using class to implement Bug10302ExtendedImplementsTrait\Interface1, but Bug10302ExtendedImplementsTrait\Baz does not.
+Trait Bug10302ExtendedTrait\Foo requires using class to extend Bug10302ExtendedTrait\Father, but Bug10302ExtendedTrait\Baz does not.
+Trait ClassAttributes\TraitAsAttribute is not an Attribute class.
+Trait IncompatibleRequireExtends\InvalidTrait requires using class to extend IncompatibleRequireExtends\SomeFinalClass, but IncompatibleRequireExtends\InvalidClass2 does not.
+Trait IncompatibleRequireExtends\RequireNonExisstentUnionClassTrait requires using class to extend IncompatibleRequireExtends\NonExistentClass|IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\SomeClass@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-extends.php:198 does not.
+Trait IncompatibleRequireExtends\RequireNonExisstentUnionClassTrait requires using class to extend IncompatibleRequireExtends\NonExistentClass|IncompatibleRequireExtends\SomeClass, but class@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-extends.php:194 does not.
+Trait IncompatibleRequireExtends\ValidPsalmTrait requires using class to extend IncompatibleRequireExtends\SomeClass, but class@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-extends.php:163 does not.
+Trait IncompatibleRequireExtends\ValidTrait requires using class to extend IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\InValidTraitUse does not.
+Trait IncompatibleRequireExtends\ValidTrait requires using class to extend IncompatibleRequireExtends\SomeClass, but IncompatibleRequireExtends\InValidTraitUse2 does not.
+Trait IncompatibleRequireExtends\ValidTrait requires using class to extend IncompatibleRequireExtends\SomeClass, but class@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-extends.php:146 does not.
+Trait IncompatibleRequireImplements\InvalidTrait1 requires using class to implement IncompatibleRequireImplements\SomeTrait, but IncompatibleRequireImplements\InvalidTraitUse1 does not.
+Trait IncompatibleRequireImplements\InvalidTrait2 requires using class to implement IncompatibleRequireImplements\SomeEnum, but IncompatibleRequireImplements\InvalidTraitUse2 does not.
+Trait IncompatibleRequireImplements\InvalidTrait3 requires using class to implement IncompatibleRequireImplements\TypeDoesNotExist, but IncompatibleRequireImplements\InvalidTraitUse3 does not.
+Trait IncompatibleRequireImplements\InvalidTrait4 requires using class to implement IncompatibleRequireImplements\SomeClass<T>, but IncompatibleRequireImplements\InvalidTraitUse4 does not.
+Trait IncompatibleRequireImplements\ValidPsalmTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface, but class@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-implements.php:168 does not.
+Trait IncompatibleRequireImplements\ValidPsalmTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface2, but IncompatibleRequireImplements\RequiredInterface@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-implements.php:164 does not.
+Trait IncompatibleRequireImplements\ValidPsalmTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface2, but class@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-implements.php:168 does not.
+Trait IncompatibleRequireImplements\ValidTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface, but IncompatibleRequireImplements\InValidTraitUse does not.
+Trait IncompatibleRequireImplements\ValidTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface, but IncompatibleRequireImplements\InValidTraitUse2 does not.
+Trait IncompatibleRequireImplements\ValidTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface, but IncompatibleRequireImplements\InvalidEnumTraitUse does not.
+Trait IncompatibleRequireImplements\ValidTrait requires using class to implement IncompatibleRequireImplements\RequiredInterface, but class@anonymous/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-implements.php:117 does not.
+Trait LocalTypeTraitAliases\MissingType has type alias NoIterablueValue with no value type specified in iterable type array.
+Trait MethodTagTrait\Foo has PHPDoc tag @method for method doMissingIterablueValue() return type with no value type specified in iterable type array.
+Trait MixinTrait\FooTrait has PHPDoc tag @mixin with no value type specified in iterable type array.
+Trait NotAnalysedTrait\Bar is used zero times and is not analysed.
+Trait PropertyTagTrait\Foo has PHPDoc tag @property for property $bar with no value type specified in iterable type array.
+Trait TraitUseCase\FooTrait referenced with incorrect case: TraitUseCase\FOOTrait.
+Trait UsedTraits\NestedTrait uses generic trait UsedTraits\GenericTrait but does not specify its types: T
+Trait cannot be an Attribute class.
+Trying to invoke '' but it's not a callable.
+Trying to invoke 'nonexistent' but it's not a callable.
+Trying to invoke CallCallables\Baz but it might not be a callable.
+Trying to invoke CallCallables\Baz but it's not a callable.
+Trying to invoke array{'CallCallables\\CallableInForeach', 'bar'|'foo'} but it might not be a callable.
+Trying to invoke array{'CallCallables\\ConstantArrayUnionCallables', 'doBaz'|'doFoo'} but it might not be a callable.
+Trying to invoke array{'CallCallables\\ConstantArrayUnionCallables'|'CallCallables\\ConstantArrayUnionCallablesTest', 'doBar'|'doFoo'} but it's not a callable.
+Trying to invoke array{'CallCallables\\ConstantArrayUnionCallables'|'DateTimeImmutable', 'doFoo'} but it might not be a callable.
+Trying to invoke array{'MaybeNotCallable\\Bar'|$this(MaybeNotCallable\Bar), 'doFoo'} but it might not be a callable.
+Trying to invoke array{object, 'bar'} but it might not be a callable.
+Trying to invoke array{object, 'yo'} but it might not be a callable.
+Trying to invoke string but it might not be a callable.
+Type AllowedSubTypes\Baz is not allowed to be a subtype of AllowedSubTypes\Foo.
+Type Bug3922Ancestors\BarQuery in generic type Bug3922Ancestors\QueryHandlerInterface<string, Bug3922Ancestors\BarQuery> in PHPDoc tag @implements is not subtype of template type TQuery of Bug3922Ancestors\QueryInterface<string> of interface Bug3922Ancestors\QueryHandlerInterface.
+Type Sealed\BazClass is not allowed to be a subtype of Sealed\BaseClass.
+Type Sealed\BazClass2 is not allowed to be a subtype of Sealed\BaseInterface.
+Type Sealed\BazInterface is not allowed to be a subtype of Sealed\BaseInterface2.
+Type Throwable in generic type ClassAncestorsExtends\FooGeneric<int, Throwable> in PHPDoc tag @extends is not subtype of template type U of Exception of class ClassAncestorsExtends\FooGeneric.
+Type Throwable in generic type ClassAncestorsImplements\FooGeneric<int, Throwable> in PHPDoc tag @implements is not subtype of template type U of Exception of interface ClassAncestorsImplements\FooGeneric.
+Type Throwable in generic type InterfaceAncestorsExtends\FooGeneric<int, Throwable> in PHPDoc tag @extends is not subtype of template type U of Exception of interface InterfaceAncestorsExtends\FooGeneric.
+Type Throwable in generic type InvalidPhpDocDefinitions\FooGeneric<int, Throwable> in PHPDoc tag @param for parameter $ipsum is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type Throwable in generic type InvalidPhpDocDefinitions\FooGeneric<int, Throwable> in PHPDoc tag @param for parameter $v is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type Throwable in generic type InvalidPhpDocDefinitions\FooGeneric<int, Throwable> in PHPDoc tag @return is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type Throwable in generic type InvalidPhpDocDefinitions\FooGeneric<int, Throwable> in PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$invalidTypeGenericfoo is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type Throwable in generic type InvalidPhpDocDefinitions\FooGeneric<int, Throwable> in PHPDoc tag @var for variable $test is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type Throwable in generic type InvalidPhpDocDefinitions\FooGeneric<int, Throwable> in PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$invalidTypeGenericfoo is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type alias A contains generic type Exception<int> but class Exception is not generic.
+Type alias A contains unknown class LocalTypeAliases\Nonexistent.
+Type alias A contains unknown class LocalTypeTraitUseAliases\Nonexistent.
+Type alias A contains unresolvable type.
+Type alias B contains invalid type LocalTypeTraitAliases\Foo.
+Type alias B contains invalid type LocalTypeTraitUseAliases\SomeTrait.
+Type alias C contains unresolvable type.
+Type alias D contains generic type Exception<int> but class Exception is not generic.
+Type alias ExistingClassAlias already exists as a class in scope of LocalTypeAliases\Bar.
+Type alias ExistingClassAlias already exists as a class in scope of LocalTypeAliases\Baz.
+Type alias ExistingClassAlias already exists as a class in scope of LocalTypeTraitAliases\Bar.
+Type alias ExistingClassAlias already exists as a class in scope of LocalTypeTraitAliases\Baz.
+Type alias GlobalTypeAlias already exists as a global type alias.
+Type alias OverwrittenTypeAlias overwrites an imported type alias of the same name.
+Type alias has an invalid name: int.
+Type array<array{int, bool}> of property NestedTooWidePropertyType\Foo::$a can be narrowed to array<array{int, false}>.
+Type int in generic type NestedGenericTypesClassCheck\SomeObjectInterface<int> in PHPDoc tag @template U is not subtype of template type T of object of interface NestedGenericTypesClassCheck\SomeObjectInterface.
+Type int in generic type UsedTraits\GenericTrait<int> in PHPDoc tag @use is not subtype of template type T of object of trait UsedTraits\GenericTrait.
+Type int|string of constant OverridingConstant\Bar::IPSUM is not covariant with type int of constant OverridingConstant\Foo::IPSUM.
+Type mixed cannot be part of a nullable type declaration.
+Type mixed cannot be part of a union type declaration.
+Type mixed in generic type ClassAncestorsExtends\FooGeneric<int, mixed> in PHPDoc tag @extends is not subtype of template type U of Exception of class ClassAncestorsExtends\FooGeneric.
+Type mixed in generic type ClassAncestorsImplements\FooGeneric<int, mixed> in PHPDoc tag @implements is not subtype of template type U of Exception of interface ClassAncestorsImplements\FooGeneric.
+Type mixed in generic type InterfaceAncestorsExtends\FooGeneric<int, mixed> in PHPDoc tag @extends is not subtype of template type U of Exception of interface InterfaceAncestorsExtends\FooGeneric.
+Type mixed in generic type InvalidPhpDocDefinitions\FooGeneric<int, mixed> in PHPDoc tag @param for parameter $t is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type mixed in generic type MethodAssert\FooBar<mixed> in PHPDoc tag @phpstan-assert for $m is not subtype of template type T of int of class MethodAssert\FooBar.
+Type mixed in generic type NestedGenericTypesClassCheck\SomeObjectInterface<mixed> in PHPDoc tag @template U is not subtype of template type T of object of interface NestedGenericTypesClassCheck\SomeObjectInterface.
+Type mixed in generic type ParamClosureThisPhpDocRule\FooBar<mixed> in PHPDoc tag @param-closure-this for parameter $i is not subtype of template type T of int of class ParamClosureThisPhpDocRule\FooBar.
+Type mixed in generic type ParamOutPhpDocRule\FooBar<mixed> in PHPDoc tag @param-out for parameter $i is not subtype of template type T of int of class ParamOutPhpDocRule\FooBar.
+Type never cannot be part of a nullable type declaration.
+Type never cannot be part of a union type declaration.
+Type stdClass in generic type ClassAncestorsExtends\FooGeneric<int, stdClass> in PHPDoc tag @extends is not subtype of template type U of Exception of class ClassAncestorsExtends\FooGeneric.
+Type stdClass in generic type ClassAncestorsImplements\FooGeneric2<int, stdClass> in PHPDoc tag @implements is not subtype of template type V of Exception of interface ClassAncestorsImplements\FooGeneric2.
+Type stdClass in generic type ClassAncestorsImplements\FooGeneric<int, stdClass> in PHPDoc tag @implements is not subtype of template type U of Exception of interface ClassAncestorsImplements\FooGeneric.
+Type stdClass in generic type InterfaceAncestorsExtends\FooGeneric2<int, stdClass> in PHPDoc tag @extends is not subtype of template type V of Exception of interface InterfaceAncestorsExtends\FooGeneric2.
+Type stdClass in generic type InterfaceAncestorsExtends\FooGeneric<int, stdClass> in PHPDoc tag @extends is not subtype of template type U of Exception of interface InterfaceAncestorsExtends\FooGeneric.
+Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @param for parameter $dolor is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @param for parameter $x is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @return is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$anotherInvalidTypeGenericfoo is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @var for variable $test is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc type for property InvalidPhpDocPromotedProperties\FooWithProperty::$anotherInvalidTypeGenericfoo is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.
+Type string in generic type Bug3922AncestorsReversed\QueryHandlerInterface<Bug3922AncestorsReversed\BarQuery, string> in PHPDoc tag @implements is not subtype of template type int of interface Bug3922AncestorsReversed\QueryHandlerInterface.
+Type string in generic type IncompatibleSelfOutType\GenericCheck2<InvalidArgumentException, string> in PHPDoc tag @phpstan-self-out is not subtype of template type U of int of class IncompatibleSelfOutType\GenericCheck2.
+Type string in generic type MethodTag\Generic<string, string> in PHPDoc tag @method for method MethodTag\TestGenerics::doD() return type is not subtype of template type T of int of class MethodTag\Generic.
+Type string in generic type PropertyTag\Generic<string, string> in PHPDoc tag @property for property PropertyTag\TestGenerics::$d is not subtype of template type T of int of class PropertyTag\Generic.
+Type string in generic type ReflectionClass<string> in PHPDoc tag @mixin is not subtype of template type T of object of class ReflectionClass.
+Type string of constant OverridingConstant\Bar::BAR is not covariant with type int of constant OverridingConstant\Foo::BAR.
+Type string of constant OverridingFinalConstant\Lorem::FOO is not covariant with type int of constant OverridingFinalConstant\BarInterface::FOO.
+Type string of property OverridingProperty\Typed2Child::$foo is not the same as type int of overridden property OverridingProperty\Typed2::$foo.
+Type void cannot be part of a nullable type declaration.
+Type void cannot be part of a union type declaration.
+Unable to resolve the template type A in call to function CallGenericFunction\f
+Unable to resolve the template type A in call to function CallGenericFunction\g
+Unable to resolve the template type T in call to closure
+Unable to resolve the template type T in call to method OnlyRelevantUnableToResolve\Foo::doBaz()
+Unable to resolve the template type T in call to method Test\ClassStringWithUpperBounds::doFoo()
+Unable to resolve the template type T in call to method Test\InvalidReturnTypeUsingArrayTemplateTypeBound::bar()
+Unable to resolve the template type T in call to static method TemplateTypeInOneBranchOfConditional\DriverManager::getConnection()
+Unary operation "+" on 'bla' results in an error.
+Unary operation "+" on (array|object) results in an error.
+Unary operation "+" on T results in an error.
+Unary operation "+" on array results in an error.
+Unary operation "+" on array|bool|float|int|object|string|null results in an error.
+Unary operation "+" on mixed results in an error.
+Unary operation "+" on object results in an error.
+Unary operation "+" on resource results in an error.
+Unary operation "+" on string results in an error.
+Unary operation "-" on 'bla' results in an error.
+Unary operation "-" on (array|object) results in an error.
+Unary operation "-" on T results in an error.
+Unary operation "-" on array results in an error.
+Unary operation "-" on array|bool|float|int|object|string|null results in an error.
+Unary operation "-" on mixed results in an error.
+Unary operation "-" on object results in an error.
+Unary operation "-" on resource results in an error.
+Unary operation "-" on string results in an error.
+Unary operation "~" on (array|object) results in an error.
+Unary operation "~" on T results in an error.
+Unary operation "~" on array results in an error.
+Unary operation "~" on array{} results in an error.
+Unary operation "~" on array|bool|float|int|object|string|null results in an error.
+Unary operation "~" on bool results in an error.
+Unary operation "~" on mixed results in an error.
+Unary operation "~" on null results in an error.
+Unary operation "~" on object results in an error.
+Unary operation "~" on resource results in an error.
+Undefined variable: $a
+Undefined variable: $anArray
+Undefined variable: $anotherVariableInIsset
+Undefined variable: $argc
+Undefined variable: $arrayDoesNotExist
+Undefined variable: $assignedInKey
+Undefined variable: $b
+Undefined variable: $bar
+Undefined variable: $baseDir
+Undefined variable: $buz
+Undefined variable: $definedLater
+Undefined variable: $f
+Undefined variable: $foo
+Undefined variable: $fooParameterBeforeDeclaration
+Undefined variable: $http_response_header
+Undefined variable: $key
+Undefined variable: $mustAlreadyExistWhenDividing
+Undefined variable: $negatedVariableInEmpty
+Undefined variable: $parseStrParameter
+Undefined variable: $test
+Undefined variable: $this
+Undefined variable: $three
+Undefined variable: $undefinedVariable
+Undefined variable: $undefinedVariableInForeach
+Undefined variable: $val
+Undefined variable: $value
+Undefined variable: $var3
+Undefined variable: $variableAssignedInSecondCase
+Undefined variable: $variableInBitwiseAndAssign
+Undefined variable: $variableInEmpty
+Undefined variable: $variableInIsset
+Undefined variable: $variableInSecondCase
+Undefined variable: $willBeUnset
+Unknown PHPDoc tag: @phpstan-extens
+Unknown PHPDoc tag: @phpstan-pararm
+Unknown PHPDoc tag: @phpstan-va
+Unknown PHPDoc tag: @phpstan-varr
+Unknown parameter $a in call to function array_merge.
+Unknown parameter $className in call to method PDO::query().
+Unknown parameter $className in call to method PDOStatement::setFetchMode().
+Unknown parameter $colno in call to method PDO::query().
+Unknown parameter $constructorArgs in call to method PDO::query().
+Unknown parameter $greetings in call to function Bug13719\implicit_variadic.
+Unknown parameter $greetings in call to function Bug13719\non_variadic.
+Unknown parameter $i in call to callable callable(int, int): void.
+Unknown parameter $isostr in call to DatePeriod constructor.
+Unknown parameter $j in call to callable passed to call_user_func().
+Unknown parameter $j in call to callable passed to call_user_func_array().
+Unknown parameter $options in call to method XSLTProcessor::setParameter().
+Unknown parameter $r in call to ClassAttributes\AttributeWithConstructor constructor.
+Unknown parameter $recurrences in call to DatePeriod constructor.
+Unknown parameter $samesite in call to function setcookie.
+Unknown parameter $samesite in call to function setrawcookie.
+Unknown parameter $str1 in call to function levenshtein.
+Unknown parameter $str2 in call to function levenshtein.
+Unknown parameter $z in call to InstantiationNamedArguments\Foo constructor.
+Unknown parameter $z in call to callable callable(int, int): void.
+Unknown parameter $z in call to function FunctionNamedArguments\foo.
+Unknown parameter $z in call to method NamedArgumentsMethod\Foo::doFoo().
+Unknown parameter $z in call to static method StaticMethodNamedArguments\Foo::doFoo().
+Unpacked argument (...) cannot be followed by a non-unpacked argument.
+Unreachable statement - code above always terminates.
+Unsafe access to private constant AccessPrivateConstantThroughStatic\Foo::FOO through static::.
+Unsafe access to private property AccessPrivatePropertyThroughStatic\Foo::$foo through static::.
+Unsafe call to private method CallPrivateMethodThroughStatic\Foo::doBar() through static::.
+Unsafe usage of new static() in abstract class NewStaticInAbstractClassStaticMethod\Bar in static method staticDoFoo().
+Unsafe usage of new static().
+Unused result of "&&" operator.
+Unused result of "and" operator.
+Unused result of "or" operator.
+Unused result of "xor" operator.
+Unused result of "||" operator.
+Unused result of ternary operator.
+Used constant Uses\OTHER_CONSTANT not found.
+Used function Uses\bar not found.
+Used function Uses\baz not found.
+Using PHPStan\Type\JustNullableTypeTrait is not covered by backward compatibility promise. The trait might change in a minor PHPStan version.
+Using nullsafe method call on non-nullable type $this(Bug14150NullsafeMethod\HelloWorld). Use -> instead.
+Using nullsafe method call on non-nullable type Exception. Use -> instead.
+Using nullsafe property access "?->(Expression)" in empty() is unnecessary. Use -> instead.
+Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.
+Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.
+Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.
+Using nullsafe property access "?->bla" in isset() is unnecessary. Use -> instead.
+Using nullsafe property access "?->notFalsy" in empty() is unnecessary. Use -> instead.
+Using nullsafe property access on non-nullable type $this(Bug14150NullsafeProperty\HelloWorld). Use -> instead.
+Using nullsafe property access on non-nullable type Exception. Use -> instead.
+Using parent outside of class scope.
+Using self outside of class scope.
+Using static outside of class scope.
+Variable $a in empty() always exists and is always falsy.
+Variable $a in empty() always exists and is not falsy.
+Variable $a in empty() is never defined.
+Variable $a in isset() always exists and is always null.
+Variable $a in isset() always exists and is not nullable.
+Variable $a might not be defined.
+Variable $a on left side of ?? always exists and is always null.
+Variable $a on left side of ??= always exists and is always null.
+Variable $alwaysDefinedForCaseNodeCondition in isset() always exists and is not nullable.
+Variable $alwaysDefinedForSwitchCondition in isset() always exists and is not nullable.
+Variable $alwaysDefinedNotNullable in isset() always exists and is not nullable.
+Variable $anotherForLoopVariable might not be defined.
+Variable $anotherMaybeDefinedInTernary might not be defined.
+Variable $anotherNeverDefinedVariable in isset() is never defined.
+Variable $anotherUndefinedArrayIndex might not be defined.
+Variable $anotherVariableFromForCond might not be defined.
+Variable $anotherVariableInDoWhile in isset() always exists and is not nullable.
+Variable $ar in empty() is never defined.
+Variable $argc might not be defined.
+Variable $b in PHPDoc tag @var does not exist.
+Variable $b in empty() always exists and is not falsy.
+Variable $bar in PHPDoc tag @var does not exist.
+Variable $bar might not be defined.
+Variable $bar on left side of ?? always exists and is not nullable.
+Variable $bar on left side of ?? is never defined.
+Variable $baseDir might not be defined.
+Variable $baz in PHPDoc tag @var does not match any global variable: $lorem
+Variable $command might not be defined.
+Variable $definedInCases might not be defined.
+Variable $definedInIfOnly might not be defined.
+Variable $doesNotExist in isset() is never defined.
+Variable $doesNotExist on left side of ?? is never defined.
+Variable $doesNotExist on left side of ??= is never defined.
+Variable $foo in PHPDoc tag @var does not exist.
+Variable $foo in PHPDoc tag @var does not match any static variable: $test
+Variable $foo in PHPDoc tag @var does not match any variable in the foreach loop: $list, $key, $val
+Variable $foo in PHPDoc tag @var does not match assigned variable $test.
+Variable $foo in isset() is never defined.
+Variable $foo might not be defined.
+Variable $foo on left side of ?? is never defined.
+Variable $forI might not be defined.
+Variable $forJ might not be defined.
+Variable $forVariableUsedAndThenDefined might not be defined.
+Variable $i might not be defined.
+Variable $key might not be defined.
+Variable $matches might not be defined.
+Variable $maybe might not be defined.
+Variable $maybeDefinedInTernary might not be defined.
+Variable $mightBeUndefinedInDoWhile might not be defined.
+Variable $neverDefinedVariable in isset() is never defined.
+Variable $null in isset() always exists and is always null.
+Variable $onlyInIf might not be defined.
+Variable $pow might not be defined.
+Variable $result might not be defined.
+Variable $scalar in isset() always exists and is not nullable.
+Variable $scalar on left side of ?? always exists and is not nullable.
+Variable $scalar on left side of ??= always exists and is not nullable.
+Variable $slots in PHPDoc tag @var does not exist.
+Variable $slots in PHPDoc tag @var does not match assigned variable $itemSlots.
+Variable $sql might not be defined.
+Variable $str might not be defined.
+Variable $test might not be defined.
+Variable $this might not be defined.
+Variable $undefinedArrayIndex might not be defined.
+Variable $undefinedVar in empty() is never defined.
+Variable $undefinedVar in isset() is never defined.
+Variable $undefinedVar on left side of ?? is never defined.
+Variable $unknownVariablePassedToReset might not be defined.
+Variable $v might not be defined.
+Variable $val might not be defined.
+Variable $value might not be defined.
+Variable $variableAssignedInSecondCase in isset() is never defined.
+Variable $variableAvailableInAllCatches might not be defined.
+Variable $variableDefinedOnlyInOneCatch might not be defined.
+Variable $variableFromDefaultFirst might not be defined.
+Variable $variableInAssign might not be defined.
+Variable $variableInFallthroughCase might not be defined.
+Variable $variableInFirstCase in isset() always exists and is not nullable.
+Variable $variableInFirstCase in isset() is never defined.
+Variable $variableInSecondCase in isset() is never defined.
+Variable $variableInSecondCase might not be defined.
+Variable $whileVar might not be defined.
+Variable $whileVariableUsedAndThenDefined might not be defined.
+Variable $wrongErrorHandler might not be defined.
+Variable $x1 on left side of ?? always exists and is always null.
+Variable $yetAnotherNeverDefinedVariable in isset() is never defined.
+Variable $yetYetAnotherNeverDefinedVariableInIsset in isset() is never defined.
+Variable $z might not be defined.
+Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type T in in function FunctionSignatureVariance\f().
+Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in in method MethodSignatureVariance\C::b().
+Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in in method MethodSignatureVariance\C::c().
+While loop condition is always false.
+While loop condition is always true.
+Yield can be used only inside a function.
+Yield can be used only with these return types: Generator, Iterator, Traversable, iterable.
+condition about $c #1: if $debug=false then $c is *ERROR* (No)
+condition about $c #2: if $debug=true then $c is 1 (Yes)
+found echo
+found virtual echo
+native $a (Yes): int
+native $b (Yes): int
+native $c (Maybe): 1
+native $debug (Yes): bool
+native $result (Yes): 'no matches!'
+print_r
+print_r ($value)
+sleep
+sleep ($seconds)
+var_dump
+var_dump ($value)

--- a/test/snapshot.spec.ts
+++ b/test/snapshot.spec.ts
@@ -34,7 +34,7 @@ describe.skipIf(errorFiles.length === 0)(
           }));
 
           expect(results).toMatchSnapshot();
-        });
+        }, 60_000);
       });
     }
   },


### PR DESCRIPTION
## Summary

Allow the "Collect PHPStan Errors" workflow to run directly from a PR by adding a label.

## Changes

- Add `pull_request: types: [labeled]` trigger to `collect-errors.yml`
- Workflow runs when the `collect-errors` label is added to a PR
- Checks out the PR branch (`github.head_ref`) so results are committed to the PR
- Defaults to PHPStan branch `2.2.x` when triggered via label
- `workflow_dispatch` still works as before for manual runs with custom branches

## Usage

**From a PR:**
1. Add the `collect-errors` label to the PR
2. The workflow collects errors and commits results to the PR branch

**Manual (unchanged):**
1. Actions tab → Collect PHPStan Errors → Run workflow
2. Select target branch and enter PHPStan branches

## Test plan

- [x] Existing tests pass
- [x] Biome check passes
- [ ] Verify label trigger works on a PR

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A