### PR TITLE
Add colon token for type syntax

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -12,6 +12,7 @@ export type Word = {
     | 'comma'
     | 'lparen'
     | 'rparen'
+    | 'colon'
     | 'period';
   value: string;
   location: {
@@ -47,6 +48,7 @@ export function format(errorMessageCst: CstNode): Word[] {
     { tokenType: 'comma', nodes: comma },
     { tokenType: 'lparen', nodes: sentenceNode?.children?.lparen },
     { tokenType: 'rparen', nodes: sentenceNode?.children?.rparen },
+    { tokenType: 'colon', nodes: sentenceNode?.children?.colon },
     { tokenType: 'period', nodes: sentenceNode?.children?.period },
   ] as const;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,6 +35,11 @@ const tokens = {
   COMMA: createToken({ name: 'comma', pattern: ',', line_breaks: false }),
   LPAREN: createToken({ name: 'lparen', pattern: '(', line_breaks: false }),
   RPAREN: createToken({ name: 'rparen', pattern: ')', line_breaks: false }),
+  COLON: createToken({
+    name: 'colon',
+    pattern: /(?<!:):(?!:)/,
+    line_breaks: false,
+  }),
   VARIABLE: createToken({
     name: 'Variable',
     pattern: /\$[a-z][\w]*/,
@@ -76,6 +81,7 @@ export class Parser extends CstParser {
         { ALT: () => this.CONSUME(tokens.COMMA) },
         { ALT: () => this.CONSUME(tokens.LPAREN) },
         { ALT: () => this.CONSUME(tokens.RPAREN) },
+        { ALT: () => this.CONSUME(tokens.COLON) },
       ]);
     });
     this.CONSUME(tokens.PERIOD);

--- a/test/__snapshots__/2.2.x/Arrays.snap
+++ b/test/__snapshots__/2.2.x/Arrays.snap
@@ -3579,6 +3579,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -3656,6 +3664,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -3677,6 +3693,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -3717,6 +3741,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -4896,6 +4928,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -5002,6 +5042,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -7786,6 +7834,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -7964,6 +8020,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "blabla",
         "location": {
@@ -8046,6 +8110,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -8134,6 +8206,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -8155,6 +8235,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -8259,6 +8347,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -8280,6 +8376,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -8307,6 +8411,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -8328,6 +8440,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -8355,6 +8475,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -8376,6 +8504,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -8403,6 +8539,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
@@ -8424,6 +8568,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -8536,6 +8688,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -8557,6 +8717,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -8645,6 +8813,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -8666,6 +8842,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -8754,6 +8938,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -8778,6 +8970,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
@@ -8799,6 +8999,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -8903,6 +9111,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -8940,6 +9156,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -8983,6 +9207,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9020,6 +9252,14 @@
         "location": {
           "startColumn": 142,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -9076,6 +9316,14 @@
         "location": {
           "startColumn": 184,
           "endColumn": 191
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 192,
+          "endColumn": 193
         }
       },
       {
@@ -9634,6 +9882,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9655,6 +9911,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -9682,6 +9946,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -9703,6 +9975,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -9730,6 +10010,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -9751,6 +10039,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -9778,6 +10074,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
@@ -9799,6 +10103,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -9911,6 +10223,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9932,6 +10252,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -10020,6 +10348,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -10033,6 +10369,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -10126,6 +10470,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -10230,6 +10582,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -10251,6 +10611,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -10355,6 +10723,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -10408,6 +10784,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -10552,6 +10936,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -10605,6 +10997,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -10717,6 +11117,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -10746,6 +11154,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -11578,6 +11994,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -11663,6 +12087,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -11684,6 +12116,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -13550,6 +13990,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -13571,6 +14019,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -13598,6 +14054,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -13619,6 +14083,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -15491,6 +15963,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "number",
         "value": "21",
         "location": {
@@ -15515,6 +15995,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "number",
         "value": "17",
         "location": {
@@ -15536,6 +16024,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -16115,6 +16611,14 @@
         "location": {
           "startColumn": 39,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Cast.snap
+++ b/test/__snapshots__/2.2.x/Cast.snap
@@ -958,6 +958,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -1625,6 +1633,14 @@
         "location": {
           "startColumn": 18,
           "endColumn": 19
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Classes.snap
+++ b/test/__snapshots__/2.2.x/Classes.snap
@@ -5869,6 +5869,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -5967,6 +5975,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -6071,6 +6087,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -6172,6 +6196,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -6270,6 +6302,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -6390,6 +6430,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "type",
         "location": {
@@ -6504,6 +6552,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
         }
       },
       {
@@ -9111,6 +9167,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClassAttributes",
         "location": {
@@ -9326,6 +9390,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClassConstantNamespace",
         "location": {
@@ -9408,6 +9480,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -9724,6 +9804,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       }
     ]
@@ -10242,6 +10330,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "ExtendsImplements",
         "location": {
@@ -10595,6 +10691,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "InstanceOfNamespaceRule",
         "location": {
@@ -10677,6 +10781,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -10967,6 +11079,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -11358,6 +11478,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -11781,6 +11909,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -12257,6 +12393,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -12951,6 +13095,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -13810,6 +13962,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestInstantiation",
         "location": {
@@ -13993,6 +14153,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -18619,6 +18787,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "EnumImplements",
         "location": {
@@ -20724,6 +20900,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 197,
+          "endColumn": 198
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -20945,6 +21129,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 173,
+          "endColumn": 174
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21131,6 +21323,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -21403,6 +21603,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 192,
+          "endColumn": 193
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21624,6 +21832,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 168,
+          "endColumn": 169
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21837,6 +22053,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -21927,6 +22151,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -28508,6 +28740,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "EnumImplements",
         "location": {
@@ -28590,6 +28830,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -31228,6 +31476,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -31760,6 +32016,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -31874,6 +32138,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -33597,6 +33869,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -34403,6 +34683,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "baz",
         "location": {
@@ -34528,6 +34816,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -34549,6 +34845,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -34581,6 +34885,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -37291,6 +37603,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "HumbugBox",
         "location": {
@@ -37392,6 +37712,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "App",
         "location": {
@@ -37482,6 +37810,14 @@
         "location": {
           "startColumn": 32,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -37594,6 +37930,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -37684,6 +38028,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -37780,6 +38132,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPUnitPHAR",
         "location": {
@@ -37854,6 +38214,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -42264,6 +42632,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "TraitUseCase",
         "location": {
@@ -44233,6 +44609,14 @@
         "location": {
           "startColumn": 26,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Comparison.snap
+++ b/test/__snapshots__/2.2.x/Comparison.snap
@@ -216,6 +216,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -240,6 +248,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "bar",
         "location": {
@@ -261,6 +277,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -397,6 +421,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "bar",
         "location": {
@@ -418,6 +450,14 @@
         "location": {
           "startColumn": 56,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -570,6 +610,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -591,6 +639,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -743,6 +799,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -764,6 +828,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -4466,6 +4538,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "bar",
         "location": {
@@ -4487,6 +4567,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -8999,6 +9087,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -9036,6 +9132,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -11242,6 +11346,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "count",
         "location": {
@@ -11263,6 +11375,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -17207,6 +17327,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -17228,6 +17356,14 @@
         "location": {
           "startColumn": 57,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -30850,6 +30986,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -30919,6 +31063,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -30985,6 +31137,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -31070,6 +31230,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -31222,6 +31390,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -31347,6 +31523,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -31469,6 +31653,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -31613,6 +31805,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
@@ -31679,6 +31879,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -31764,6 +31972,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -31873,6 +32089,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -34391,6 +34615,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -34420,6 +34652,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -34532,6 +34772,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -34561,6 +34809,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -41450,6 +41706,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -41471,6 +41735,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -41506,6 +41778,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -41527,6 +41807,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -41639,6 +41927,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -41660,6 +41956,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -41695,6 +41999,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -41716,6 +42028,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -41828,6 +42148,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -41857,6 +42185,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Constants.snap
+++ b/test/__snapshots__/2.2.x/Constants.snap
@@ -1038,6 +1038,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -1346,6 +1354,14 @@
         "location": {
           "startColumn": 120,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Debug.snap
+++ b/test/__snapshots__/2.2.x/Debug.snap
@@ -35,6 +35,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 8,
+          "endColumn": 9
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -77,6 +85,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 8
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 8,
+          "endColumn": 9
         }
       },
       {
@@ -125,6 +141,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -167,6 +191,14 @@
         "location": {
           "startColumn": 11,
           "endColumn": 12
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
         }
       },
       {
@@ -215,6 +247,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
+        }
+      },
+      {
         "type": "common_word",
         "value": "no",
         "location": {
@@ -252,6 +292,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -281,6 +329,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -307,6 +363,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 11
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
         }
       },
       {
@@ -363,11 +427,27 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
         }
       },
       {
@@ -392,6 +472,14 @@
         "location": {
           "startColumn": 31,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       }
     ]
@@ -416,11 +504,27 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
         }
       },
       {
@@ -446,6 +550,14 @@
           "startColumn": 31,
           "endColumn": 34
         }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
       }
     ]
   },
@@ -469,11 +581,27 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
         }
       },
       {
@@ -498,6 +626,14 @@
         "location": {
           "startColumn": 30,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       }
     ]
@@ -522,11 +658,27 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
         }
       },
       {
@@ -552,6 +704,14 @@
           "startColumn": 30,
           "endColumn": 32
         }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
       }
     ]
   },
@@ -575,11 +735,27 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       }
     ]
@@ -604,6 +780,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -617,6 +801,14 @@
         "location": {
           "startColumn": 20,
           "endColumn": 24
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -649,6 +841,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -678,6 +878,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -726,6 +934,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -755,6 +971,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -787,6 +1011,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -819,6 +1051,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "yes",
         "location": {
@@ -848,6 +1088,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -861,6 +1109,14 @@
         "location": {
           "startColumn": 20,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -904,6 +1160,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "starts",
         "location": {
@@ -941,6 +1205,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -984,6 +1256,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "no",
         "location": {
@@ -1021,6 +1301,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1034,6 +1322,14 @@
         "location": {
           "startColumn": 20,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -1066,6 +1362,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1095,6 +1399,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -1127,6 +1439,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1159,6 +1479,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "yes",
         "location": {
@@ -1188,6 +1516,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1201,6 +1537,14 @@
         "location": {
           "startColumn": 20,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -1233,6 +1577,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1246,6 +1598,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -1278,6 +1638,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1291,6 +1659,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -1315,6 +1691,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
         }
       },
       {
@@ -1347,6 +1731,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1360,6 +1752,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -1392,6 +1792,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1413,6 +1821,14 @@
         "location": {
           "startColumn": 23,
           "endColumn": 26
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
         }
       },
       {
@@ -1453,6 +1869,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1482,6 +1906,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -1514,6 +1946,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1546,6 +1986,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "yes",
         "location": {
@@ -1575,6 +2023,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1588,6 +2044,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -1617,6 +2081,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 11
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
         }
       },
       {
@@ -1673,6 +2145,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -1715,6 +2195,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 11
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
         }
       },
       {
@@ -1787,6 +2275,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -1848,6 +2344,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -1906,6 +2410,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -1978,6 +2490,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "Yes",
         "location": {
@@ -2044,6 +2564,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -2116,6 +2644,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -2177,6 +2713,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -2235,6 +2779,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -2315,6 +2867,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "No",
         "location": {
@@ -2381,6 +2941,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -2455,6 +3023,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -2572,6 +3148,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -2700,6 +3284,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -2750,6 +3342,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 15
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
         }
       },
       {
@@ -2806,6 +3406,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -2859,6 +3467,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -2909,6 +3525,14 @@
         "location": {
           "startColumn": 19,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Exceptions.snap
+++ b/test/__snapshots__/2.2.x/Exceptions.snap
@@ -189,6 +189,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestCatch",
         "location": {
@@ -7482,6 +7490,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Functions.snap
+++ b/test/__snapshots__/2.2.x/Functions.snap
@@ -4111,6 +4111,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "IncorrectFunctionCase",
         "location": {
@@ -4204,6 +4212,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "foobar",
         "location": {
@@ -4286,6 +4302,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -4395,6 +4419,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -4621,6 +4653,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -5174,6 +5214,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -7233,6 +7281,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -10291,6 +10347,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "dateTimeImmutable",
         "location": {
@@ -10357,6 +10421,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -10429,6 +10501,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "fOOFunctionTypehintS",
         "location": {
@@ -10495,6 +10575,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -10572,6 +10660,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -10660,6 +10756,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "ParamOutClasses",
         "location": {
@@ -10742,6 +10846,14 @@
         "location": {
           "startColumn": 82,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -10830,6 +10942,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestClosureFunctionTypehints",
         "location": {
@@ -10912,6 +11032,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -11000,6 +11128,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestFunctionTypehints",
         "location": {
@@ -11082,6 +11218,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -13877,6 +14021,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -14502,6 +14654,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "Required",
         "location": {
@@ -14600,6 +14760,14 @@
         "location": {
           "startColumn": 18,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -14704,6 +14872,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "Required",
         "location": {
@@ -14805,6 +14981,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "Required",
         "location": {
@@ -14903,6 +15087,14 @@
         "location": {
           "startColumn": 18,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -16638,6 +16830,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -16662,6 +16862,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
@@ -16683,6 +16891,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -16718,6 +16934,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
@@ -16750,6 +16974,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
@@ -16771,6 +17003,14 @@
         "location": {
           "startColumn": 180,
           "endColumn": 186
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 186,
+          "endColumn": 187
         }
       },
       {
@@ -16806,6 +17046,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 208,
+          "endColumn": 209
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -16835,6 +17083,14 @@
         "location": {
           "startColumn": 226,
           "endColumn": 232
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 232,
+          "endColumn": 233
         }
       },
       {
@@ -17154,6 +17410,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       }
     ]
@@ -17949,6 +18213,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
+        }
+      },
+      {
         "type": "common_word",
         "value": "A",
         "location": {
@@ -18119,6 +18391,14 @@
         "location": {
           "startColumn": 183,
           "endColumn": 188
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 188,
+          "endColumn": 189
         }
       },
       {
@@ -19811,6 +20091,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 175,
+          "endColumn": 176
+        }
+      },
+      {
         "type": "common_word",
         "value": "A",
         "location": {
@@ -20045,6 +20333,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -20223,6 +20519,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 146
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
         }
       },
       {
@@ -20415,6 +20719,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
+        }
+      },
+      {
         "type": "common_word",
         "value": "A",
         "location": {
@@ -20572,6 +20884,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 173,
+          "endColumn": 174
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -20721,6 +21041,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -20867,6 +21195,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -21349,6 +21685,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21535,6 +21879,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -28481,6 +28833,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -28933,6 +29293,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -34779,6 +35147,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -45674,6 +46050,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -45751,6 +46135,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -45887,6 +46279,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -45948,6 +46348,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -46092,6 +46500,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -46153,6 +46569,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -46281,6 +46705,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -46342,6 +46774,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -46518,6 +46958,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -46627,6 +47075,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -46872,6 +47328,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -46885,6 +47349,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -46944,6 +47416,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -46957,6 +47437,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -47093,6 +47581,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "bogus",
         "location": {
@@ -47114,6 +47610,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -47218,6 +47722,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -47242,6 +47754,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47263,6 +47783,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -47298,6 +47826,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -47319,6 +47855,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -47346,6 +47890,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 160,
+          "endColumn": 161
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47370,6 +47922,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47391,6 +47951,14 @@
         "location": {
           "startColumn": 188,
           "endColumn": 205
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 206,
+          "endColumn": 207
         }
       },
       {
@@ -47426,6 +47994,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 224,
+          "endColumn": 225
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -47450,6 +48026,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 241,
+          "endColumn": 242
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47471,6 +48055,14 @@
         "location": {
           "startColumn": 251,
           "endColumn": 261
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 262,
+          "endColumn": 263
         }
       },
       {
@@ -47506,6 +48098,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 291,
+          "endColumn": 292
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47527,6 +48127,14 @@
         "location": {
           "startColumn": 301,
           "endColumn": 311
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 312,
+          "endColumn": 313
         }
       },
       {
@@ -47554,6 +48162,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 324,
+          "endColumn": 325
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47578,6 +48194,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 342,
+          "endColumn": 343
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -47599,6 +48223,14 @@
         "location": {
           "startColumn": 352,
           "endColumn": 369
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 370,
+          "endColumn": 371
         }
       },
       {
@@ -47985,6 +48617,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -48142,6 +48782,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -48179,6 +48827,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -48238,6 +48894,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -48259,6 +48923,14 @@
         "location": {
           "startColumn": 150,
           "endColumn": 162
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 162,
+          "endColumn": 163
         }
       },
       {
@@ -61990,6 +62662,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -62051,6 +62731,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -62179,6 +62867,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -62240,6 +62936,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -62368,6 +63072,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -62429,6 +63141,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -62581,6 +63301,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -62642,6 +63370,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -62818,6 +63554,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -62879,6 +63623,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -63023,6 +63775,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -63084,6 +63844,14 @@
         "location": {
           "startColumn": 110,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -63228,6 +63996,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -63289,6 +64065,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -63441,6 +64225,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -63502,6 +64294,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -63678,6 +64478,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -63739,6 +64547,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -63883,6 +64699,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -63944,6 +64768,14 @@
         "location": {
           "startColumn": 114,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -64088,6 +64920,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -64149,6 +64989,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -64325,6 +65173,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -64426,6 +65282,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -64594,6 +65458,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -64655,6 +65527,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -64807,6 +65687,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -64884,6 +65772,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -65028,6 +65924,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -65089,6 +65993,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -65249,6 +66161,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -65326,6 +66246,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -65470,6 +66398,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -65507,6 +66443,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -65659,6 +66603,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -65704,6 +66656,14 @@
         "location": {
           "startColumn": 126,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -65856,6 +66816,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -65901,6 +66869,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -66029,6 +67005,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -66066,6 +67050,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -66194,6 +67186,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -66239,6 +67239,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -66367,6 +67375,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -66412,6 +67428,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -66580,6 +67604,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -66641,6 +67673,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {
@@ -66809,6 +67849,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -66870,6 +67918,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -67006,6 +68062,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -67067,6 +68131,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -67235,6 +68307,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -67296,6 +68376,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -67432,6 +68520,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -67493,6 +68589,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -67775,6 +68879,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -68938,6 +70050,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -68991,6 +70111,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -69095,6 +70223,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -69116,6 +70252,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -69143,6 +70287,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69164,6 +70316,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -69191,6 +70351,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69212,6 +70380,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -69271,6 +70447,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
@@ -69295,6 +70479,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -69308,6 +70500,14 @@
         "location": {
           "startColumn": 182,
           "endColumn": 184
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 184,
+          "endColumn": 185
         }
       },
       {
@@ -69335,6 +70535,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 192,
+          "endColumn": 193
+        }
+      },
+      {
         "type": "number",
         "value": "30",
         "location": {
@@ -69359,6 +70567,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 200,
+          "endColumn": 201
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -69380,6 +70596,14 @@
         "location": {
           "startColumn": 205,
           "endColumn": 210
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 210,
+          "endColumn": 211
         }
       },
       {
@@ -69500,6 +70724,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -69521,6 +70753,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -69548,6 +70788,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69569,6 +70817,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -69596,6 +70852,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69617,6 +70881,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -69676,6 +70948,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
@@ -69700,6 +70980,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -69713,6 +71001,14 @@
         "location": {
           "startColumn": 182,
           "endColumn": 184
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 184,
+          "endColumn": 185
         }
       },
       {
@@ -69740,6 +71036,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 192,
+          "endColumn": 193
+        }
+      },
+      {
         "type": "number",
         "value": "30",
         "location": {
@@ -69764,6 +71068,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 200,
+          "endColumn": 201
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -69785,6 +71097,14 @@
         "location": {
           "startColumn": 205,
           "endColumn": 210
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 210,
+          "endColumn": 211
         }
       },
       {
@@ -69905,6 +71225,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -69926,6 +71254,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -69953,6 +71289,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69977,6 +71321,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69998,6 +71350,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -70033,6 +71393,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "number",
         "value": "123",
         "location": {
@@ -70057,6 +71425,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -70070,6 +71446,14 @@
         "location": {
           "startColumn": 153,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -70097,6 +71481,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
+        }
+      },
+      {
         "type": "number",
         "value": "30",
         "location": {
@@ -70118,6 +71510,14 @@
         "location": {
           "startColumn": 169,
           "endColumn": 171
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 171,
+          "endColumn": 172
         }
       },
       {
@@ -76840,6 +78240,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -76901,6 +78309,14 @@
         "location": {
           "startColumn": 132,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -77109,6 +78525,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -77170,6 +78594,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -77410,6 +78842,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -77471,6 +78911,14 @@
         "location": {
           "startColumn": 118,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -77983,6 +79431,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -78044,6 +79500,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -78180,6 +79644,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -78241,6 +79713,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -78441,6 +79921,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -78502,6 +79990,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -78726,6 +80222,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -78787,6 +80291,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -78995,6 +80507,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -79056,6 +80576,14 @@
         "location": {
           "startColumn": 134,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -79264,6 +80792,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -79325,6 +80861,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -79533,6 +81077,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -79594,6 +81146,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -79802,6 +81362,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -79863,6 +81431,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -80071,6 +81647,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -80132,6 +81716,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -80356,6 +81948,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -80417,6 +82017,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -80734,6 +82342,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -80795,6 +82411,14 @@
         "location": {
           "startColumn": 129,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -81003,6 +82627,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -81064,6 +82696,14 @@
         "location": {
           "startColumn": 119,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -81240,6 +82880,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -81301,6 +82949,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -81525,6 +83181,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -81586,6 +83250,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -81794,6 +83466,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -81855,6 +83535,14 @@
         "location": {
           "startColumn": 139,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -82063,6 +83751,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -82124,6 +83820,14 @@
         "location": {
           "startColumn": 129,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -82332,6 +84036,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -82393,6 +84105,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -82601,6 +84321,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -82662,6 +84390,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -85391,6 +87127,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -85452,6 +87196,14 @@
         "location": {
           "startColumn": 132,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -85660,6 +87412,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -85721,6 +87481,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -85929,6 +87697,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -85990,6 +87766,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -86198,6 +87982,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -86259,6 +88051,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -89207,6 +91007,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -89268,6 +91076,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -95322,6 +97138,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -96010,6 +97834,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Generators.snap
+++ b/test/__snapshots__/2.2.x/Generators.snap
@@ -572,6 +572,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTime",
         "location": {
@@ -593,6 +601,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -620,6 +636,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -641,6 +665,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -865,6 +897,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTime",
         "location": {
@@ -886,6 +926,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -913,6 +961,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -934,6 +990,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -1505,6 +1569,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Generics.snap
+++ b/test/__snapshots__/2.2.x/Generics.snap
@@ -3787,6 +3787,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -4053,6 +4061,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -4295,6 +4311,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -4521,6 +4545,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "TObject",
         "location": {
@@ -4659,6 +4691,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -4912,6 +4952,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -5162,6 +5210,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -5401,6 +5457,14 @@
         "location": {
           "startColumn": 151,
           "endColumn": 156
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
         }
       },
       {
@@ -5662,6 +5726,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -5800,6 +5872,14 @@
         "location": {
           "startColumn": 146,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -5949,6 +6029,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -6202,6 +6290,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -6284,6 +6380,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -6425,6 +6529,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -7503,6 +7615,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8059,6 +8179,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 194,
+          "endColumn": 195
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8237,6 +8365,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -8469,6 +8605,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 207,
+          "endColumn": 208
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8650,6 +8794,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 164,
+          "endColumn": 165
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8828,6 +8980,14 @@
         "location": {
           "startColumn": 148,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -9060,6 +9220,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 206,
+          "endColumn": 207
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -9238,6 +9406,14 @@
         "location": {
           "startColumn": 153,
           "endColumn": 163
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
         }
       },
       {
@@ -9454,6 +9630,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -9576,6 +9760,14 @@
         "location": {
           "startColumn": 148,
           "endColumn": 153
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
         }
       },
       {
@@ -9837,6 +10029,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -9983,6 +10183,14 @@
         "location": {
           "startColumn": 150,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -10233,6 +10441,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -17238,6 +17454,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 194,
+          "endColumn": 195
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -18345,6 +18569,14 @@
         "location": {
           "startColumn": 226,
           "endColumn": 227
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 227,
+          "endColumn": 228
         }
       },
       {
@@ -33836,6 +34068,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "InterfaceAncestorsExtends",
         "location": {
@@ -33974,6 +34214,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 154
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
         }
       },
       {
@@ -34150,6 +34398,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClassAncestorsImplements",
         "location": {
@@ -34288,6 +34544,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -34594,6 +34858,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Ignore.snap
+++ b/test/__snapshots__/2.2.x/Ignore.snap
@@ -43,6 +43,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -232,6 +240,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -354,6 +370,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -506,6 +530,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -612,6 +644,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Methods.snap
+++ b/test/__snapshots__/2.2.x/Methods.snap
@@ -6675,6 +6675,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "foobar",
         "location": {
@@ -7451,6 +7459,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "dofoo",
         "location": {
@@ -7517,6 +7533,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -9210,6 +9234,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "TEST",
         "location": {
@@ -9611,6 +9643,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -10342,6 +10382,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -13903,6 +13951,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "CallStaticMethods",
         "location": {
@@ -13980,6 +14036,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "dateTimeImmutable",
         "location": {
@@ -14054,6 +14118,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -14142,6 +14214,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "ParamOutClassesMethods",
         "location": {
@@ -14224,6 +14304,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -14312,6 +14400,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestMethodTypehints",
         "location": {
@@ -14394,6 +14490,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -14482,6 +14586,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestMethodTypehints",
         "location": {
@@ -14559,6 +14671,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "STDClass",
         "location": {
@@ -14625,6 +14745,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -16426,6 +16554,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "Required",
         "location": {
@@ -16524,6 +16660,14 @@
         "location": {
           "startColumn": 18,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -16628,6 +16772,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "Required",
         "location": {
@@ -16729,6 +16881,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "Required",
         "location": {
@@ -16827,6 +16987,14 @@
         "location": {
           "startColumn": 18,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -20589,6 +20757,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -21089,6 +21265,14 @@
         "location": {
           "startColumn": 155,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -21701,6 +21885,14 @@
         "location": {
           "startColumn": 85,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -22611,6 +22803,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -22675,6 +22875,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -22688,6 +22896,14 @@
         "location": {
           "startColumn": 186,
           "endColumn": 189
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 189,
+          "endColumn": 190
         }
       },
       {
@@ -22712,6 +22928,14 @@
         "location": {
           "startColumn": 198,
           "endColumn": 201
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 201,
+          "endColumn": 202
         }
       },
       {
@@ -22771,6 +22995,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 242,
+          "endColumn": 243
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -22795,6 +23027,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 261,
+          "endColumn": 262
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -22808,6 +23048,14 @@
         "location": {
           "startColumn": 269,
           "endColumn": 283
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 283,
+          "endColumn": 284
         }
       },
       {
@@ -24724,6 +24972,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -27039,6 +27295,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 175,
+          "endColumn": 176
+        }
+      },
+      {
         "type": "common_word",
         "value": "A",
         "location": {
@@ -27196,6 +27460,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 187,
+          "endColumn": 188
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -27350,6 +27622,14 @@
         "location": {
           "startColumn": 197,
           "endColumn": 202
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 202,
+          "endColumn": 203
         }
       },
       {
@@ -27651,6 +27931,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 216,
+          "endColumn": 217
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -27805,6 +28093,14 @@
         "location": {
           "startColumn": 212,
           "endColumn": 217
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 217,
+          "endColumn": 218
         }
       },
       {
@@ -28555,6 +28851,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 196,
+          "endColumn": 197
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -28725,6 +29029,14 @@
         "location": {
           "startColumn": 173,
           "endColumn": 178
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
         }
       },
       {
@@ -29119,6 +29431,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 160,
+          "endColumn": 161
+        }
+      },
+      {
         "type": "common_word",
         "value": "A",
         "location": {
@@ -29260,6 +29580,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 172,
+          "endColumn": 173
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -29398,6 +29726,14 @@
         "location": {
           "startColumn": 182,
           "endColumn": 187
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 187,
+          "endColumn": 188
         }
       },
       {
@@ -30371,6 +30707,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -33059,6 +33403,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -33080,6 +33432,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -33184,6 +33544,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -33205,6 +33573,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -33811,6 +34187,14 @@
         "location": {
           "startColumn": 116,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -42160,6 +42544,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -42181,6 +42573,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -42208,6 +42608,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
@@ -42229,6 +42637,14 @@
         "location": {
           "startColumn": 120,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -42272,6 +42688,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -42293,6 +42717,14 @@
         "location": {
           "startColumn": 163,
           "endColumn": 165
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 165,
+          "endColumn": 166
         }
       },
       {
@@ -48639,6 +49071,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -48692,6 +49132,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -51391,6 +51839,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -52176,6 +52632,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -52338,6 +52802,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -52506,6 +52978,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -52660,6 +53140,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -52833,6 +53321,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -53046,6 +53542,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -53278,6 +53782,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -53347,6 +53859,14 @@
         "location": {
           "startColumn": 128,
           "endColumn": 129
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
         }
       },
       {
@@ -53475,6 +53995,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -53520,6 +54048,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -53648,6 +54184,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -53701,6 +54245,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -53853,6 +54405,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -53922,6 +54482,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -54050,6 +54618,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -54095,6 +54671,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -54223,6 +54807,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -54276,6 +54868,14 @@
         "location": {
           "startColumn": 126,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -54412,6 +55012,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -54449,6 +55057,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -54569,6 +55185,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -54614,6 +55238,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -54726,6 +55358,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -54763,6 +55403,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -54883,6 +55531,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -54920,6 +55576,14 @@
         "location": {
           "startColumn": 120,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -55040,6 +55704,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -55077,6 +55749,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -55213,6 +55893,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -55330,6 +56018,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -55375,6 +56071,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -55487,6 +56191,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -55532,6 +56244,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -55660,6 +56380,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -55705,6 +56433,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -55833,6 +56569,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -55878,6 +56622,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -55998,6 +56750,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -56035,6 +56795,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -56631,6 +57399,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
         "type": "number",
         "value": "123",
         "location": {
@@ -56793,6 +57569,14 @@
         "location": {
           "startColumn": 136,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -57211,6 +57995,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -57232,6 +58024,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -57392,6 +58192,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -57413,6 +58221,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -57565,6 +58381,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -57586,6 +58410,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -60333,6 +61165,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -60378,6 +61218,14 @@
         "location": {
           "startColumn": 118,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -61080,6 +61928,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -67376,6 +68232,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -67397,6 +68261,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -67437,6 +68309,14 @@
         "location": {
           "startColumn": 134,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -68573,6 +69453,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -68695,6 +69583,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -68847,6 +69743,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -68996,6 +69900,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -69009,6 +69921,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -69161,6 +70081,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69310,6 +70238,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69331,6 +70267,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -69451,6 +70395,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69472,6 +70424,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -69592,6 +70552,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69613,6 +70581,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -69648,6 +70624,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -69669,6 +70653,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 124
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -69773,6 +70765,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69794,6 +70794,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -69829,6 +70837,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -69850,6 +70866,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 124
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -69962,6 +70986,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69983,6 +71015,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -70018,6 +71058,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -70039,6 +71087,14 @@
         "location": {
           "startColumn": 119,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -70143,6 +71199,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -70164,6 +71228,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -70284,6 +71356,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -70313,6 +71393,14 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -70417,6 +71505,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -70446,6 +71542,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -70547,6 +71651,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -70672,6 +71784,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -73078,6 +74198,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -73099,6 +74227,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -73126,6 +74262,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -73147,6 +74291,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -73174,6 +74326,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -73195,6 +74355,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -73222,6 +74390,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -73243,6 +74419,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -73464,6 +74648,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -73517,6 +74709,14 @@
         "location": {
           "startColumn": 205,
           "endColumn": 217
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 217,
+          "endColumn": 218
         }
       },
       {
@@ -76895,6 +78095,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -76916,6 +78124,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -77823,6 +79039,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -78174,6 +79398,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -78296,6 +79528,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -89446,6 +90686,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -89587,6 +90835,14 @@
         "location": {
           "startColumn": 163,
           "endColumn": 166
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 167,
+          "endColumn": 168
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Namespaces.snap
+++ b/test/__snapshots__/2.2.x/Namespaces.snap
@@ -51,6 +51,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "DATETIME",
         "location": {
@@ -117,6 +125,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -205,6 +221,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "Uses",
         "location": {
@@ -263,6 +287,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Other.snap
+++ b/test/__snapshots__/2.2.x/Other.snap
@@ -239,6 +239,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "The",
         "location": {

--- a/test/__snapshots__/2.2.x/PhpDoc.snap
+++ b/test/__snapshots__/2.2.x/PhpDoc.snap
@@ -3208,6 +3208,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "InvalidVarTagType",
         "location": {
@@ -3290,6 +3298,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -3580,6 +3596,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -3609,6 +3633,14 @@
         "location": {
           "startColumn": 39,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -4636,6 +4668,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 221,
+          "endColumn": 222
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -4846,6 +4886,14 @@
         "location": {
           "startColumn": 190,
           "endColumn": 191
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 191,
+          "endColumn": 192
         }
       },
       {
@@ -5102,6 +5150,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 219,
+          "endColumn": 220
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -5328,6 +5384,14 @@
         "location": {
           "startColumn": 198,
           "endColumn": 199
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 199,
+          "endColumn": 200
         }
       },
       {
@@ -5600,6 +5664,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 264,
+          "endColumn": 265
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -5850,6 +5922,14 @@
         "location": {
           "startColumn": 214,
           "endColumn": 215
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 215,
+          "endColumn": 216
         }
       },
       {
@@ -6114,6 +6194,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 278,
+          "endColumn": 279
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -6319,6 +6407,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 174,
+          "endColumn": 175
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -6497,6 +6593,14 @@
         "location": {
           "startColumn": 146,
           "endColumn": 156
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
         }
       },
       {
@@ -6721,6 +6825,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 223,
+          "endColumn": 224
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -6923,6 +7035,14 @@
         "location": {
           "startColumn": 162,
           "endColumn": 172
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 172,
+          "endColumn": 173
         }
       },
       {
@@ -7136,6 +7256,14 @@
         "location": {
           "startColumn": 227,
           "endColumn": 237
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 237,
+          "endColumn": 238
         }
       },
       {
@@ -7392,6 +7520,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -7597,6 +7733,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -7799,6 +7943,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -8023,6 +8175,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 181,
+          "endColumn": 182
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8244,6 +8404,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 183,
+          "endColumn": 184
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8457,6 +8625,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -8667,6 +8843,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 158
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
         }
       },
       {
@@ -8904,6 +9088,14 @@
         "location": {
           "startColumn": 180,
           "endColumn": 181
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 181,
+          "endColumn": 182
         }
       },
       {
@@ -10141,6 +10333,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -10343,6 +10543,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -10966,6 +11174,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -11328,6 +11544,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -11530,6 +11754,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -11743,6 +11975,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -11972,6 +12212,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -12539,6 +12787,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -12560,6 +12816,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -12587,6 +12851,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -12608,6 +12880,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -12808,6 +13088,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -12970,6 +13258,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -13170,6 +13466,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -13351,6 +13655,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -13500,6 +13812,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$arrX",
         "location": {
@@ -13558,6 +13878,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -14045,6 +14373,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$b",
         "location": {
@@ -14260,6 +14596,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -14481,6 +14825,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$c",
         "location": {
@@ -14627,6 +14979,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -14824,6 +15184,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -15045,6 +15413,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -15343,6 +15719,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -15827,6 +16211,14 @@
         "location": {
           "startColumn": 102,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -18398,6 +18790,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -18422,6 +18822,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -18435,6 +18843,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -18462,6 +18878,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -18483,6 +18907,14 @@
         "location": {
           "startColumn": 134,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -19313,6 +19745,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -19861,6 +20301,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -20031,6 +20479,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -20223,6 +20679,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -20409,6 +20873,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -20617,6 +21089,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -20822,6 +21302,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21003,6 +21491,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21173,6 +21669,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -21381,6 +21885,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21551,6 +22063,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -21743,6 +22263,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -21905,6 +22433,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -22299,6 +22835,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -22320,6 +22864,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -22347,6 +22899,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -22368,6 +22928,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -22783,6 +23351,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -28312,6 +28888,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -28474,6 +29058,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -29764,6 +30356,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -29934,6 +30534,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -30118,6 +30726,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -30299,6 +30915,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unexpected",
         "location": {
@@ -30453,6 +31077,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -30642,6 +31274,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -30847,6 +31487,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -31071,6 +31719,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -31260,6 +31916,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "TInvalid",
         "location": {
@@ -31422,6 +32086,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -31606,6 +32278,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "TypeAlias",
         "location": {
@@ -31771,6 +32451,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -31864,6 +32552,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -33993,6 +34689,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -34131,6 +34835,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -34397,6 +35109,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -34932,6 +35652,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -35001,6 +35729,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -35762,6 +36498,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "z",
         "location": {
@@ -35783,6 +36527,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -35810,6 +36562,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "b",
         "location": {
@@ -35831,6 +36591,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -35975,6 +36743,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -35996,6 +36772,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -36023,6 +36807,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "b",
         "location": {
@@ -36044,6 +36836,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -36188,6 +36988,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -36209,6 +37017,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -36353,6 +37169,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "b",
         "location": {
@@ -36374,6 +37198,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -42518,6 +43350,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "doc_tag",
         "value": "@phpstan-e",
         "location": {
@@ -42560,6 +43400,14 @@
         "location": {
           "startColumn": 15,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -42608,6 +43456,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "doc_tag",
         "value": "@phpstan-v",
         "location": {
@@ -42650,6 +43506,14 @@
         "location": {
           "startColumn": 15,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -42940,6 +43804,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$lorem",
         "location": {
@@ -43134,6 +44006,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$test",
         "location": {
@@ -43264,6 +44144,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Properties.snap
+++ b/test/__snapshots__/2.2.x/Properties.snap
@@ -5869,6 +5869,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -5890,6 +5898,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -5978,6 +5994,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -5999,6 +6023,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -6084,6 +6116,14 @@
         "location": {
           "startColumn": 39,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -11376,6 +11416,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "Use",
         "location": {
@@ -13267,6 +13315,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "Datetime",
         "location": {
@@ -13333,6 +13389,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -14855,6 +14919,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -18676,6 +18748,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -18772,6 +18852,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -18817,6 +18905,14 @@
         "location": {
           "startColumn": 139,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -19070,6 +19166,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -19206,6 +19310,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 160,
+          "endColumn": 161
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -19304,6 +19416,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -19443,6 +19563,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -19541,6 +19669,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -19685,6 +19821,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -25354,6 +25498,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -25375,6 +25527,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -25434,6 +25594,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -25455,6 +25623,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -25559,6 +25735,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -25580,6 +25764,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -25663,6 +25855,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -25684,6 +25884,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -25804,6 +26012,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -25825,6 +26041,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -25884,6 +26108,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -25905,6 +26137,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -26025,6 +26265,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -26046,6 +26294,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -26129,6 +26385,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -26150,6 +26414,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -26278,6 +26550,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -26299,6 +26579,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -26382,6 +26670,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -26403,6 +26699,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -28529,6 +28833,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "common_word",
         "value": "A",
         "location": {
@@ -28670,6 +28982,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -28808,6 +29128,14 @@
         "location": {
           "startColumn": 136,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -36594,6 +36922,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36615,6 +36951,14 @@
         "location": {
           "startColumn": 26,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -36692,6 +37036,14 @@
         "location": {
           "startColumn": 16,
           "endColumn": 19
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Regexp.snap
+++ b/test/__snapshots__/2.2.x/Regexp.snap
@@ -370,6 +370,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Compilation",
         "location": {
@@ -383,6 +391,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -450,6 +466,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -495,6 +519,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Compilation",
         "location": {
@@ -508,6 +540,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -575,6 +615,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -588,6 +636,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {
@@ -636,6 +692,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Delimiter",
         "location": {
@@ -729,6 +793,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -777,6 +849,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Delimiter",
         "location": {
@@ -873,6 +953,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "nok",
         "location": {
@@ -886,6 +974,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -934,6 +1030,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Delimiter",
         "location": {
@@ -1030,6 +1134,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "nok",
         "location": {
@@ -1043,6 +1155,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -1091,6 +1211,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Delimiter",
         "location": {
@@ -1187,6 +1315,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "nok",
         "location": {
@@ -1200,6 +1336,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -1248,6 +1392,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "Unknown",
         "location": {
@@ -1285,6 +1437,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Variables.snap
+++ b/test/__snapshots__/2.2.x/Variables.snap
@@ -1413,6 +1413,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1442,6 +1450,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -1530,6 +1546,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1559,6 +1583,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -2034,6 +2066,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 6
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6,
+          "endColumn": 7
         }
       },
       {
@@ -2709,6 +2749,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -2850,6 +2898,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -2879,6 +2935,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -2930,6 +2994,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -2943,6 +3015,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -2983,6 +3063,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -3127,6 +3215,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -3156,6 +3252,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -3207,6 +3311,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -3220,6 +3332,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -3260,6 +3380,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -3404,6 +3532,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -3433,6 +3569,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -3484,6 +3628,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -3497,6 +3649,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -3537,6 +3697,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -3705,6 +3873,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -3734,6 +3910,14 @@
         "location": {
           "startColumn": 47,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -3785,6 +3969,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -3798,6 +3990,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -3838,6 +4038,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -3982,6 +4190,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -4011,6 +4227,14 @@
         "location": {
           "startColumn": 47,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -4062,6 +4286,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -4075,6 +4307,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -4115,6 +4355,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -4259,6 +4507,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -4288,6 +4544,14 @@
         "location": {
           "startColumn": 47,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -4339,6 +4603,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -4352,6 +4624,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -4392,6 +4672,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -4509,6 +4797,14 @@
         "location": {
           "startColumn": 22,
           "endColumn": 25
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -4653,6 +4949,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -4677,6 +4981,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -4698,6 +5010,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -5816,6 +6136,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -5954,6 +6282,14 @@
         "location": {
           "startColumn": 25,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -6782,6 +7118,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -6803,6 +7147,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -6830,6 +7182,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -6854,6 +7214,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -6875,6 +7243,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -7019,6 +7395,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -7043,6 +7427,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -7064,6 +7456,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -7485,6 +7885,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -7509,6 +7917,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -7530,6 +7946,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -13183,6 +13607,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$a",
         "location": {
@@ -13209,6 +13641,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13241,6 +13681,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$anotherVariableInIsset",
         "location": {
@@ -13267,6 +13715,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13299,6 +13755,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$arrayDoesNotExist",
         "location": {
@@ -13325,6 +13789,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13357,6 +13829,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$b",
         "location": {
@@ -13383,6 +13863,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13415,6 +13903,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$baseDir",
         "location": {
@@ -13441,6 +13937,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13473,6 +13977,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$definedLater",
         "location": {
@@ -13499,6 +14011,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13531,6 +14051,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$foo",
         "location": {
@@ -13557,6 +14085,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13589,6 +14125,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$http_response_header",
         "location": {
@@ -13615,6 +14159,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13647,6 +14199,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$mustAlreadyExistWhenDividing",
         "location": {
@@ -13673,6 +14233,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13705,6 +14273,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$parseStrParameter",
         "location": {
@@ -13731,6 +14307,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13763,6 +14347,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$this",
         "location": {
@@ -13789,6 +14381,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13821,6 +14421,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$undefinedVariable",
         "location": {
@@ -13847,6 +14455,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13879,6 +14495,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$val",
         "location": {
@@ -13905,6 +14529,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13937,6 +14569,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$var3",
         "location": {
@@ -13963,6 +14603,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -13995,6 +14643,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$variableInBitwiseAndAssign",
         "location": {
@@ -14021,6 +14677,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -14053,6 +14717,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$variableInIsset",
         "location": {
@@ -14082,6 +14754,14 @@
         }
       },
       {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$variableInSecondCase",
         "location": {
@@ -14108,6 +14788,14 @@
         "location": {
           "startColumn": 10,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -825,6 +825,87 @@ describe('test formatted results', () => {
     expect(result).toStrictEqual(expected);
   });
 
+  it('parse colon', () => {
+    const message =
+      'Parameter Closure(): void of print cannot be converted to string.';
+    const result = parse(message);
+
+    const expected = [
+      {
+        type: 'common_word',
+        value: 'Parameter',
+        location: { startColumn: 0, endColumn: 9 },
+      },
+      {
+        type: 'common_word',
+        value: 'Closure',
+        location: { startColumn: 10, endColumn: 17 },
+      },
+      {
+        type: 'lparen',
+        value: '(',
+        location: { startColumn: 17, endColumn: 18 },
+      },
+      {
+        type: 'rparen',
+        value: ')',
+        location: { startColumn: 18, endColumn: 19 },
+      },
+      {
+        type: 'colon',
+        value: ':',
+        location: { startColumn: 19, endColumn: 20 },
+      },
+      {
+        type: 'common_word',
+        value: 'void',
+        location: { startColumn: 21, endColumn: 25 },
+      },
+      {
+        type: 'common_word',
+        value: 'of',
+        location: { startColumn: 26, endColumn: 28 },
+      },
+      {
+        type: 'common_word',
+        value: 'print',
+        location: { startColumn: 29, endColumn: 34 },
+      },
+      {
+        type: 'common_word',
+        value: 'cannot',
+        location: { startColumn: 35, endColumn: 41 },
+      },
+      {
+        type: 'common_word',
+        value: 'be',
+        location: { startColumn: 42, endColumn: 44 },
+      },
+      {
+        type: 'common_word',
+        value: 'converted',
+        location: { startColumn: 45, endColumn: 54 },
+      },
+      {
+        type: 'common_word',
+        value: 'to',
+        location: { startColumn: 55, endColumn: 57 },
+      },
+      {
+        type: 'common_word',
+        value: 'string',
+        location: { startColumn: 58, endColumn: 64 },
+      },
+      {
+        type: 'period',
+        value: '.',
+        location: { startColumn: 64, endColumn: 65 },
+      },
+    ];
+
+    expect(result).toStrictEqual(expected);
+  });
+
   it('parse static method', () => {
     const message =
       'Call to static method PHPStan\\Tests\\AssertionClass::assertInt() with int will always evaluate to true.';

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -136,7 +136,26 @@ describe('sample test', () => {
         ['rparen:)', true],
         // Closure(): void is split into flat tokens, not parsed as a callable type
         ['CommonWord:Closure', true],
+        ['colon::', true],
         ['CommonWord:void', true],
+      ],
+    },
+    {
+      name: 'parse colon in array shape',
+      m: 'Offset does not exist on array{key: string}.',
+      assertions: [
+        ['colon::', true],
+        ['CommonWord:key', true],
+        ['CommonWord:string', true],
+      ],
+    },
+    {
+      name: 'colon does not match double colon in static method',
+      m: 'Call to static method PHPStan\\Tests\\AssertionClass::assertInt() with int will always evaluate to true.',
+      assertions: [
+        ['StaticMethodName:PHPStan\\Tests\\AssertionClass::assertInt()', true],
+        // :: is consumed by StaticMethodName, not as two colons
+        ['colon::', false],
       ],
     },
   ] satisfies DataSet[];


### PR DESCRIPTION
## Summary

Add single colon (`:`) as a token, used in:
- Array shapes: `array{key: value}`
- Return types: `Closure(): void`
- Object shapes: `object{foo: int}`

Uses negative lookahead/behind (`/(?<!:):(?!:)/`) to avoid matching `::` which is consumed by `StaticMethodName`.

## Test plan

- [x] All 71 tests pass
- [x] Parser test: colon detected in `Closure(): void`
- [x] Parser test: colon detected in `array{key: string}`
- [x] Parser test: `::` in static methods is NOT matched as colon
- [x] Format test: colon has correct location info
- [x] 18 snapshot categories updated (colons now tokenized)
- [x] Biome check passes

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A