### PR TITLE
Add benchmark CI with PR comparison and /benchmark trigger

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,156 @@
+name: Benchmark
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.body == '/benchmark')
+
+    steps:
+      - name: Get PR info
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            let prNumber, headRef, baseRef;
+            if (context.eventName === 'pull_request') {
+              prNumber = context.payload.pull_request.number;
+              headRef = context.payload.pull_request.head.ref;
+              baseRef = context.payload.pull_request.base.ref;
+            } else {
+              prNumber = context.payload.issue.number;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              headRef = pr.head.ref;
+              baseRef = pr.base.ref;
+            }
+            core.setOutput('number', prNumber);
+            core.setOutput('head_ref', headRef);
+            core.setOutput('base_ref', baseRef);
+
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies (PR)
+        run: npm ci
+
+      - name: Benchmark PR branch
+        run: |
+          npm run build
+          node --experimental-strip-types test/benchmark.ts 2>/dev/null > /tmp/bench-pr.json
+
+      - name: Checkout base branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.base_ref }}
+          clean: false
+
+      - name: Install dependencies (base)
+        run: npm ci
+
+      - name: Benchmark base branch
+        run: |
+          npm run build
+          node --experimental-strip-types test/benchmark.ts 2>/dev/null > /tmp/bench-base.json || echo '{}' > /tmp/bench-base.json
+
+      - name: Compare and comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+
+            function readResult(file) {
+              try { return JSON.parse(fs.readFileSync(file, 'utf-8')); }
+              catch { return null; }
+            }
+
+            const pr = readResult('/tmp/bench-pr.json');
+            const base = readResult('/tmp/bench-base.json');
+
+            if (!pr) {
+              core.setFailed('PR benchmark failed');
+              return;
+            }
+
+            let body = '## Benchmark Results\n\n';
+            body += `| Metric | Base | PR | Change |\n`;
+            body += `|--------|------|-----|--------|\n`;
+
+            const metrics = [
+              ['Messages', 'messages', '', false],
+              ['Mean (ms)', 'mean', 'ms', true],
+              ['Median (ms)', 'median', 'ms', true],
+              ['Min (ms)', 'min', 'ms', true],
+              ['Max (ms)', 'max', 'ms', true],
+              ['Per message (ms)', 'perMessage', 'ms', true],
+            ];
+
+            for (const [label, key, unit, showChange] of metrics) {
+              const baseVal = base?.[key];
+              const prVal = pr[key];
+              const baseStr = baseVal != null ? `${baseVal}` : 'N/A';
+              const prStr = prVal != null ? `${prVal}` : 'N/A';
+
+              let change = '';
+              if (showChange && baseVal != null && prVal != null && baseVal > 0) {
+                const pct = ((prVal - baseVal) / baseVal * 100).toFixed(1);
+                const sign = pct > 0 ? '+' : '';
+                const emoji = pct > 10 ? ' ⚠️' : pct < -10 ? ' 🚀' : '';
+                change = `${sign}${pct}%${emoji}`;
+              }
+
+              body += `| ${label} | ${baseStr} | ${prStr} | ${change} |\n`;
+            }
+
+            body += `\n> ${pr.iterations} iterations, ${pr.messages} messages. ⚠️ = >10% slower, 🚀 = >10% faster`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.number }},
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('## Benchmark Results')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ steps.pr.outputs.number }},
+                body,
+              });
+            }

--- a/test/benchmark.ts
+++ b/test/benchmark.ts
@@ -1,0 +1,74 @@
+/**
+ * Benchmark script for measuring parse performance.
+ *
+ * Usage: npm run build && node --experimental-strip-types test/benchmark.ts
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error -- runs against dist after build
+import { parse } from '../dist/index.js';
+
+const baseDir = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(baseDir, 'fixtures');
+
+function loadMessages(): string[] {
+  const messages: string[] = [];
+  let branchDirs: string[];
+  try {
+    branchDirs = readdirSync(fixturesDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return messages;
+  }
+
+  for (const branch of branchDirs) {
+    const dir = join(fixturesDir, branch);
+    for (const file of readdirSync(dir).filter((f) => f.endsWith('.txt'))) {
+      const lines = readFileSync(join(dir, file), 'utf-8')
+        .split('\n')
+        .filter((l) => l.length > 0);
+      messages.push(...lines);
+    }
+  }
+  return messages;
+}
+
+const ITERATIONS = 10;
+const WARMUP = 3;
+const messages = loadMessages();
+
+if (messages.length === 0) {
+  console.error('No fixture files found');
+  process.exit(1);
+}
+
+// Warmup
+for (let i = 0; i < WARMUP; i++) {
+  for (const m of messages) parse(m);
+}
+
+// Benchmark
+const times: number[] = [];
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = performance.now();
+  for (const m of messages) parse(m);
+  times.push(performance.now() - start);
+}
+
+times.sort((a, b) => a - b);
+const mean = times.reduce((a, b) => a + b, 0) / times.length;
+const median = times[Math.floor(times.length / 2)];
+
+const result = {
+  messages: messages.length,
+  iterations: ITERATIONS,
+  mean: Number.parseFloat(mean.toFixed(2)),
+  median: Number.parseFloat(median.toFixed(2)),
+  min: Number.parseFloat(times[0].toFixed(2)),
+  max: Number.parseFloat(times[times.length - 1].toFixed(2)),
+  perMessage: Number.parseFloat((mean / messages.length).toFixed(4)),
+};
+
+console.log(JSON.stringify(result));


### PR DESCRIPTION
## Summary

Add benchmark script and CI workflow to detect performance regressions.

### Why not vitest bench?

vitest bench was initially considered but it timed out (>120s) even with a simple configuration when running against ~4500 fixture messages. The overhead of vitest's benchmark framework (based on tinybench) was too high for this use case. A custom script using `performance.now()` runs the same benchmark in ~15s.

### Benchmark script (`test/benchmark.ts`)

- Loads all fixture messages (~4500)
- 3 warmup iterations + 10 measured iterations
- Outputs JSON with mean, median, min, max, per-message time
- Runs via `npm run build && node --experimental-strip-types test/benchmark.ts`

### CI workflow (`.github/workflows/benchmark.yml`)

**Triggers:**
- Automatically on PR open/sync
- Manually via `/benchmark` comment on PR

**Flow:**
1. Benchmark PR branch
2. Benchmark base (main) branch
3. Compare results and post as PR comment

**PR comment format:**
```
## Benchmark Results
| Metric | Base | PR | Change |
|--------|------|-----|--------|
| Mean (ms) | 120.5 | 125.3 | +4.0% |
| Per message (ms) | 0.026 | 0.027 | +3.8% |
```
- ⚠️ = >10% slower, 🚀 = >10% faster
- Updates existing comment on re-run instead of creating duplicates

### Note on first run

Since the base branch (main) does not have the benchmark script yet, the "Base" column will show `N/A` on this PR. Comparison will work on subsequent PRs after this is merged.

## Test plan

- [x] Biome check passes
- [x] Benchmark script runs locally (~14s for 4594 messages)
- [x] Verify CI workflow posts comparison comment on PR

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A