### PR TITLE
Add type delimiter tokens (&lt;&gt; {} [] | &amp; ?)

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -15,6 +15,15 @@ export type Word = {
     | 'lparen'
     | 'rparen'
     | 'colon'
+    | 'langle'
+    | 'rangle'
+    | 'lbrace'
+    | 'rbrace'
+    | 'lbracket'
+    | 'rbracket'
+    | 'pipe'
+    | 'ampersand'
+    | 'question'
     | 'period';
   value: string;
   location: {
@@ -55,6 +64,15 @@ export function format(errorMessageCst: CstNode): Word[] {
     { tokenType: 'lparen', nodes: sentenceNode?.children?.lparen },
     { tokenType: 'rparen', nodes: sentenceNode?.children?.rparen },
     { tokenType: 'colon', nodes: sentenceNode?.children?.colon },
+    { tokenType: 'langle', nodes: sentenceNode?.children?.langle },
+    { tokenType: 'rangle', nodes: sentenceNode?.children?.rangle },
+    { tokenType: 'lbrace', nodes: sentenceNode?.children?.lbrace },
+    { tokenType: 'rbrace', nodes: sentenceNode?.children?.rbrace },
+    { tokenType: 'lbracket', nodes: sentenceNode?.children?.lbracket },
+    { tokenType: 'rbracket', nodes: sentenceNode?.children?.rbracket },
+    { tokenType: 'pipe', nodes: sentenceNode?.children?.pipe },
+    { tokenType: 'ampersand', nodes: sentenceNode?.children?.ampersand },
+    { tokenType: 'question', nodes: sentenceNode?.children?.question },
     { tokenType: 'period', nodes: sentenceNode?.children?.period },
   ] as const;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -50,6 +50,19 @@ const tokens = {
     pattern: /(?<!:):(?!:)/,
     line_breaks: false,
   }),
+  LANGLE: createToken({ name: 'langle', pattern: '<', line_breaks: false }),
+  RANGLE: createToken({ name: 'rangle', pattern: '>', line_breaks: false }),
+  LBRACE: createToken({ name: 'lbrace', pattern: '{', line_breaks: false }),
+  RBRACE: createToken({ name: 'rbrace', pattern: '}', line_breaks: false }),
+  LBRACKET: createToken({ name: 'lbracket', pattern: '[', line_breaks: false }),
+  RBRACKET: createToken({ name: 'rbracket', pattern: ']', line_breaks: false }),
+  PIPE: createToken({ name: 'pipe', pattern: '|', line_breaks: false }),
+  AMPERSAND: createToken({
+    name: 'ampersand',
+    pattern: '&',
+    line_breaks: false,
+  }),
+  QUESTION: createToken({ name: 'question', pattern: '?', line_breaks: false }),
   VARIABLE: createToken({
     name: 'Variable',
     pattern: /\$[a-z][\w]*/,
@@ -94,6 +107,15 @@ export class Parser extends CstParser {
         { ALT: () => this.CONSUME(tokens.LPAREN) },
         { ALT: () => this.CONSUME(tokens.RPAREN) },
         { ALT: () => this.CONSUME(tokens.COLON) },
+        { ALT: () => this.CONSUME(tokens.LANGLE) },
+        { ALT: () => this.CONSUME(tokens.RANGLE) },
+        { ALT: () => this.CONSUME(tokens.LBRACE) },
+        { ALT: () => this.CONSUME(tokens.RBRACE) },
+        { ALT: () => this.CONSUME(tokens.LBRACKET) },
+        { ALT: () => this.CONSUME(tokens.RBRACKET) },
+        { ALT: () => this.CONSUME(tokens.PIPE) },
+        { ALT: () => this.CONSUME(tokens.AMPERSAND) },
+        { ALT: () => this.CONSUME(tokens.QUESTION) },
       ]);
     });
     this.CONSUME(tokens.PERIOD);

--- a/test/__snapshots__/2.2.x/Arrays.snap
+++ b/test/__snapshots__/2.2.x/Arrays.snap
@@ -479,11 +479,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 34,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -620,11 +644,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 33,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -2854,6 +2902,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -2875,6 +2931,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -2910,6 +2974,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -2934,6 +3006,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -2952,6 +3032,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 11
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
         }
       },
       {
@@ -2976,6 +3064,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -3032,6 +3128,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -3053,6 +3157,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -3088,6 +3200,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -3117,6 +3237,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -3138,6 +3266,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -3194,6 +3330,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -3215,6 +3359,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       },
       {
@@ -3433,6 +3585,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -3454,6 +3614,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -3672,6 +3840,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -3725,6 +3901,22 @@
         "location": {
           "startColumn": 43,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -4025,6 +4217,14 @@
         "location": {
           "startColumn": 30,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -4540,11 +4740,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -4569,6 +4785,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -4747,6 +4971,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -4819,6 +5051,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -4832,6 +5072,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -5021,11 +5269,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'test'",
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -5146,11 +5418,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'test'",
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -5735,6 +6031,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -6003,6 +6307,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -6069,6 +6381,14 @@
         "location": {
           "startColumn": 30,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -6247,6 +6567,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -6287,6 +6615,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "to",
         "location": {
@@ -6300,6 +6636,14 @@
         "location": {
           "startColumn": 39,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -6324,6 +6668,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -6502,6 +6854,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -6571,6 +6931,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -6592,6 +6960,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -6645,6 +7021,14 @@
         "location": {
           "startColumn": 21,
           "endColumn": 24
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
         }
       },
       {
@@ -6762,6 +7146,22 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "for",
         "location": {
@@ -6836,6 +7236,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -7343,6 +7751,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -7367,11 +7783,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 38,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -7749,6 +8181,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -7770,6 +8210,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -7842,6 +8290,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "b",
         "location": {
@@ -7863,6 +8319,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -7935,6 +8399,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'a'",
         "location": {
@@ -7956,6 +8428,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -8028,6 +8508,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -8049,6 +8537,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -8121,6 +8617,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -8142,6 +8646,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -8214,6 +8726,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -8267,6 +8787,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -8355,11 +8883,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 48,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -8395,6 +8939,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -8424,6 +8976,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -8459,6 +9019,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -8488,6 +9056,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -8523,6 +9099,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -8555,6 +9139,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -8584,6 +9176,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -8696,11 +9296,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 48,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -8736,6 +9352,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -8749,6 +9373,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -8821,6 +9453,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "bar",
         "location": {
@@ -8861,6 +9501,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -8874,6 +9522,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -8946,6 +9602,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "c",
         "location": {
@@ -8970,11 +9634,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -9002,11 +9690,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 61,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -9031,6 +9743,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -9100,6 +9820,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -9175,6 +9903,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -9220,6 +9956,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -9319,6 +10063,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 191,
+          "endColumn": 192
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -9335,11 +10087,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 200,
+          "endColumn": 201
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 201,
           "endColumn": 205
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 205,
+          "endColumn": 206
         }
       },
       {
@@ -9550,6 +10318,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -9571,6 +10347,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -9640,6 +10424,22 @@
         "location": {
           "startColumn": 31,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -9781,6 +10581,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9874,11 +10682,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 48,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -9914,6 +10738,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -9943,6 +10775,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -9978,6 +10818,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -10007,6 +10855,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -10042,6 +10898,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -10074,6 +10938,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -10103,6 +10975,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -10215,11 +11095,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 48,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -10255,6 +11151,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -10268,6 +11172,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -10340,6 +11252,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -10361,6 +11281,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -10388,11 +11316,43 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 59,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -10465,6 +11425,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "b",
         "location": {
@@ -10489,11 +11457,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 50,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -10523,6 +11515,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 12
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
         }
       },
       {
@@ -10571,6 +11571,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -10630,6 +11638,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -10656,6 +11672,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
         }
       },
       {
@@ -10707,11 +11731,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "require",
         "location": {
           "startColumn": 56,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -10728,6 +11768,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -10755,6 +11803,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -10779,6 +11835,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -10792,6 +11856,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -10816,6 +11888,22 @@
         "location": {
           "startColumn": 117,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -10845,6 +11933,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
         }
       },
       {
@@ -10912,11 +12008,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "require",
         "location": {
           "startColumn": 66,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -10933,6 +12045,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -10960,6 +12080,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -10984,6 +12112,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -10997,6 +12133,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -11021,6 +12165,22 @@
         "location": {
           "startColumn": 127,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -11093,6 +12253,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "categoryKeys",
         "location": {
@@ -11117,11 +12285,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 63,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -11157,11 +12341,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 88,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -11303,11 +12511,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 36,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -11353,6 +12585,14 @@
         "location": {
           "startColumn": 8,
           "endColumn": 11
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
         }
       },
       {
@@ -11428,11 +12668,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -11465,6 +12721,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 9,
+          "endColumn": 10
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -11473,11 +12737,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "number",
         "value": "6",
         "location": {
           "startColumn": 12,
           "endColumn": 13
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
         }
       },
       {
@@ -11529,11 +12809,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 41,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -11566,11 +12862,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 9,
+          "endColumn": 10
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 10,
           "endColumn": 13
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
         }
       },
       {
@@ -11595,6 +12907,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 20
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -11638,11 +12958,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 46,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -11715,6 +13051,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -11736,6 +13080,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -11808,6 +13160,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -11837,6 +13205,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 8,
+          "endColumn": 9
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -11845,11 +13221,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 15,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -11893,11 +13285,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 45,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -11970,6 +13378,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -11991,6 +13407,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -12063,6 +13487,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -12116,6 +13548,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -12188,11 +13628,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 33,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -12281,11 +13737,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 44,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -12427,6 +13899,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -12464,11 +13944,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 8,
+          "endColumn": 9
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 9,
           "endColumn": 12
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
         }
       },
       {
@@ -12493,6 +13989,14 @@
         "location": {
           "startColumn": 16,
           "endColumn": 19
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
         }
       },
       {
@@ -12533,6 +14037,22 @@
         "location": {
           "startColumn": 39,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -12605,6 +14125,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -12626,6 +14154,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -12655,6 +14191,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 8
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 8,
+          "endColumn": 9
         }
       },
       {
@@ -12706,6 +14250,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -12714,11 +14266,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
           "startColumn": 42,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -12738,11 +14306,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 52,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -12762,11 +14346,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 62,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -12839,6 +14447,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -12895,6 +14511,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -12935,6 +14559,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -12964,6 +14604,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -12988,6 +14636,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -12996,11 +14652,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 30,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -13068,11 +14748,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 76,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -13084,6 +14780,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -13092,11 +14796,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 91,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -13129,11 +14849,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 13,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -13185,11 +14929,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 47,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -13222,11 +14982,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 13,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -13278,11 +15062,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 47,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -13323,11 +15131,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 13,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -13379,11 +15211,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 47,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -13416,11 +15264,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 13,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -13472,11 +15344,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 50,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -13509,11 +15397,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 12,
+          "endColumn": 13
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 13,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -13565,11 +15477,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 50,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -13642,6 +15570,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -13663,6 +15599,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -13804,11 +15748,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 36,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -13881,11 +15841,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 36,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -13958,11 +15934,43 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 38,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -14022,11 +16030,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 56,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -14083,6 +16115,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -14155,11 +16195,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 35,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -14248,6 +16304,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -14269,6 +16333,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -14301,6 +16373,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -14322,6 +16402,14 @@
         "location": {
           "startColumn": 15,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -14365,11 +16453,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 45,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -14402,6 +16506,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -14423,6 +16535,14 @@
         "location": {
           "startColumn": 15,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -14482,11 +16602,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -14519,6 +16655,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -14540,6 +16684,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 15
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
         }
       },
       {
@@ -14580,6 +16732,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -14639,6 +16799,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -14668,6 +16836,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -14689,6 +16865,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -14761,6 +16945,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -14782,6 +16974,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -14825,11 +17025,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 43,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -14862,6 +17078,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -14883,6 +17107,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -14926,11 +17158,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -14963,6 +17211,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -14984,6 +17240,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -15027,11 +17291,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -15064,6 +17344,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -15085,6 +17373,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -15144,6 +17440,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -15165,6 +17469,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -15197,6 +17509,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -15218,6 +17538,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -15277,11 +17605,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -15314,6 +17658,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -15335,6 +17687,22 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -15386,11 +17754,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 48,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -15423,6 +17807,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -15444,6 +17836,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -15503,11 +17903,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 53,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -15540,6 +17956,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -15561,6 +17985,14 @@
         "location": {
           "startColumn": 14,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -15620,11 +18052,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 54,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -15652,6 +18100,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -15665,6 +18121,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -15697,6 +18161,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -15745,6 +18217,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -15766,6 +18246,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -15798,6 +18286,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -15846,6 +18342,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -15867,6 +18371,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -15896,6 +18408,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 10
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -15947,6 +18467,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "baz",
         "location": {
@@ -15971,11 +18499,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 51,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -16035,6 +18587,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -16061,6 +18621,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 10
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -16141,6 +18709,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -16189,6 +18765,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -16223,6 +18807,14 @@
         "location": {
           "startColumn": 7,
           "endColumn": 10
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -16359,6 +18951,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -16380,6 +18980,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -16452,6 +19060,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -16521,11 +19145,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 39,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -16598,6 +19238,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -16619,6 +19267,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -16691,11 +19347,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 39,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -16861,11 +19533,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 38,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -17254,6 +19950,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -17278,6 +19982,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -17286,11 +19998,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 55,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -17421,6 +20157,14 @@
         "location": {
           "startColumn": 32,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Cast.snap
+++ b/test/__snapshots__/2.2.x/Cast.snap
@@ -247,11 +247,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 18,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       },
       {
@@ -528,6 +544,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -748,6 +772,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -817,6 +849,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -825,11 +865,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'string'",
         "location": {
           "startColumn": 29,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -1083,11 +1139,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 20,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
         }
       },
       {
@@ -1205,6 +1285,22 @@
         "location": {
           "startColumn": 14,
           "endColumn": 19
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -1519,6 +1615,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -1527,11 +1631,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'string'",
         "location": {
           "startColumn": 25,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -1737,11 +1857,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 16,
           "endColumn": 19
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -1835,6 +1979,22 @@
         "location": {
           "startColumn": 10,
           "endColumn": 15
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
         }
       },
       {
@@ -2008,6 +2168,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 9,
+          "endColumn": 10
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "obj",
         "location": {
@@ -2029,6 +2205,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 25
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Classes.snap
+++ b/test/__snapshots__/2.2.x/Classes.snap
@@ -1389,6 +1389,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -1543,6 +1551,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClassConstantVisibility",
         "location": {
@@ -1625,6 +1641,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -4973,6 +4997,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -4994,6 +5026,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -5234,6 +5274,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -5255,6 +5303,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -5460,6 +5516,14 @@
         "location": {
           "startColumn": 30,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -5670,6 +5734,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -5736,6 +5808,14 @@
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -15033,6 +15113,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -15304,6 +15392,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -15581,6 +15677,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -15855,6 +15959,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -15929,6 +16041,14 @@
         "location": {
           "startColumn": 24,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -20692,6 +20812,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -20729,6 +20857,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -20969,11 +21105,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 31,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -21198,6 +21350,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "MixinRule",
         "location": {
@@ -21211,6 +21371,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -21395,6 +21563,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -21432,6 +21608,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -21672,11 +21856,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 33,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -21893,6 +22093,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -21930,6 +22138,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -23948,6 +24164,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleInstanceOf",
         "location": {
@@ -24070,6 +24294,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -25179,6 +25411,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -25607,6 +25847,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -25721,6 +25969,14 @@
         "location": {
           "startColumn": 56,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -26269,11 +26525,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
           "startColumn": 32,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -26378,11 +26650,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
           "startColumn": 32,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -26487,11 +26775,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
           "startColumn": 32,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -26519,11 +26823,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeInterface",
         "location": {
           "startColumn": 68,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -26625,6 +26945,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -27486,6 +27814,14 @@
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -28950,6 +29286,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
+        }
+      },
+      {
         "type": "common_word",
         "value": "IncompatibleRequireExtends",
         "location": {
@@ -29160,6 +29504,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -30114,6 +30466,14 @@
         "location": {
           "startColumn": 24,
           "endColumn": 27
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
         }
       },
       {
@@ -31843,11 +32203,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 104,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -32234,6 +32610,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "MixinRule",
         "location": {
@@ -32247,6 +32631,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -34236,11 +34628,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 95,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -34651,11 +35059,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 65,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -34672,6 +35096,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -34696,6 +35128,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -34808,6 +35248,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -34864,6 +35312,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -34877,6 +35333,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -34901,6 +35365,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -35481,6 +35953,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "RecursiveIterator",
         "location": {
@@ -35502,6 +35982,14 @@
         "location": {
           "startColumn": 120,
           "endColumn": 129
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
         }
       },
       {
@@ -35558,6 +36046,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -35784,6 +36280,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -36162,11 +36666,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 89,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -36183,6 +36703,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -36207,6 +36735,14 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -36311,11 +36847,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 89,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -36332,6 +36884,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -36356,6 +36916,14 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -36670,6 +37238,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "TEnd",
         "location": {
@@ -36803,6 +37379,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "number",
         "value": "16",
         "location": {
@@ -36909,6 +37493,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -37069,6 +37661,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -37093,6 +37693,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -37114,6 +37722,30 @@
         "location": {
           "startColumn": 124,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -39095,6 +39727,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
+        }
+      },
+      {
         "type": "common_word",
         "value": "IncompatibleRequireExtends",
         "location": {
@@ -39305,6 +39945,14 @@
         "location": {
           "startColumn": 126,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -40660,11 +41308,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
           "startColumn": 124,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -43270,11 +43934,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 45,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -43825,11 +44505,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 45,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -44697,6 +45393,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -44718,6 +45422,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -44966,6 +45678,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -44987,6 +45707,14 @@
         "location": {
           "startColumn": 56,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -45227,11 +45955,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 44,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Comparison.snap
+++ b/test/__snapshots__/2.2.x/Comparison.snap
@@ -67,6 +67,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -88,6 +96,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -208,6 +224,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -293,6 +317,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -413,6 +445,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -466,6 +506,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -602,6 +650,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -642,6 +698,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -655,6 +719,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -791,6 +863,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -831,6 +911,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -844,6 +932,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -1331,6 +1427,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -1344,6 +1448,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -1480,6 +1592,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -1493,6 +1613,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -1629,6 +1757,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -1658,6 +1794,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -1794,6 +1938,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -1823,6 +1975,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -1967,11 +2127,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'A'",
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -2116,11 +2292,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -2265,11 +2457,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 83,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -2414,11 +2622,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'A'",
         "location": {
           "startColumn": 83,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -2563,11 +2787,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 83,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -2712,11 +2952,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 83,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -2885,6 +3141,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -2906,6 +3170,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -3074,6 +3346,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -3095,6 +3375,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -3239,6 +3527,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -3255,6 +3551,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -3268,6 +3572,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -3428,6 +3740,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -3441,6 +3761,14 @@
         "location": {
           "startColumn": 82,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -3601,6 +3929,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -3614,6 +3950,14 @@
         "location": {
           "startColumn": 82,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -3790,6 +4134,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -3811,6 +4163,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -3987,6 +4347,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -4008,6 +4376,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -4168,6 +4544,30 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -4176,11 +4576,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 64,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -4325,6 +4741,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
@@ -4349,6 +4773,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'baz'",
         "location": {
@@ -4370,6 +4802,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -4530,6 +4970,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -4570,6 +5018,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -4583,6 +5039,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -4743,6 +5207,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'a'",
         "location": {
@@ -4751,11 +5223,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
           "startColumn": 57,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -4916,6 +5404,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
@@ -4937,6 +5433,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -5097,11 +5601,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 56,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -5262,6 +5782,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -5419,11 +5955,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 52,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -5592,11 +6144,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'A'",
         "location": {
           "startColumn": 92,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -5765,11 +6333,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 92,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -5922,6 +6506,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -5954,11 +6546,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'A'",
         "location": {
           "startColumn": 132,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -6111,6 +6719,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -6143,11 +6759,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 132,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -6316,11 +6948,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 90,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -6489,11 +7137,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 90,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -6662,11 +7326,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'A'",
         "location": {
           "startColumn": 90,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -6835,11 +7515,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 90,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -7032,6 +7728,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -7053,6 +7757,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -7245,6 +7957,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -7266,6 +7986,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -7458,6 +8186,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -7479,6 +8215,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -7671,6 +8415,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -7692,6 +8444,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -7852,6 +8612,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -7868,6 +8636,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -7881,6 +8657,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -8041,6 +8825,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -8054,6 +8846,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -8214,6 +9014,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -8227,6 +9035,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -8387,6 +9203,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -8408,6 +9232,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -8568,11 +9400,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -8733,6 +9581,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
@@ -8754,6 +9610,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -8914,6 +9778,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -9071,6 +9951,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "key",
         "location": {
@@ -9100,6 +9988,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -9148,6 +10044,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -9308,6 +10212,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -9321,6 +10233,14 @@
         "location": {
           "startColumn": 85,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -9481,6 +10401,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -9494,6 +10422,14 @@
         "location": {
           "startColumn": 85,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -9646,6 +10582,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -9659,6 +10603,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -9795,6 +10747,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -9808,6 +10768,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -9944,6 +10912,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -9973,6 +10949,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -10109,6 +11093,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -10122,6 +11114,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -10258,6 +11258,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -10287,6 +11295,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -10423,6 +11439,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "LooseComparisonAgainstEnums",
         "location": {
@@ -10436,6 +11460,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -11197,11 +12229,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 42,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -11322,6 +12370,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -11378,6 +12434,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -11399,6 +12463,22 @@
         "location": {
           "startColumn": 74,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -11519,11 +12599,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "ArrayObject",
         "location": {
           "startColumn": 42,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -11551,6 +12647,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -11564,6 +12668,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -12617,6 +13729,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -13700,6 +14820,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -13721,6 +14849,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -16068,6 +17204,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -16081,6 +17225,22 @@
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -16241,6 +17401,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -16254,6 +17422,22 @@
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -16414,6 +17598,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -16427,6 +17619,22 @@
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -16587,6 +17795,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -16600,6 +17816,22 @@
         "location": {
           "startColumn": 94,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -16760,6 +17992,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -16773,6 +18013,22 @@
         "location": {
           "startColumn": 94,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -17239,6 +18495,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -17279,6 +18543,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -17292,6 +18564,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -19204,6 +20484,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'a'",
         "location": {
@@ -19228,6 +20516,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -19241,6 +20537,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -19265,6 +20569,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -19369,6 +20681,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -19393,6 +20713,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -19406,6 +20734,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -19430,6 +20766,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -19534,6 +20878,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -19547,6 +20907,22 @@
         "location": {
           "startColumn": 70,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -20587,6 +21963,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'a'",
         "location": {
@@ -20611,6 +21995,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -20624,6 +22016,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -20648,6 +22048,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -20752,6 +22160,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -20776,6 +22192,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -20789,6 +22213,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -20813,6 +22245,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -20917,6 +22357,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -20930,6 +22386,22 @@
         "location": {
           "startColumn": 67,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -21656,6 +23128,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -21677,6 +23157,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -22959,6 +24447,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -22980,6 +24476,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -23076,6 +24580,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -23100,6 +24612,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -23113,6 +24633,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -23137,6 +24665,14 @@
         "location": {
           "startColumn": 56,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -23217,6 +24753,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -23238,6 +24782,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -23475,6 +25027,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "6",
         "location": {
@@ -23496,6 +25056,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -23826,6 +25394,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -23847,6 +25423,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -24084,6 +25668,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -24105,6 +25697,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -24535,6 +26135,22 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -24593,6 +26209,22 @@
         "location": {
           "startColumn": 10,
           "endColumn": 12
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
         }
       },
       {
@@ -25071,6 +26703,22 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -25129,6 +26777,22 @@
         "location": {
           "startColumn": 10,
           "endColumn": 12
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 14
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
         }
       },
       {
@@ -25334,6 +26998,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -25355,6 +27027,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -25467,6 +27147,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -25488,6 +27176,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -25600,6 +27296,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -25621,6 +27325,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -25935,11 +27647,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 36,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -26294,6 +28022,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -26315,6 +28051,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -26536,6 +28280,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -26557,6 +28309,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -27273,6 +29033,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -27294,6 +29062,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -27390,6 +29166,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -27411,6 +29195,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -27523,6 +29315,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -27544,6 +29344,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -27656,6 +29464,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -27677,6 +29493,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -27789,6 +29613,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -27810,6 +29642,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -27922,6 +29762,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -27943,6 +29791,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -28055,6 +29911,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -28076,6 +29940,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -28188,6 +30060,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -28209,6 +30089,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -28321,6 +30209,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -28342,6 +30238,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -28470,6 +30374,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -28491,6 +30403,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -28603,6 +30523,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -28624,6 +30552,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -28749,6 +30685,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -28917,6 +30861,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "LastMatchArmAlwaysTrue",
         "location": {
@@ -29079,6 +31031,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -29401,6 +31361,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -29502,11 +31470,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -29611,11 +31595,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -29720,11 +31720,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -29736,6 +31752,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
@@ -29744,11 +31768,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 37,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -30502,6 +32542,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "MatchEnums",
         "location": {
@@ -30635,6 +32683,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -30659,11 +32715,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 39,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -30688,6 +32768,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -30784,6 +32872,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -30805,6 +32901,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -31281,6 +33385,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31302,6 +33414,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -31329,6 +33449,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31350,6 +33478,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       }
     ]
@@ -31438,6 +33574,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31462,6 +33606,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31483,6 +33635,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       }
     ]
@@ -31571,6 +33731,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31595,6 +33763,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31616,6 +33792,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       }
     ]
@@ -31704,6 +33888,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -31744,6 +33936,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -31765,6 +33965,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       }
     ]
@@ -31922,11 +34130,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 53,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -32031,6 +34255,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "MatchEnums",
         "location": {
@@ -32132,6 +34364,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -32156,11 +34396,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 63,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -32185,6 +34449,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       }
     ]
@@ -32381,6 +34653,22 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -32431,6 +34719,22 @@
         "location": {
           "startColumn": 7,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
         }
       },
       {
@@ -32755,6 +35059,22 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 11,
+          "endColumn": 12
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -32816,6 +35136,22 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -32874,6 +35210,22 @@
         "location": {
           "startColumn": 11,
           "endColumn": 13
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
         }
       },
       {
@@ -33352,6 +35704,22 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -33410,6 +35778,22 @@
         "location": {
           "startColumn": 11,
           "endColumn": 13
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
         }
       },
       {
@@ -34168,6 +36552,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -34293,6 +36685,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -34410,6 +36810,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -34450,6 +36858,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -34463,6 +36879,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -34503,6 +36927,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -34599,6 +37031,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "test",
         "location": {
@@ -34623,6 +37063,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -34636,6 +37084,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -34660,6 +37116,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -34756,6 +37220,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "test",
         "location": {
@@ -34780,6 +37252,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -34793,6 +37273,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -34817,6 +37305,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -35971,6 +38467,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -37766,6 +40270,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -37790,11 +40302,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -37819,6 +40355,22 @@
         "location": {
           "startColumn": 56,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -37955,6 +40507,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -37979,11 +40539,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -38008,6 +40592,22 @@
         "location": {
           "startColumn": 56,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -38152,6 +40752,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -38184,6 +40792,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -38213,6 +40829,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -38365,6 +40989,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -38394,6 +41026,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -38745,6 +41385,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -39301,6 +41949,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "StrictComparison",
         "location": {
@@ -39317,11 +41973,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 70,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -39870,11 +42550,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -41490,6 +44186,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "X",
         "location": {
@@ -41546,6 +44250,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -41559,6 +44271,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -41615,6 +44335,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -41711,6 +44439,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "X",
         "location": {
@@ -41767,6 +44503,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -41780,6 +44524,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -41836,6 +44588,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -41932,6 +44692,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "X",
         "location": {
@@ -41956,6 +44724,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -41969,6 +44745,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -41993,6 +44777,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -42097,6 +44889,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$this",
         "location": {
@@ -42142,6 +44942,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -42262,6 +45070,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$this",
         "location": {
@@ -42307,6 +45123,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -42427,6 +45251,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$this",
         "location": {
@@ -42472,6 +45304,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -42592,6 +45432,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$this",
         "location": {
@@ -42637,6 +45485,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -42967,6 +45823,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -42988,6 +45852,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -43100,6 +45972,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -43121,6 +46001,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -43233,6 +46121,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -43254,6 +46150,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -43366,6 +46270,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -43387,6 +46299,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -43499,6 +46419,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "number",
         "value": "10",
         "location": {
@@ -43520,6 +46448,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -43874,6 +46810,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -44012,6 +46956,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -44257,11 +47209,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "INF",
         "location": {
           "startColumn": 52,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -44608,6 +47576,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -44616,11 +47592,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 58,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -45416,6 +48408,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Constants.snap
+++ b/test/__snapshots__/2.2.x/Constants.snap
@@ -474,6 +474,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -604,6 +612,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -2279,6 +2295,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -2300,6 +2324,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -3429,6 +3461,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -3607,6 +3647,14 @@
         "location": {
           "startColumn": 12,
           "endColumn": 15
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
         }
       },
       {
@@ -4278,11 +4326,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 112,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -5302,6 +5366,14 @@
         "location": {
           "startColumn": 5,
           "endColumn": 8
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 8,
+          "endColumn": 9
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Debug.snap
+++ b/test/__snapshots__/2.2.x/Debug.snap
@@ -374,6 +374,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -395,6 +403,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       }
     ]
@@ -432,6 +448,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -489,6 +513,14 @@
           "startColumn": 36,
           "endColumn": 39
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
       }
     ]
   },
@@ -525,6 +557,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -582,6 +622,14 @@
           "startColumn": 36,
           "endColumn": 39
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
       }
     ]
   },
@@ -618,6 +666,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -675,6 +731,14 @@
           "startColumn": 34,
           "endColumn": 37
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
       }
     ]
   },
@@ -711,6 +775,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -768,6 +840,14 @@
           "startColumn": 34,
           "endColumn": 37
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
       }
     ]
   },
@@ -807,6 +887,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "''",
         "location": {
@@ -828,6 +916,14 @@
         "location": {
           "startColumn": 23,
           "endColumn": 25
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       }
     ]
@@ -868,6 +964,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'3.14'",
         "location": {
@@ -889,6 +993,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       }
     ]
@@ -926,6 +1038,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -975,6 +1095,14 @@
           "startColumn": 37,
           "endColumn": 43
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
       }
     ]
   },
@@ -1014,6 +1142,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Shall we dance'",
         "location": {
@@ -1035,6 +1171,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       }
     ]
@@ -1075,6 +1219,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Shall we dance?'",
         "location": {
@@ -1096,6 +1248,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       }
     ]
@@ -1133,6 +1293,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -1254,6 +1422,14 @@
           "startColumn": 103,
           "endColumn": 110
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
       }
     ]
   },
@@ -1293,6 +1469,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo?'",
         "location": {
@@ -1314,6 +1498,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       }
     ]
@@ -1354,6 +1546,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'shall-we-dance?'",
         "location": {
@@ -1375,6 +1575,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       }
     ]
@@ -1415,6 +1623,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'shall_we_dance?'",
         "location": {
@@ -1436,6 +1652,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       }
     ]
@@ -1476,6 +1700,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'shallwedance?'",
         "location": {
@@ -1497,6 +1729,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       }
     ]
@@ -1537,6 +1777,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -1558,6 +1806,14 @@
         "location": {
           "startColumn": 22,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       }
     ]
@@ -1595,6 +1851,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 18
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
         }
       },
       {
@@ -1652,6 +1916,14 @@
           "startColumn": 31,
           "endColumn": 36
         }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
       }
     ]
   },
@@ -1691,6 +1963,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -1712,6 +1992,14 @@
         "location": {
           "startColumn": 22,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       }
     ]
@@ -1752,6 +2040,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "Foo",
         "location": {
@@ -1781,6 +2077,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       }
     ]
@@ -1821,6 +2125,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "shall",
         "location": {
@@ -1858,6 +2170,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       }
     ]
@@ -1898,6 +2218,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "shall",
         "location": {
@@ -1935,6 +2263,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       }
     ]
@@ -1975,6 +2311,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "shallwedance",
         "location": {
@@ -1996,6 +2340,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       }
     ]
@@ -2036,6 +2388,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
@@ -2057,6 +2417,14 @@
         "location": {
           "startColumn": 20,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       }
     ]
@@ -2166,6 +2534,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -2187,6 +2563,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       }
     ]
@@ -2479,11 +2863,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 26,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -2519,11 +2919,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       }
     ]
@@ -2694,11 +3110,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 20,
           "endColumn": 26
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
         }
       },
       {
@@ -2734,11 +3166,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 43,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       }
     ]

--- a/test/__snapshots__/2.2.x/Exceptions.snap
+++ b/test/__snapshots__/2.2.x/Exceptions.snap
@@ -3318,6 +3318,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {

--- a/test/__snapshots__/2.2.x/Functions.snap
+++ b/test/__snapshots__/2.2.x/Functions.snap
@@ -815,6 +815,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClosureReturnTypes",
         "location": {
@@ -921,6 +929,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -1033,6 +1049,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "SomeOtherNamespace",
         "location": {
@@ -1131,6 +1155,30 @@
         "location": {
           "startColumn": 33,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -1402,6 +1450,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -7454,6 +7510,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 14,
+          "endColumn": 15
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'CallCallables\\\\Foo'",
         "location": {
@@ -7475,6 +7539,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -11667,6 +11739,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -11781,6 +11861,14 @@
         "location": {
           "startColumn": 20,
           "endColumn": 24
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -13965,6 +14053,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -15199,6 +15295,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -15220,6 +15324,22 @@
         "location": {
           "startColumn": 66,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -15255,6 +15375,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -15276,6 +15404,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -15348,6 +15484,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -15369,6 +15513,14 @@
         "location": {
           "startColumn": 56,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -15396,6 +15548,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -15417,6 +15577,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -15675,11 +15843,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 73,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -15723,11 +15907,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 106,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -15755,6 +15955,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -15768,6 +15976,14 @@
         "location": {
           "startColumn": 119,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -15856,6 +16072,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -15880,6 +16104,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -15893,6 +16125,22 @@
         "location": {
           "startColumn": 62,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -15936,11 +16184,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -16029,6 +16293,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -16050,6 +16322,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -16093,6 +16373,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "O",
         "location": {
@@ -16130,6 +16418,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -16202,6 +16498,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -16226,11 +16530,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -16258,6 +16586,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "but",
         "location": {
@@ -16282,6 +16618,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -16303,6 +16647,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -16375,6 +16727,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
@@ -16399,11 +16759,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -16431,6 +16815,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "but",
         "location": {
@@ -16455,6 +16847,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -16476,6 +16876,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -16588,6 +16996,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -16609,6 +17025,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -16790,11 +17214,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 47,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -17155,11 +17595,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 42,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -17187,6 +17643,22 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "but",
         "location": {
@@ -17211,11 +17683,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 72,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -17240,6 +17728,22 @@
         "location": {
           "startColumn": 79,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -23715,11 +24219,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 57,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -23755,6 +24283,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23763,11 +24299,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 94,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -30255,6 +30807,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -30268,6 +30828,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -30287,6 +30855,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -30300,6 +30876,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -30332,6 +30916,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -30412,6 +31004,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -30425,6 +31025,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -30617,6 +31225,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -30625,11 +31241,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 33,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -30822,11 +31454,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 27,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -31019,6 +31667,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "''",
         "location": {
@@ -31040,6 +31696,14 @@
         "location": {
           "startColumn": 31,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -31200,11 +31864,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'test'",
         "location": {
           "startColumn": 27,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -31365,11 +32045,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'test'",
         "location": {
           "startColumn": 27,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -31562,6 +32258,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -31599,6 +32303,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -31759,11 +32471,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
           "startColumn": 27,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -31924,11 +32652,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
           "startColumn": 27,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -32121,6 +32865,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -32142,6 +32894,14 @@
         "location": {
           "startColumn": 30,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -32302,6 +33062,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -32323,6 +33091,14 @@
         "location": {
           "startColumn": 30,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -32515,6 +33291,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -32536,6 +33320,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -32696,6 +33488,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -32717,6 +33517,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -32909,6 +33717,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -32930,6 +33746,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -33090,6 +33914,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -33111,6 +33943,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -33303,11 +34143,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 27,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -33500,11 +34356,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 27,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -33697,6 +34569,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
@@ -33718,6 +34598,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -33910,6 +34798,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -34048,6 +34952,22 @@
         "location": {
           "startColumn": 21,
           "endColumn": 26
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
         }
       },
       {
@@ -34192,11 +35112,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 26,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
         }
       },
       {
@@ -34876,11 +35812,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 77,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -35001,11 +35953,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -35126,6 +36094,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "bar",
         "location": {
@@ -35147,6 +36123,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -35182,11 +36166,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 88,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -35339,6 +36339,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35376,6 +36384,14 @@
         "location": {
           "startColumn": 153,
           "endColumn": 154
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
         }
       },
       {
@@ -35528,6 +36544,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35552,6 +36576,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35573,6 +36605,22 @@
         "location": {
           "startColumn": 120,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -35725,6 +36773,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35773,6 +36829,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -35805,6 +36869,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -35834,6 +36906,14 @@
         "location": {
           "startColumn": 166,
           "endColumn": 169
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 169,
+          "endColumn": 170
         }
       },
       {
@@ -35986,6 +37066,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36007,6 +37095,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -36159,6 +37255,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36196,6 +37300,14 @@
         "location": {
           "startColumn": 150,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -36348,6 +37460,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36369,6 +37489,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -36521,6 +37649,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36529,11 +37665,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 105,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -36686,6 +37838,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36734,6 +37894,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -36763,6 +37931,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -36915,6 +38091,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36936,6 +38120,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -37088,6 +38280,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37112,11 +38312,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 108,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -37269,6 +38485,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37306,6 +38530,14 @@
         "location": {
           "startColumn": 148,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -37458,6 +38690,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37487,6 +38727,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -37639,6 +38887,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37663,6 +38919,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37684,6 +38948,22 @@
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -37836,6 +39116,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37857,6 +39145,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -38009,6 +39305,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38033,11 +39337,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 108,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -38190,6 +39510,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38211,6 +39539,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -38363,6 +39699,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38387,11 +39731,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
           "startColumn": 113,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -38544,6 +39904,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38565,6 +39933,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -38717,6 +40093,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38738,6 +40122,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -38890,6 +40282,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38898,11 +40298,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 103,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -39055,11 +40471,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 99,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -39212,6 +40644,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39260,6 +40700,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -39289,6 +40737,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -39441,6 +40897,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39462,6 +40926,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -39614,6 +41086,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39638,11 +41118,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 104,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -39795,6 +41291,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39832,6 +41336,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -39984,6 +41496,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40013,6 +41533,14 @@
         "location": {
           "startColumn": 131,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -40165,6 +41693,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40189,6 +41725,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40210,6 +41754,22 @@
         "location": {
           "startColumn": 111,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -40362,6 +41922,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40383,6 +41951,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -40535,6 +42111,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40559,11 +42143,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 104,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -40716,6 +42316,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40737,6 +42345,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -40889,6 +42505,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40913,11 +42537,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
           "startColumn": 109,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -41070,6 +42710,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41091,6 +42739,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -41243,6 +42899,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41264,6 +42928,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -41416,6 +43088,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41424,11 +43104,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 99,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -41581,11 +43277,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -41738,6 +43450,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41778,11 +43498,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 153,
           "endColumn": 159
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
         }
       },
       {
@@ -41935,6 +43671,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41959,11 +43703,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 108,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -42116,6 +43884,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42124,11 +43900,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 102,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -42281,6 +44073,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42310,6 +44110,14 @@
         "location": {
           "startColumn": 131,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -42478,6 +44286,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42507,6 +44323,14 @@
         "location": {
           "startColumn": 142,
           "endColumn": 159
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
         }
       },
       {
@@ -42659,6 +44483,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42688,6 +44520,14 @@
         "location": {
           "startColumn": 136,
           "endColumn": 143
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
         }
       },
       {
@@ -42840,6 +44680,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42864,11 +44712,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 102,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -43021,6 +44893,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "SortParamCastableToStringFunctionsEnum",
         "location": {
@@ -43042,6 +44922,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -43194,11 +45082,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 90,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -43223,6 +45127,22 @@
         "location": {
           "startColumn": 101,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -43311,11 +45231,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -43332,6 +45268,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -43359,6 +45303,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -43380,6 +45332,22 @@
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -43468,11 +45436,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -43489,6 +45473,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -43516,6 +45508,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -43540,11 +45540,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
           "startColumn": 89,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -43633,11 +45657,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -43654,6 +45694,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -43681,6 +45729,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -43702,6 +45758,22 @@
         "location": {
           "startColumn": 85,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -43854,6 +45926,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -43891,6 +45971,14 @@
         "location": {
           "startColumn": 146,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
         }
       },
       {
@@ -44043,6 +46131,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -44067,6 +46163,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -44088,6 +46192,22 @@
         "location": {
           "startColumn": 113,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -44240,6 +46360,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -44277,6 +46405,14 @@
         "location": {
           "startColumn": 142,
           "endColumn": 143
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
         }
       },
       {
@@ -44429,6 +46565,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -44453,6 +46597,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -44474,6 +46626,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -44559,6 +46727,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -44735,6 +46911,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "SortParamCastableToStringFunctionsEnum",
         "location": {
@@ -44756,6 +46940,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -44908,11 +47100,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 90,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -44937,6 +47145,22 @@
         "location": {
           "startColumn": 101,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -45105,11 +47329,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 99,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -45134,6 +47374,22 @@
         "location": {
           "startColumn": 110,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -45286,6 +47542,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -45323,6 +47587,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -45475,6 +47747,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -45504,6 +47784,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -45656,6 +47944,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -45680,6 +47976,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -45701,6 +48005,22 @@
         "location": {
           "startColumn": 106,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -45853,6 +48173,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -45877,11 +48205,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -45994,6 +48346,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -46015,6 +48375,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -46055,6 +48423,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -46247,6 +48623,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -46284,6 +48668,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -46508,6 +48900,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -46710,6 +49110,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -46963,6 +49371,14 @@
         "location": {
           "startColumn": 102,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -47525,11 +49941,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 57,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -47554,6 +49994,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -47610,6 +50058,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -47698,11 +50154,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "mov",
         "location": {
           "startColumn": 59,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -47738,6 +50210,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -47770,6 +50250,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -47783,6 +50271,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -47807,6 +50303,14 @@
         "location": {
           "startColumn": 116,
           "endColumn": 129
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
         }
       },
       {
@@ -47842,6 +50346,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -47871,6 +50383,14 @@
         "location": {
           "startColumn": 155,
           "endColumn": 159
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
         }
       },
       {
@@ -47906,6 +50426,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 177,
+          "endColumn": 178
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -47938,6 +50466,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 205,
+          "endColumn": 206
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -47951,6 +50487,14 @@
         "location": {
           "startColumn": 208,
           "endColumn": 211
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 211,
+          "endColumn": 212
         }
       },
       {
@@ -47970,11 +50514,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 219,
+          "endColumn": 220
+        }
+      },
+      {
         "type": "common_word",
         "value": "mov",
         "location": {
           "startColumn": 220,
           "endColumn": 223
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 223,
+          "endColumn": 224
         }
       },
       {
@@ -48010,6 +50570,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 240,
+          "endColumn": 241
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -48042,6 +50610,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 261,
+          "endColumn": 262
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -48055,6 +50631,14 @@
         "location": {
           "startColumn": 264,
           "endColumn": 270
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 270,
+          "endColumn": 271
         }
       },
       {
@@ -48079,6 +50663,14 @@
         "location": {
           "startColumn": 277,
           "endColumn": 290
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 290,
+          "endColumn": 291
         }
       },
       {
@@ -48114,6 +50706,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 311,
+          "endColumn": 312
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -48143,6 +50743,14 @@
         "location": {
           "startColumn": 319,
           "endColumn": 323
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 323,
+          "endColumn": 324
         }
       },
       {
@@ -48178,6 +50786,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 341,
+          "endColumn": 342
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -48210,6 +50826,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 369,
+          "endColumn": 370
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -48223,6 +50847,14 @@
         "location": {
           "startColumn": 372,
           "endColumn": 375
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 375,
+          "endColumn": 376
         }
       },
       {
@@ -48319,11 +50951,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTime",
         "location": {
           "startColumn": 70,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -48758,6 +51406,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "policy",
         "location": {
@@ -48830,6 +51486,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -48854,6 +51518,22 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -48867,6 +51547,14 @@
         "location": {
           "startColumn": 129,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -48923,6 +51611,14 @@
         "location": {
           "startColumn": 164,
           "endColumn": 169
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 169,
+          "endColumn": 170
         }
       },
       {
@@ -49237,6 +51933,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$this",
         "location": {
@@ -49290,6 +51994,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -49772,6 +52484,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -50107,6 +52827,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "given",
         "location": {
@@ -50208,11 +52944,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 77,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -50317,6 +53069,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -50325,11 +53085,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "Iterator",
         "location": {
           "startColumn": 87,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -50354,6 +53138,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -50506,6 +53298,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -50546,11 +53346,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 120,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -50562,11 +53378,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
           "startColumn": 130,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -50578,11 +53410,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 143,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -50735,6 +53591,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -50772,6 +53636,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -50924,6 +53796,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -50948,6 +53828,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -50969,6 +53857,22 @@
         "location": {
           "startColumn": 114,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -51121,6 +54025,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -51142,6 +54054,14 @@
         "location": {
           "startColumn": 109,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -51294,6 +54214,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -51342,6 +54270,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -51371,6 +54307,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -51523,6 +54467,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -51560,6 +54512,14 @@
         "location": {
           "startColumn": 149,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -51712,6 +54672,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -51736,6 +54704,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -51757,6 +54733,22 @@
         "location": {
           "startColumn": 116,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -51909,6 +54901,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -51917,11 +54917,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 104,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -52255,6 +55271,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "number",
         "value": "-10",
         "location": {
@@ -52276,6 +55300,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -52444,6 +55476,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "number",
         "value": "-10",
         "location": {
@@ -52465,6 +55505,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -52694,6 +55742,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "number",
         "value": "-10",
         "location": {
@@ -52715,6 +55771,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -52883,6 +55947,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "number",
         "value": "-5",
         "location": {
@@ -52904,6 +55976,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -53011,6 +56091,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -53032,6 +56120,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -53096,6 +56192,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "number",
         "value": "-5",
         "location": {
@@ -53117,6 +56221,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -53224,6 +56336,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -53245,6 +56365,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -53309,6 +56437,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -53330,6 +56466,14 @@
         "location": {
           "startColumn": 26,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -53437,6 +56581,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -53458,6 +56610,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -53522,6 +56682,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -53543,6 +56711,14 @@
         "location": {
           "startColumn": 26,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -53748,6 +56924,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -53958,6 +57142,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -54982,11 +58174,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 65,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -55099,11 +58315,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -55317,11 +58557,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -55434,11 +58698,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 61,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -55870,6 +59158,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -55979,11 +59275,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 54,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -55995,11 +59307,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -56112,11 +59440,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 54,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -56128,11 +59472,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -56245,11 +59605,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 60,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -56261,11 +59637,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 64,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -56378,11 +59770,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 60,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -56394,11 +59802,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 64,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -56516,6 +59940,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -57016,6 +60448,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "Countable",
         "location": {
@@ -57040,11 +60480,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 69,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -57141,11 +60605,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 55,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -57157,11 +60637,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -57173,11 +60669,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 74,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -57189,11 +60701,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -57370,11 +60898,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 55,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -57386,11 +60930,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -57402,11 +60962,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 74,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -57418,11 +60994,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -57591,11 +61183,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 55,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -57607,11 +61215,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -57623,11 +61247,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 74,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -57639,11 +61279,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -57756,11 +61412,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 55,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -57772,11 +61444,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -57788,11 +61476,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 74,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -57804,11 +61508,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -57921,11 +61641,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -57937,11 +61673,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -57953,11 +61705,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -57969,11 +61737,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -58150,11 +61934,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -58166,11 +61966,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -58182,11 +61998,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -58198,11 +62030,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -58371,11 +62219,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -58387,11 +62251,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -58403,11 +62283,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -58419,11 +62315,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -58536,11 +62448,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -58552,11 +62480,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "GMP",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -58568,11 +62512,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "resource",
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -58584,11 +62544,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -58701,11 +62677,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -58717,11 +62709,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -58733,11 +62741,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 75,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -58850,11 +62874,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -58866,11 +62906,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -58882,11 +62938,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 75,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -58999,11 +63071,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -59015,11 +63103,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -59031,11 +63135,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 75,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -59522,6 +63642,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -59535,6 +63663,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -59554,6 +63690,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -59567,6 +63711,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -59599,6 +63751,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -59820,11 +63980,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -59937,11 +64121,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 60,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -60139,11 +64347,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -60160,6 +64384,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -60200,6 +64432,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -60288,11 +64528,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -60309,6 +64565,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -60336,6 +64600,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -60357,6 +64629,22 @@
         "location": {
           "startColumn": 85,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -60445,11 +64733,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -60466,6 +64770,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -60493,6 +64805,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -60501,11 +64821,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 87,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -60594,11 +64938,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 54,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -60618,6 +64978,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -60626,11 +64994,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 73,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -60735,11 +65119,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 58,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -60852,11 +65260,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 57,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -60953,11 +65385,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 51,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -60974,6 +65422,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -61001,6 +65457,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61022,6 +65486,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -61174,6 +65654,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61219,6 +65707,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 124
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -61371,6 +65867,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61408,6 +65912,14 @@
         "location": {
           "startColumn": 146,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
         }
       },
       {
@@ -61560,6 +66072,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61589,6 +66109,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 153
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
         }
       },
       {
@@ -61741,6 +66269,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61762,6 +66298,14 @@
         "location": {
           "startColumn": 102,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -61914,6 +66458,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61951,6 +66503,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 153
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
         }
       },
       {
@@ -62103,6 +66663,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -62132,6 +66700,14 @@
         "location": {
           "startColumn": 139,
           "endColumn": 159
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
         }
       },
       {
@@ -62284,6 +66860,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -62321,6 +66905,14 @@
         "location": {
           "startColumn": 151,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -62473,6 +67065,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -62502,6 +67102,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 158
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
         }
       },
       {
@@ -62614,11 +67222,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'baz'",
         "location": {
           "startColumn": 72,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -62630,11 +67254,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'quux'",
         "location": {
           "startColumn": 84,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -62675,6 +67315,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -62883,6 +67531,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -63088,6 +67744,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -63253,6 +67917,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -63274,6 +67946,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -63386,6 +68066,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -63506,6 +68194,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -63527,6 +68223,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -63751,6 +68455,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -63972,6 +68684,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -64076,6 +68796,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
         "type": "common_word",
         "value": "given",
         "location": {
@@ -64177,6 +68913,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -64198,6 +68942,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -64310,6 +69062,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -64430,6 +69190,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -64451,6 +69219,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -64675,6 +69451,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -64896,6 +69680,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -64997,6 +69789,22 @@
         "location": {
           "startColumn": 115,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -65117,6 +69925,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -65141,11 +69957,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -65202,6 +70034,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -65426,11 +70266,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 75,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -65639,6 +70495,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -65660,6 +70524,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -65884,6 +70756,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -65905,6 +70785,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -66113,6 +71001,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -66134,6 +71030,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -66374,11 +71278,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 83,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -66403,6 +71323,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -66579,11 +71507,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 83,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -66608,6 +71552,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -66792,11 +71744,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 83,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -66821,6 +71789,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -67005,11 +71981,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -67186,11 +72178,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -67375,11 +72383,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -67564,11 +72588,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -67596,11 +72636,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 68,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -67809,11 +72865,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'three'",
         "location": {
           "startColumn": 65,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -67841,11 +72913,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'three'",
         "location": {
           "startColumn": 86,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -68267,11 +73355,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 60,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -68299,11 +73403,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 67,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -68632,6 +73752,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -68733,6 +73861,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -68754,6 +73890,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -69015,11 +74159,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 55,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -69047,11 +74207,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 72,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -69063,6 +74239,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -69071,11 +74255,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 89,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -69092,6 +74292,14 @@
         "location": {
           "startColumn": 96,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -69124,6 +74332,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -69212,11 +74428,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 47,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -69228,11 +74460,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -69244,11 +74492,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 55,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -69260,11 +74524,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "number",
         "value": "7",
         "location": {
           "startColumn": 59,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -69276,11 +74556,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "17",
         "location": {
           "startColumn": 64,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -69292,11 +74588,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "number",
         "value": "19",
         "location": {
           "startColumn": 70,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -69308,6 +74620,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "number",
         "value": "21",
         "location": {
@@ -69316,11 +74636,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "number",
         "value": "22",
         "location": {
           "startColumn": 79,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -69433,6 +74769,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -69441,11 +74785,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 61,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -69558,6 +74918,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -69579,6 +74947,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -69683,6 +75059,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -69704,6 +75088,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -69808,6 +75200,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -69829,6 +75229,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -69933,6 +75341,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -69954,6 +75370,14 @@
         "location": {
           "startColumn": 57,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -70058,11 +75482,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "number",
         "value": "10022",
         "location": {
           "startColumn": 66,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -70098,6 +75538,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -70114,11 +75562,43 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 101,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -70143,6 +75623,14 @@
         "location": {
           "startColumn": 114,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -70228,6 +75716,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -70431,11 +75927,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 145,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -70452,6 +75964,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -70655,6 +76175,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 253,
+          "endColumn": 254
+        }
+      },
+      {
         "type": "common_word",
         "value": "given",
         "location": {
@@ -70737,6 +76265,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -70940,11 +76476,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 145,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -70961,6 +76513,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -71164,6 +76724,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 247,
+          "endColumn": 248
+        }
+      },
+      {
         "type": "common_word",
         "value": "given",
         "location": {
@@ -71246,6 +76814,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -71401,6 +76977,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -71414,6 +76998,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -71566,6 +77158,14 @@
         "location": {
           "startColumn": 173,
           "endColumn": 178
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
         }
       },
       {
@@ -73087,6 +78687,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -76686,6 +82294,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -76856,6 +82472,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -78360,6 +83984,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -78368,11 +84000,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -78400,6 +84048,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -78408,11 +84064,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 101,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -78520,6 +84192,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -78541,6 +84221,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -78645,6 +84333,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -78653,11 +84349,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 80,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -78685,6 +84397,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -78693,11 +84413,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 89,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -78805,6 +84541,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -78826,6 +84570,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -78930,11 +84682,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 72,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -78946,6 +84714,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
@@ -78954,11 +84730,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 78,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -78986,11 +84778,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 85,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -79002,6 +84810,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
@@ -79010,11 +84826,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 91,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -79130,11 +84962,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'12'",
         "location": {
           "startColumn": 127,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -79146,11 +84994,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'14'",
         "location": {
           "startColumn": 137,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -79162,11 +85026,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'16'",
         "location": {
           "startColumn": 147,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -79178,11 +85058,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'22'",
         "location": {
           "startColumn": 157,
           "endColumn": 161
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
         }
       },
       {
@@ -79194,11 +85090,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'24'",
         "location": {
           "startColumn": 167,
           "endColumn": 171
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 171,
+          "endColumn": 172
         }
       },
       {
@@ -79210,11 +85122,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'26'",
         "location": {
           "startColumn": 177,
           "endColumn": 181
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 181,
+          "endColumn": 182
         }
       },
       {
@@ -79226,11 +85154,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 186,
+          "endColumn": 187
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'32'",
         "location": {
           "startColumn": 187,
           "endColumn": 191
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 191,
+          "endColumn": 192
         }
       },
       {
@@ -79242,11 +85186,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 196,
+          "endColumn": 197
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'34'",
         "location": {
           "startColumn": 197,
           "endColumn": 201
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 201,
+          "endColumn": 202
         }
       },
       {
@@ -79258,11 +85218,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 206,
+          "endColumn": 207
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'36'",
         "location": {
           "startColumn": 207,
           "endColumn": 211
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 211,
+          "endColumn": 212
         }
       },
       {
@@ -79274,11 +85250,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 216,
+          "endColumn": 217
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'42'",
         "location": {
           "startColumn": 217,
           "endColumn": 221
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 221,
+          "endColumn": 222
         }
       },
       {
@@ -79290,11 +85282,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 226,
+          "endColumn": 227
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'44'",
         "location": {
           "startColumn": 227,
           "endColumn": 231
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 231,
+          "endColumn": 232
         }
       },
       {
@@ -79306,11 +85314,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 236,
+          "endColumn": 237
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'46'",
         "location": {
           "startColumn": 237,
           "endColumn": 241
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 241,
+          "endColumn": 242
         }
       },
       {
@@ -79322,11 +85346,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 246,
+          "endColumn": 247
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'52'",
         "location": {
           "startColumn": 247,
           "endColumn": 251
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 251,
+          "endColumn": 252
         }
       },
       {
@@ -79338,11 +85378,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 256,
+          "endColumn": 257
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'54'",
         "location": {
           "startColumn": 257,
           "endColumn": 261
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 261,
+          "endColumn": 262
         }
       },
       {
@@ -79354,11 +85410,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 266,
+          "endColumn": 267
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'56'",
         "location": {
           "startColumn": 267,
           "endColumn": 271
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 271,
+          "endColumn": 272
         }
       },
       {
@@ -79370,11 +85442,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 276,
+          "endColumn": 277
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'62'",
         "location": {
           "startColumn": 277,
           "endColumn": 281
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 281,
+          "endColumn": 282
         }
       },
       {
@@ -79386,6 +85474,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 286,
+          "endColumn": 287
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'64'",
         "location": {
@@ -79394,11 +85490,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 291,
+          "endColumn": 292
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'65'",
         "location": {
           "startColumn": 292,
           "endColumn": 296
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 296,
+          "endColumn": 297
         }
       },
       {
@@ -79519,11 +85631,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 72,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -79535,6 +85663,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
@@ -79543,11 +85679,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 78,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -79575,11 +85727,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 85,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -79591,6 +85759,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
@@ -79599,11 +85775,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "number",
         "value": "5",
         "location": {
           "startColumn": 91,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -80041,6 +86233,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -80049,11 +86249,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -80081,6 +86297,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -80089,11 +86313,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 102,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -80201,6 +86441,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -80222,6 +86470,14 @@
         "location": {
           "startColumn": 144,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -80326,11 +86582,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 79,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -80342,11 +86614,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 83,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -80374,11 +86662,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -80390,11 +86694,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 94,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -80502,6 +86822,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -80523,6 +86851,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -80627,6 +86963,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -80635,11 +86979,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 86,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -80667,6 +87027,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -80675,11 +87043,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 103,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -80787,6 +87171,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -80808,6 +87200,14 @@
         "location": {
           "startColumn": 145,
           "endColumn": 146
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
         }
       },
       {
@@ -80912,6 +87312,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -80920,11 +87328,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 82,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -80952,6 +87376,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -80960,11 +87392,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 91,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -81072,6 +87520,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -81093,6 +87549,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -81197,6 +87661,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -81205,11 +87677,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 92,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -81237,6 +87725,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -81245,11 +87741,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -81357,6 +87869,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -81378,6 +87898,14 @@
         "location": {
           "startColumn": 151,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -81482,6 +88010,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -81490,11 +88026,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 88,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -81522,6 +88074,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -81530,11 +88090,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -81642,6 +88218,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -81663,6 +88247,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -81767,6 +88359,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -81775,11 +88375,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 93,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -81807,6 +88423,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -81815,11 +88439,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 110,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -81927,6 +88567,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -81948,6 +88596,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 153
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
         }
       },
       {
@@ -82052,11 +88708,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 87,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -82068,11 +88740,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 91,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -82100,11 +88788,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 98,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -82116,11 +88820,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 102,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -82228,6 +88948,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -82249,6 +88977,14 @@
         "location": {
           "startColumn": 146,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
         }
       },
       {
@@ -82334,6 +89070,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -82462,6 +89206,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -82470,11 +89222,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 81,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -82502,6 +89270,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -82510,11 +89286,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 98,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -82622,6 +89414,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -82643,6 +89443,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -82747,6 +89555,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -82755,11 +89571,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 77,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -82787,6 +89619,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -82795,11 +89635,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 86,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -82907,6 +89763,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -82928,6 +89792,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -83032,6 +89904,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -83053,6 +89933,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -83160,6 +90048,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -83181,6 +90077,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -83285,11 +90189,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 77,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -83301,11 +90221,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -83333,11 +90269,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 88,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -83349,11 +90301,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 92,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -83461,6 +90429,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -83482,6 +90458,14 @@
         "location": {
           "startColumn": 136,
           "endColumn": 137
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
         }
       },
       {
@@ -83586,6 +90570,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -83594,11 +90586,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 91,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -83626,6 +90634,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -83634,11 +90650,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -83746,6 +90778,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -83767,6 +90807,14 @@
         "location": {
           "startColumn": 150,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -83871,6 +90919,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -83879,11 +90935,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 87,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -83911,6 +90983,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -83919,11 +90999,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 96,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -84031,6 +91127,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -84052,6 +91156,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -84156,6 +91268,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -84164,11 +91284,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 89,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -84196,6 +91332,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -84204,11 +91348,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 106,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -84316,6 +91476,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -84337,6 +91505,14 @@
         "location": {
           "startColumn": 148,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -84441,6 +91617,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -84449,11 +91633,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 85,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -84481,6 +91681,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -84489,11 +91697,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 94,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -84601,6 +91825,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -84622,6 +91854,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -84707,6 +91947,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -85021,6 +92269,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -85045,6 +92301,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -85058,6 +92322,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -85082,6 +92354,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -85170,6 +92450,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -85191,6 +92479,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -85292,6 +92588,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -85606,6 +92910,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -85627,6 +92939,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -86191,6 +93511,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -86587,6 +93915,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -86624,6 +93960,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -86768,6 +94112,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -86797,6 +94149,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -87263,6 +94623,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -87271,11 +94639,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -87303,6 +94687,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -87311,11 +94703,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 101,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -87423,6 +94831,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -87444,6 +94860,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -87548,6 +94972,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -87556,11 +94988,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 80,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -87588,6 +95036,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -87596,11 +95052,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 89,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -87708,6 +95180,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -87729,6 +95209,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -87833,6 +95321,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -87841,11 +95337,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 92,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -87873,6 +95385,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'b'",
         "location": {
@@ -87881,11 +95401,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'c'",
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -87993,6 +95529,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -88014,6 +95558,14 @@
         "location": {
           "startColumn": 151,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -88118,6 +95670,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -88126,11 +95686,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 88,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -88158,6 +95734,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -88166,11 +95750,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 97,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -88278,6 +95878,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "number",
         "value": "-1",
         "location": {
@@ -88299,6 +95907,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -89201,6 +96817,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -89225,6 +96849,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -89246,6 +96878,22 @@
         "location": {
           "startColumn": 112,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -89390,6 +97038,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -89414,6 +97070,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -89435,6 +97099,22 @@
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -89579,6 +97259,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -89603,11 +97291,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 105,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -89752,6 +97464,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -89776,11 +97496,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 99,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -89925,11 +97669,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 87,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -89954,6 +97714,22 @@
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -90034,11 +97810,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 51,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -90055,6 +97847,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -90082,6 +97882,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -90103,6 +97911,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -90247,11 +98071,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 87,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -90276,6 +98116,22 @@
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -90420,6 +98276,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -90444,6 +98308,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -90465,6 +98337,22 @@
         "location": {
           "startColumn": 103,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -91223,6 +99111,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -91718,6 +99614,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -91742,6 +99646,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -91763,6 +99675,22 @@
         "location": {
           "startColumn": 111,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -91907,6 +99835,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -91931,6 +99867,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -91952,6 +99896,22 @@
         "location": {
           "startColumn": 113,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -92436,11 +100396,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 55,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -92457,6 +100433,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -92484,6 +100468,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -92505,6 +100497,22 @@
         "location": {
           "startColumn": 86,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -95644,6 +103652,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'CallCallables\\\\CallableInForeach'",
         "location": {
@@ -95668,11 +103684,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 65,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -95777,6 +103809,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'CallCallables\\\\ConstantArrayUnionCallables'",
         "location": {
@@ -95801,11 +103841,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'doFoo'",
         "location": {
           "startColumn": 77,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -95910,11 +103966,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'CallCallables\\\\ConstantArrayUnionCallables'",
         "location": {
           "startColumn": 23,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -95942,11 +104014,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'doFoo'",
         "location": {
           "startColumn": 126,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -96043,11 +104131,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'CallCallables\\\\ConstantArrayUnionCallables'",
         "location": {
           "startColumn": 23,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -96072,6 +104176,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -96176,11 +104288,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'MaybeNotCallable\\\\Bar'",
         "location": {
           "startColumn": 23,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -96237,6 +104365,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -96341,6 +104477,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -96362,6 +104506,14 @@
         "location": {
           "startColumn": 31,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -96466,6 +104618,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -96487,6 +104647,14 @@
         "location": {
           "startColumn": 31,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Generators.snap
+++ b/test/__snapshots__/2.2.x/Generators.snap
@@ -200,6 +200,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -362,6 +370,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -415,6 +431,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -564,6 +588,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -684,6 +716,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -697,6 +737,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {
@@ -753,6 +801,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -817,6 +873,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTime",
         "location": {
@@ -873,6 +937,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -886,6 +958,14 @@
         "location": {
           "startColumn": 85,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -1006,6 +1086,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Generics.snap
+++ b/test/__snapshots__/2.2.x/Generics.snap
@@ -107,6 +107,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -144,6 +152,14 @@
         "location": {
           "startColumn": 163,
           "endColumn": 166
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
         }
       },
       {
@@ -312,6 +328,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -341,6 +365,14 @@
         "location": {
           "startColumn": 126,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -509,6 +541,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -538,6 +578,14 @@
         "location": {
           "startColumn": 123,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
         }
       },
       {
@@ -706,6 +754,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -735,6 +791,14 @@
         "location": {
           "startColumn": 126,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -903,6 +967,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -916,6 +988,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -1076,6 +1156,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1089,6 +1177,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {
@@ -1329,6 +1425,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1342,6 +1446,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -1582,6 +1694,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1595,6 +1715,14 @@
         "location": {
           "startColumn": 102,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -1835,6 +1963,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1848,6 +1984,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -2088,6 +2232,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -2101,6 +2253,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -2341,6 +2501,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2354,6 +2522,14 @@
         "location": {
           "startColumn": 91,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -2610,6 +2786,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2623,6 +2807,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -2879,6 +3071,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2892,6 +3092,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -3148,6 +3356,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -3161,6 +3377,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -3417,6 +3641,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -3430,6 +3662,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -3920,6 +4160,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
         "type": "common_word",
         "value": "iterable",
         "location": {
@@ -3928,11 +4176,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 127,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -4811,6 +5075,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClassAncestorsExtends",
         "location": {
@@ -4824,6 +5096,14 @@
         "location": {
           "startColumn": 128,
           "endColumn": 129
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
         }
       },
       {
@@ -5069,6 +5349,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "common_word",
         "value": "iterable",
         "location": {
@@ -5077,11 +5365,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 136,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -5577,11 +5881,27 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "iterable",
         "location": {
           "startColumn": 123,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -5606,6 +5926,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 143
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
         }
       },
       {
@@ -6149,6 +6477,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "ClassAncestorsImplements",
         "location": {
@@ -6162,6 +6498,14 @@
         "location": {
           "startColumn": 140,
           "endColumn": 141
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
         }
       },
       {
@@ -8011,6 +8355,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -8048,6 +8400,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -8248,11 +8608,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 46,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -8437,6 +8813,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -8474,6 +8858,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -8674,11 +9066,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -8863,11 +9271,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 42,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -9052,6 +9476,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -9089,6 +9521,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -9289,11 +9729,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 50,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -9478,6 +9934,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -9499,6 +9963,14 @@
         "location": {
           "startColumn": 47,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -10303,6 +10775,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "InterfaceAncestorsExtends",
         "location": {
@@ -10316,6 +10796,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -13443,6 +13931,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "InterfaceAncestorsImplements",
         "location": {
@@ -13456,6 +13952,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 153
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
         }
       },
       {
@@ -14262,11 +14766,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -17209,11 +17729,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 91,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -17358,11 +17894,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 84,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -18428,6 +18980,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -18465,6 +19025,14 @@
         "location": {
           "startColumn": 105,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -21570,11 +22138,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 65,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -21964,6 +22548,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21985,6 +22577,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -22193,6 +22793,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -22214,6 +22822,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -22587,6 +23203,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -22608,6 +23232,14 @@
         "location": {
           "startColumn": 129,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -22816,6 +23448,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -22837,6 +23477,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -23045,6 +23693,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -23066,6 +23722,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -34978,6 +35642,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -35023,6 +35695,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -35154,11 +35834,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 220,
+          "endColumn": 221
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 221,
           "endColumn": 227
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 227,
+          "endColumn": 228
         }
       },
       {
@@ -35279,6 +35975,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35300,6 +36004,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -35508,6 +36220,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35529,6 +36249,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -35737,6 +36465,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35758,6 +36494,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -35966,11 +36710,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 74,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -36187,11 +36947,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -36400,6 +37176,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36421,6 +37205,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -36629,6 +37421,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36650,6 +37450,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -36858,6 +37666,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36879,6 +37695,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -37087,11 +37911,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 76,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -37308,6 +38148,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37329,6 +38177,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -37545,6 +38401,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37566,6 +38430,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -37782,6 +38654,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -37803,6 +38683,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -38019,6 +38907,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38040,6 +38936,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -38256,6 +39160,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38277,6 +39189,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -38501,6 +39421,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -38546,6 +39474,14 @@
         "location": {
           "startColumn": 110,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Methods.snap
+++ b/test/__snapshots__/2.2.x/Methods.snap
@@ -1646,6 +1646,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -1667,6 +1675,14 @@
         "location": {
           "startColumn": 45,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -1813,6 +1829,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -2718,11 +2742,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
           "startColumn": 52,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -3421,6 +3461,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "Test",
         "location": {
@@ -3519,6 +3567,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -5075,6 +5131,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "UnitEnum",
         "location": {
@@ -5189,6 +5253,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -11758,6 +11830,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -11957,6 +12037,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -12031,6 +12119,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -12204,6 +12300,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -12270,6 +12374,14 @@
         "location": {
           "startColumn": 28,
           "endColumn": 31
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -12472,6 +12584,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -12546,6 +12666,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -12748,6 +12876,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -12761,6 +12897,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -12833,6 +12977,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -12846,6 +12998,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -12918,6 +13078,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -12931,6 +13099,14 @@
         "location": {
           "startColumn": 93,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -13003,6 +13179,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -13016,6 +13200,14 @@
         "location": {
           "startColumn": 93,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -13093,6 +13285,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -13181,6 +13381,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -13266,6 +13474,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -13343,6 +13559,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -13356,6 +13580,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -13428,6 +13660,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "ImpossibleMethodExistsOnGenericClassString",
         "location": {
@@ -13441,6 +13681,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -13505,6 +13753,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "Test",
         "location": {
@@ -13518,6 +13774,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -13802,6 +14066,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -17792,11 +18064,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 39,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -19595,6 +19883,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "static",
         "location": {
@@ -19648,6 +19944,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -19962,6 +20266,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -19983,6 +20295,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -20140,6 +20460,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -20161,6 +20489,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -20241,6 +20577,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -20262,6 +20606,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -20419,6 +20771,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -20440,6 +20800,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -20467,11 +20835,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -20496,6 +20880,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -20552,11 +20944,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -20584,11 +20992,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -20669,11 +21101,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -20698,6 +21146,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -20741,11 +21205,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 122,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -20770,6 +21250,22 @@
         "location": {
           "startColumn": 132,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -20842,11 +21338,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -20871,6 +21383,22 @@
         "location": {
           "startColumn": 79,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -20914,6 +21442,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -20922,11 +21458,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 125,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -20999,6 +21559,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -21007,11 +21575,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -21055,6 +21647,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -21063,11 +21663,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 120,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -21156,11 +21780,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 87,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -21185,6 +21825,22 @@
         "location": {
           "startColumn": 101,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -21252,11 +21908,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 149,
           "endColumn": 154
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
         }
       },
       {
@@ -21281,6 +21953,22 @@
         "location": {
           "startColumn": 159,
           "endColumn": 165
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 165,
+          "endColumn": 166
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
         }
       },
       {
@@ -21361,6 +22049,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "NewTKey",
         "location": {
@@ -21393,6 +22089,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -21422,6 +22126,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -21465,6 +22177,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -21478,6 +22198,14 @@
         "location": {
           "startColumn": 142,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -21510,6 +22238,14 @@
         "location": {
           "startColumn": 155,
           "endColumn": 160
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 160,
+          "endColumn": 161
         }
       },
       {
@@ -21566,6 +22302,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -21587,6 +22331,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -21614,6 +22366,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -21635,6 +22395,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -21848,11 +22616,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 57,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -21880,6 +22664,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -21901,6 +22693,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -22518,6 +23318,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
@@ -22547,6 +23355,14 @@
         "location": {
           "startColumn": 67,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -22598,11 +23414,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
           "startColumn": 96,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -22614,6 +23446,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -22622,11 +23462,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 113,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -22654,11 +23510,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 137,
           "endColumn": 143
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
         }
       },
       {
@@ -22715,6 +23587,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -22752,6 +23632,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -22795,6 +23683,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -22835,6 +23731,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
         "type": "common_word",
         "value": "non",
         "location": {
@@ -22856,6 +23760,14 @@
         "location": {
           "startColumn": 158,
           "endColumn": 164
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 164,
+          "endColumn": 165
         }
       },
       {
@@ -22888,6 +23800,14 @@
         "location": {
           "startColumn": 180,
           "endColumn": 185
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 185,
+          "endColumn": 186
         }
       },
       {
@@ -22947,6 +23867,38 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 208,
+          "endColumn": 209
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 209,
+          "endColumn": 210
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 210,
+          "endColumn": 211
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 211,
+          "endColumn": 212
+        }
+      },
+      {
         "type": "common_word",
         "value": "but",
         "location": {
@@ -22968,6 +23920,14 @@
         "location": {
           "startColumn": 225,
           "endColumn": 230
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 230,
+          "endColumn": 231
         }
       },
       {
@@ -23011,6 +23971,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 249,
+          "endColumn": 250
+        }
+      },
+      {
         "type": "common_word",
         "value": "gasegyh",
         "location": {
@@ -23043,6 +24011,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 268,
+          "endColumn": 269
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -23064,6 +24040,14 @@
         "location": {
           "startColumn": 285,
           "endColumn": 290
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 290,
+          "endColumn": 291
         }
       },
       {
@@ -23163,6 +24147,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 343,
+          "endColumn": 344
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -23192,6 +24184,14 @@
         "location": {
           "startColumn": 359,
           "endColumn": 364
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 364,
+          "endColumn": 365
         }
       },
       {
@@ -23251,6 +24251,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 397,
+          "endColumn": 398
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 398,
+          "endColumn": 399
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -23283,6 +24299,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 415,
+          "endColumn": 416
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -23307,11 +24331,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 437,
+          "endColumn": 438
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 3.'",
         "location": {
           "startColumn": 438,
           "endColumn": 454
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 454,
+          "endColumn": 455
         }
       },
       {
@@ -23344,6 +24384,14 @@
         "location": {
           "startColumn": 470,
           "endColumn": 475
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 475,
+          "endColumn": 476
         }
       },
       {
@@ -23403,6 +24451,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 507,
+          "endColumn": 508
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 508,
+          "endColumn": 509
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -23435,6 +24499,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 525,
+          "endColumn": 526
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -23459,11 +24531,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 547,
+          "endColumn": 548
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 3.'",
         "location": {
           "startColumn": 548,
           "endColumn": 564
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 564,
+          "endColumn": 565
         }
       },
       {
@@ -23496,6 +24584,14 @@
         "location": {
           "startColumn": 580,
           "endColumn": 585
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 585,
+          "endColumn": 586
         }
       },
       {
@@ -23555,6 +24651,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 618,
+          "endColumn": 619
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 619,
+          "endColumn": 620
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -23603,6 +24715,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 638,
+          "endColumn": 639
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -23627,11 +24747,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 660,
+          "endColumn": 661
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 5.'",
         "location": {
           "startColumn": 661,
           "endColumn": 677
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 677,
+          "endColumn": 678
         }
       },
       {
@@ -23664,6 +24800,14 @@
         "location": {
           "startColumn": 693,
           "endColumn": 698
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 698,
+          "endColumn": 699
         }
       },
       {
@@ -23723,6 +24867,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 731,
+          "endColumn": 732
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 732,
+          "endColumn": 733
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -23763,6 +24923,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 751,
+          "endColumn": 752
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -23787,11 +24955,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 773,
+          "endColumn": 774
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 6.'",
         "location": {
           "startColumn": 774,
           "endColumn": 790
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 790,
+          "endColumn": 791
         }
       },
       {
@@ -23824,6 +25008,14 @@
         "location": {
           "startColumn": 806,
           "endColumn": 811
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 811,
+          "endColumn": 812
         }
       },
       {
@@ -23883,6 +25075,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 843,
+          "endColumn": 844
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 844,
+          "endColumn": 845
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -23931,6 +25139,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 864,
+          "endColumn": 865
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -23955,11 +25171,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 886,
+          "endColumn": 887
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 6.'",
         "location": {
           "startColumn": 887,
           "endColumn": 903
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 903,
+          "endColumn": 904
         }
       },
       {
@@ -23992,6 +25224,14 @@
         "location": {
           "startColumn": 919,
           "endColumn": 924
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 924,
+          "endColumn": 925
         }
       },
       {
@@ -24051,6 +25291,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 957,
+          "endColumn": 958
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 958,
+          "endColumn": 959
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -24099,6 +25355,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 983,
+          "endColumn": 984
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -24123,11 +25387,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1005,
+          "endColumn": 1006
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 6.'",
         "location": {
           "startColumn": 1006,
           "endColumn": 1022
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1022,
+          "endColumn": 1023
         }
       },
       {
@@ -24160,6 +25440,14 @@
         "location": {
           "startColumn": 1038,
           "endColumn": 1043
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1043,
+          "endColumn": 1044
         }
       },
       {
@@ -24219,6 +25507,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1076,
+          "endColumn": 1077
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1077,
+          "endColumn": 1078
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -24275,6 +25579,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1097,
+          "endColumn": 1098
+        }
+      },
+      {
         "type": "common_word",
         "value": "constituencies",
         "location": {
@@ -24299,11 +25611,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1119,
+          "endColumn": 1120
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bács-Kiskun 5.'",
         "location": {
           "startColumn": 1120,
           "endColumn": 1136
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1136,
+          "endColumn": 1137
         }
       },
       {
@@ -24336,6 +25664,14 @@
         "location": {
           "startColumn": 1152,
           "endColumn": 1157
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1157,
+          "endColumn": 1158
         }
       },
       {
@@ -24392,6 +25728,22 @@
         "location": {
           "startColumn": 1180,
           "endColumn": 1190
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1190,
+          "endColumn": 1191
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1191,
+          "endColumn": 1192
         }
       },
       {
@@ -24456,11 +25808,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 59,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -24488,11 +25856,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -24520,6 +25904,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -24533,6 +25925,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -25317,11 +26717,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 122,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -25418,11 +26834,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 191,
+          "endColumn": 192
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 193,
           "endColumn": 201
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 201,
+          "endColumn": 202
         }
       },
       {
@@ -27323,6 +28755,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -27344,6 +28784,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -27658,6 +29106,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -27679,6 +29135,22 @@
         "location": {
           "startColumn": 80,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -28038,6 +29510,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -28059,6 +29539,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -33572,11 +35060,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 45,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -33673,11 +35177,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 76,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -34667,11 +36187,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 53,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -34699,11 +36235,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
           "startColumn": 79,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -34739,6 +36291,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -34752,6 +36312,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -34808,11 +36376,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 53,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -34840,11 +36424,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
           "startColumn": 79,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -34880,6 +36480,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -34893,6 +36501,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -34946,6 +36562,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -35034,6 +36658,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -35116,6 +36748,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -35204,6 +36844,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -35225,6 +36873,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -35252,11 +36908,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 114,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -35313,6 +36985,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -35334,6 +37014,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -35361,6 +37049,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -35382,6 +37078,14 @@
         "location": {
           "startColumn": 128,
           "endColumn": 137
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
         }
       },
       {
@@ -35438,6 +37142,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -35462,6 +37174,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "but",
         "location": {
@@ -35483,6 +37203,14 @@
         "location": {
           "startColumn": 110,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -35523,6 +37251,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -35595,6 +37331,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -35603,11 +37347,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 71,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -35667,6 +37427,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -35675,11 +37443,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 111,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -35696,6 +37480,14 @@
         "location": {
           "startColumn": 121,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -36039,11 +37831,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 72,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -36071,6 +37879,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36092,6 +37908,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -36148,11 +37972,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 76,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -36180,6 +38020,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36201,6 +38049,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -36257,11 +38113,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 70,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -36289,6 +38161,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36297,11 +38177,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 97,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -36358,11 +38254,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 70,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -36390,6 +38302,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -36411,6 +38331,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -36467,6 +38395,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -36491,6 +38427,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -36504,6 +38448,22 @@
         "location": {
           "startColumn": 95,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -36531,6 +38491,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -36555,6 +38523,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -36568,6 +38544,22 @@
         "location": {
           "startColumn": 144,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -36685,6 +38677,14 @@
         "location": {
           "startColumn": 127,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
         }
       },
       {
@@ -37607,6 +39607,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "float",
         "location": {
@@ -37615,11 +39623,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -38333,6 +40357,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -38458,6 +40490,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -38572,6 +40612,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -38692,6 +40740,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -38705,6 +40761,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -38724,6 +40796,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -38737,6 +40817,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -38857,6 +40953,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -38870,6 +40974,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -38889,6 +41009,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -38902,6 +41030,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -38961,6 +41105,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -38974,6 +41126,22 @@
         "location": {
           "startColumn": 172,
           "endColumn": 175
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 175,
+          "endColumn": 176
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
         }
       },
       {
@@ -39001,6 +41169,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 207,
+          "endColumn": 208
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -39017,6 +41193,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 217,
+          "endColumn": 218
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39030,6 +41214,22 @@
         "location": {
           "startColumn": 230,
           "endColumn": 233
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 233,
+          "endColumn": 234
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 234,
+          "endColumn": 235
         }
       },
       {
@@ -39110,6 +41310,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39123,6 +41331,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -39142,6 +41366,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39155,6 +41387,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -39267,6 +41515,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39280,6 +41536,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -39299,6 +41571,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39312,6 +41592,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -39424,6 +41720,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39437,6 +41741,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -39456,6 +41776,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39469,6 +41797,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -39520,6 +41864,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39549,6 +41901,14 @@
         "location": {
           "startColumn": 173,
           "endColumn": 176
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
         }
       },
       {
@@ -39605,6 +41965,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39618,6 +41986,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -39637,6 +42021,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39650,6 +42042,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -39754,6 +42162,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39767,6 +42183,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -39786,6 +42218,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39799,6 +42239,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -39850,6 +42306,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39863,6 +42327,22 @@
         "location": {
           "startColumn": 171,
           "endColumn": 174
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 174,
+          "endColumn": 175
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 175,
+          "endColumn": 176
         }
       },
       {
@@ -39935,6 +42415,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39948,6 +42436,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -39967,6 +42471,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -39980,6 +42492,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -40031,6 +42559,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -40044,6 +42580,22 @@
         "location": {
           "startColumn": 171,
           "endColumn": 174
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 174,
+          "endColumn": 175
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 175,
+          "endColumn": 176
         }
       },
       {
@@ -40116,6 +42668,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -40129,6 +42689,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -40148,6 +42724,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -40161,6 +42745,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -40212,6 +42812,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -40225,6 +42833,22 @@
         "location": {
           "startColumn": 171,
           "endColumn": 174
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 174,
+          "endColumn": 175
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 175,
+          "endColumn": 176
         }
       },
       {
@@ -40297,6 +42921,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -40310,6 +42942,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -40329,6 +42977,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReturnTypes",
         "location": {
@@ -40342,6 +42998,22 @@
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -40701,6 +43373,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -41198,6 +43878,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -41219,6 +43907,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -41246,6 +43942,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -41270,6 +43974,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -41291,6 +44003,22 @@
         "location": {
           "startColumn": 119,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -41347,6 +44075,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -41368,6 +44104,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -41395,6 +44139,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -41419,11 +44171,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 110,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -41687,6 +44463,14 @@
         "location": {
           "startColumn": 128,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -42118,6 +44902,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -42216,6 +45008,14 @@
         "location": {
           "startColumn": 105,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -42320,6 +45120,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -42405,6 +45213,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -42463,6 +45279,14 @@
         "location": {
           "startColumn": 63,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -42575,6 +45399,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -42657,6 +45489,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -43056,6 +45896,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -43077,6 +45925,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -43133,6 +45989,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -43154,6 +46018,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -43181,6 +46053,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -43202,6 +46082,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -43840,6 +46728,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "updated",
         "location": {
@@ -43896,11 +46792,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 99,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -43960,6 +46880,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "common_word",
         "value": "but",
         "location": {
@@ -43981,6 +46909,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 146
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
         }
       },
       {
@@ -44037,6 +46973,14 @@
         "location": {
           "startColumn": 167,
           "endColumn": 168
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 168,
+          "endColumn": 169
         }
       },
       {
@@ -45251,6 +48195,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "WrongListTip",
         "location": {
@@ -45264,6 +48216,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -45307,6 +48267,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "WrongListTip",
         "location": {
@@ -45320,6 +48288,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -45392,6 +48368,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "WrongListTip",
         "location": {
@@ -45405,6 +48389,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -45432,6 +48424,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "WrongListTip",
         "location": {
@@ -45445,6 +48445,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -45501,6 +48509,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "WrongListTip",
         "location": {
@@ -45514,6 +48530,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -45541,6 +48565,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "WrongListTip",
         "location": {
@@ -45554,6 +48586,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -48124,11 +51164,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 38,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -48773,11 +51837,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 141,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -49167,6 +52247,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -49361,6 +52449,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
         }
       },
       {
@@ -49561,6 +52657,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -49758,6 +52862,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -49891,6 +53003,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -49984,6 +53104,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "literal",
         "location": {
@@ -49997,6 +53125,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -50016,11 +53152,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 119,
           "endColumn": 124
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -50109,6 +53261,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "literal",
         "location": {
@@ -50122,6 +53282,14 @@
         "location": {
           "startColumn": 104,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -50141,11 +53309,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 119,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -50234,11 +53418,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 81,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -50359,11 +53559,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 86,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -50391,11 +53607,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 102,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -50463,11 +53695,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 134,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -50572,11 +53828,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 97,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -50593,6 +53865,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -50617,6 +53897,14 @@
         "location": {
           "startColumn": 117,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -52217,11 +55505,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -52233,11 +55537,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "number",
         "value": "4",
         "location": {
           "startColumn": 62,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -52249,11 +55569,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "number",
         "value": "6",
         "location": {
           "startColumn": 66,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -52265,11 +55601,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "number",
         "value": "8",
         "location": {
           "startColumn": 70,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -52430,6 +55782,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -52467,6 +55827,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {
@@ -52595,6 +55963,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "given",
         "location": {
@@ -52688,6 +56072,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -52712,6 +56104,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -52728,11 +56128,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 109,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -53135,6 +56551,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -53156,6 +56580,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -53393,6 +56825,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericObjectLowerBound",
         "location": {
@@ -53409,6 +56849,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericObjectLowerBound",
         "location": {
@@ -53422,6 +56870,14 @@
         "location": {
           "startColumn": 158,
           "endColumn": 161
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
         }
       },
       {
@@ -53449,6 +56905,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 198,
+          "endColumn": 199
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericObjectLowerBound",
         "location": {
@@ -53462,6 +56926,14 @@
         "location": {
           "startColumn": 223,
           "endColumn": 226
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 226,
+          "endColumn": 227
         }
       },
       {
@@ -53566,6 +57038,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -53587,6 +57067,14 @@
         "location": {
           "startColumn": 117,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -53622,6 +57110,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -53635,6 +57131,14 @@
         "location": {
           "startColumn": 165,
           "endColumn": 168
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 168,
+          "endColumn": 169
         }
       },
       {
@@ -53667,6 +57171,14 @@
         "location": {
           "startColumn": 178,
           "endColumn": 183
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 183,
+          "endColumn": 184
         }
       },
       {
@@ -53763,6 +57275,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -53784,6 +57304,14 @@
         "location": {
           "startColumn": 116,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -53811,6 +57339,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -53832,6 +57368,14 @@
         "location": {
           "startColumn": 167,
           "endColumn": 173
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 173,
+          "endColumn": 174
         }
       },
       {
@@ -53968,6 +57512,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -53981,6 +57533,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -54005,6 +57565,14 @@
         "location": {
           "startColumn": 114,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -54141,6 +57709,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -54154,6 +57730,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -54178,6 +57762,14 @@
         "location": {
           "startColumn": 114,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -54314,6 +57906,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -54335,6 +57935,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -54479,6 +58087,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'Bug1971\\\\HelloWorld'",
         "location": {
@@ -54500,6 +58116,14 @@
         "location": {
           "startColumn": 120,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -54644,6 +58268,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -54657,6 +58289,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -54708,6 +58348,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -54721,6 +58369,14 @@
         "location": {
           "startColumn": 139,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -54865,6 +58521,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -54878,6 +58542,14 @@
         "location": {
           "startColumn": 103,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -54929,6 +58601,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -54942,6 +58622,14 @@
         "location": {
           "startColumn": 139,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
         }
       },
       {
@@ -55046,6 +58734,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -55083,6 +58779,14 @@
         "location": {
           "startColumn": 102,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -55256,6 +58960,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -55448,6 +59160,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -55512,6 +59232,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -55549,6 +59277,14 @@
         "location": {
           "startColumn": 131,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -55669,6 +59405,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -55706,6 +59450,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -55879,6 +59631,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -56071,6 +59831,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -56135,6 +59903,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -56172,6 +59948,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -57644,6 +61428,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -58195,11 +61987,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "Person",
         "location": {
           "startColumn": 83,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -58320,6 +62128,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -58410,6 +62226,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -58522,6 +62346,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'La Guardia Airport'",
         "location": {
@@ -58631,11 +62463,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'The Netherlands'",
         "location": {
           "startColumn": 88,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -58663,6 +62511,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -58676,6 +62532,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -58700,6 +62564,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -58788,11 +62660,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'The Netherlands'",
         "location": {
           "startColumn": 88,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -58820,6 +62708,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -58833,6 +62729,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -58857,6 +62761,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -58945,11 +62857,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'The Netherlands'",
         "location": {
           "startColumn": 88,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -58977,6 +62905,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -58993,11 +62929,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
           "startColumn": 136,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -59083,6 +63035,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -59219,11 +63179,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -59283,6 +63259,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -59296,6 +63288,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -59320,6 +63320,14 @@
         "location": {
           "startColumn": 150,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -59416,11 +63424,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -59480,6 +63504,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -59493,6 +63533,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -59517,6 +63565,14 @@
         "location": {
           "startColumn": 150,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -59613,6 +63669,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "newsletterName",
         "location": {
@@ -59669,6 +63733,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -59682,6 +63754,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -59706,6 +63786,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -59794,6 +63882,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTime",
         "location": {
@@ -59802,11 +63898,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "DateTimeImmutable",
         "location": {
           "startColumn": 81,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -59919,6 +64039,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -59943,11 +64071,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 111,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -60424,6 +64568,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 26
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
         }
       },
       {
@@ -61002,6 +65154,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -61196,6 +65356,14 @@
         "location": {
           "startColumn": 17,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -61718,6 +65886,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -61771,6 +65947,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -61915,6 +66099,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -61955,6 +66147,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -61976,6 +66176,22 @@
         "location": {
           "startColumn": 106,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -62003,6 +66219,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -62024,6 +66248,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 166
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
         }
       },
       {
@@ -62136,6 +66368,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -62176,6 +66416,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -62197,6 +66445,22 @@
         "location": {
           "startColumn": 106,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -62224,6 +66488,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -62245,6 +66517,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 166
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
         }
       },
       {
@@ -62272,11 +66552,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 181,
+          "endColumn": 182
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 182,
           "endColumn": 188
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 188,
+          "endColumn": 189
         }
       },
       {
@@ -62386,6 +66682,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -63062,6 +67366,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -63639,6 +67951,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -63660,6 +67980,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -63695,6 +68023,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -63716,6 +68052,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -63820,6 +68164,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -63841,6 +68193,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -63876,11 +68236,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 104,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -64879,6 +69255,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "Throwable",
         "location": {
@@ -64993,6 +69377,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -66559,11 +70951,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 79,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -66673,6 +71081,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -67298,6 +71714,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "common_word",
         "value": "CallMethodsIterables",
         "location": {
@@ -67314,6 +71738,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -67327,6 +71759,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -67351,6 +71791,14 @@
         "location": {
           "startColumn": 117,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -67551,11 +71999,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 171,
+          "endColumn": 172
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 172,
           "endColumn": 177
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 177,
+          "endColumn": 178
         }
       },
       {
@@ -67772,11 +72236,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 174,
+          "endColumn": 175
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 175,
           "endColumn": 180
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 180,
+          "endColumn": 181
         }
       },
       {
@@ -67982,6 +72462,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -68006,11 +72494,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 98,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -68107,6 +72611,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "CallMethodsIterables",
         "location": {
@@ -68120,6 +72632,14 @@
         "location": {
           "startColumn": 119,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -68139,6 +72659,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "CallMethodsIterables",
         "location": {
@@ -68152,6 +72680,14 @@
         "location": {
           "startColumn": 155,
           "endColumn": 158
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
         }
       },
       {
@@ -68240,6 +72776,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "CallMethodsIterables",
         "location": {
@@ -68253,6 +72797,14 @@
         "location": {
           "startColumn": 119,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -68897,6 +73449,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -68918,6 +73478,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -68953,6 +73521,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -68982,6 +73558,14 @@
         "location": {
           "startColumn": 128,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -69086,6 +73670,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69107,6 +73699,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -69142,6 +73742,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69171,6 +73779,14 @@
         "location": {
           "startColumn": 130,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -69275,6 +73891,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -69296,6 +73920,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -69328,6 +73960,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -69368,6 +74008,14 @@
         "location": {
           "startColumn": 132,
           "endColumn": 138
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -69456,11 +74104,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 88,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -69520,6 +74184,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -69536,11 +74216,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 128,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -69565,6 +74261,22 @@
         "location": {
           "startColumn": 140,
           "endColumn": 146
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
         }
       },
       {
@@ -69666,6 +74378,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -69860,6 +74580,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -70318,6 +75046,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 197,
+          "endColumn": 198
+        }
+      },
+      {
         "type": "common_word",
         "value": "PhpParser",
         "location": {
@@ -70331,6 +75067,14 @@
         "location": {
           "startColumn": 208,
           "endColumn": 212
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 212,
+          "endColumn": 213
         }
       },
       {
@@ -70443,11 +75187,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 100,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -70467,11 +75227,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 112,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -70576,11 +75352,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 100,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -70597,6 +75389,22 @@
         "location": {
           "startColumn": 106,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -70685,6 +75493,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -70706,6 +75522,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -70818,6 +75642,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -70839,6 +75671,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -70975,6 +75815,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "b",
         "location": {
@@ -70996,6 +75844,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -71132,6 +75988,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "d",
         "location": {
@@ -71156,6 +76020,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -71177,6 +76049,22 @@
         "location": {
           "startColumn": 93,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -71313,6 +76201,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "c",
         "location": {
@@ -71334,6 +76230,14 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -71470,6 +76374,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -71523,6 +76435,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -71627,6 +76547,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -71680,6 +76608,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -71784,6 +76720,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -71840,6 +76784,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -71853,6 +76805,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -71909,6 +76869,14 @@
         "location": {
           "startColumn": 126,
           "endColumn": 129
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
         }
       },
       {
@@ -71997,6 +76965,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -72053,6 +77029,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -72066,6 +77050,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -72122,6 +77114,22 @@
         "location": {
           "startColumn": 126,
           "endColumn": 129
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -72218,6 +77226,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -72274,6 +77290,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -72290,11 +77314,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -72343,6 +77383,14 @@
         "location": {
           "startColumn": 124,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -72431,6 +77479,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -72484,6 +77540,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -72588,11 +77652,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 90,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -72612,6 +77692,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -72628,11 +77716,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 109,
           "endColumn": 112
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -72649,6 +77753,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -72737,6 +77849,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -72761,6 +77881,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -72777,11 +77905,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -72798,6 +77942,14 @@
         "location": {
           "startColumn": 114,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -72886,6 +78038,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -72907,6 +78067,14 @@
         "location": {
           "startColumn": 93,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -73019,6 +78187,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -73040,6 +78216,14 @@
         "location": {
           "startColumn": 93,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -73200,6 +78384,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -73333,6 +78525,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -73450,6 +78650,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -73474,6 +78682,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -73487,6 +78703,14 @@
         "location": {
           "startColumn": 110,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -73530,11 +78754,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
           "startColumn": 141,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -73623,6 +78863,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "TArray",
         "location": {
@@ -73644,6 +78892,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -73751,11 +79007,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 152,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
         }
       },
       {
@@ -73799,6 +79079,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 186,
+          "endColumn": 187
+        }
+      },
+      {
         "type": "common_word",
         "value": "key",
         "location": {
@@ -73812,6 +79100,14 @@
         "location": {
           "startColumn": 191,
           "endColumn": 193
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 193,
+          "endColumn": 194
         }
       },
       {
@@ -73839,6 +79135,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 209,
+          "endColumn": 210
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -73863,6 +79167,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 219,
+          "endColumn": 220
+        }
+      },
+      {
         "type": "common_word",
         "value": "TArray",
         "location": {
@@ -73884,6 +79196,22 @@
         "location": {
           "startColumn": 230,
           "endColumn": 235
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 235,
+          "endColumn": 236
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 236,
+          "endColumn": 237
         }
       },
       {
@@ -74041,6 +79369,14 @@
         "location": {
           "startColumn": 163,
           "endColumn": 164
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 164,
+          "endColumn": 165
         }
       },
       {
@@ -74560,6 +79896,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -74573,6 +79917,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
         }
       },
       {
@@ -74600,6 +79952,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 170,
+          "endColumn": 171
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -74613,6 +79973,14 @@
         "location": {
           "startColumn": 191,
           "endColumn": 192
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 192,
+          "endColumn": 193
         }
       },
       {
@@ -74709,6 +80077,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -74722,6 +80098,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -74749,6 +80133,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -74762,6 +80154,14 @@
         "location": {
           "startColumn": 179,
           "endColumn": 180
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 180,
+          "endColumn": 181
         }
       },
       {
@@ -74858,6 +80258,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -74871,6 +80279,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -74898,6 +80314,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -74911,6 +80335,14 @@
         "location": {
           "startColumn": 179,
           "endColumn": 180
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 180,
+          "endColumn": 181
         }
       },
       {
@@ -75007,6 +80439,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -75020,6 +80460,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -75047,6 +80495,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -75060,6 +80516,14 @@
         "location": {
           "startColumn": 179,
           "endColumn": 180
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 180,
+          "endColumn": 181
         }
       },
       {
@@ -75148,6 +80612,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -75161,6 +80633,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -75180,6 +80660,22 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -75193,6 +80689,14 @@
         "location": {
           "startColumn": 141,
           "endColumn": 146
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
         }
       },
       {
@@ -75212,6 +80716,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericVarianceCall",
         "location": {
@@ -75225,6 +80737,22 @@
         "location": {
           "startColumn": 197,
           "endColumn": 198
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 198,
+          "endColumn": 199
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 199,
+          "endColumn": 200
         }
       },
       {
@@ -75310,6 +80838,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -75427,6 +80963,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -75763,6 +81307,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -75880,11 +81432,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "wrapperClass",
         "location": {
           "startColumn": 120,
           "endColumn": 132
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -75912,6 +81480,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
         "type": "common_word",
         "value": "TemplateTypeInOneBranchOfConditional",
         "location": {
@@ -75928,6 +81504,22 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 195,
+          "endColumn": 196
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 196,
+          "endColumn": 197
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -75941,6 +81533,14 @@
         "location": {
           "startColumn": 199,
           "endColumn": 204
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 204,
+          "endColumn": 205
         }
       },
       {
@@ -75965,6 +81565,14 @@
         "location": {
           "startColumn": 219,
           "endColumn": 229
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 229,
+          "endColumn": 230
         }
       },
       {
@@ -76838,11 +82446,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 104,
           "endColumn": 109
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -77811,11 +83435,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
           "startColumn": 88,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -77920,6 +83560,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -77941,6 +83589,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -78154,6 +83810,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -78175,6 +83839,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -78279,6 +83951,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -78300,6 +83980,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -79327,6 +85015,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -79380,6 +85076,14 @@
         "location": {
           "startColumn": 117,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -79489,6 +85193,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -79609,11 +85321,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 87,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -79710,6 +85438,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -79734,11 +85470,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 97,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -79835,6 +85587,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -79859,11 +85619,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 103,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -80412,11 +86188,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 84,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -80526,6 +86318,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -81917,6 +87717,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -81938,6 +87746,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -83005,6 +88821,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -83026,6 +88850,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -83154,6 +88986,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "void",
         "location": {
@@ -83207,6 +89047,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -83351,11 +89199,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 70,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -83375,11 +89239,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -83407,6 +89287,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -83420,6 +89308,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -84927,6 +90823,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -84948,6 +90852,14 @@
         "location": {
           "startColumn": 49,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -85347,6 +91259,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -85363,11 +91283,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 81,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -85597,6 +91533,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -85618,6 +91562,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -86718,6 +92670,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "common_word",
         "value": "CallMethodsIterables",
         "location": {
@@ -86731,6 +92691,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -86843,6 +92811,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -86859,11 +92835,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 86,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -87584,11 +93576,27 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
         "type": "common_word",
         "value": "iterable",
         "location": {
           "startColumn": 116,
           "endColumn": 124
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -87605,6 +93613,14 @@
         "location": {
           "startColumn": 146,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -87876,11 +93892,27 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
+        }
+      },
+      {
         "type": "common_word",
         "value": "iterable",
         "location": {
           "startColumn": 124,
           "endColumn": 132
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -87897,6 +93929,14 @@
         "location": {
           "startColumn": 154,
           "endColumn": 157
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 157,
+          "endColumn": 158
         }
       },
       {
@@ -88001,11 +94041,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -91886,6 +97942,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -92035,6 +98099,14 @@
         "location": {
           "startColumn": 157,
           "endColumn": 160
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
         }
       },
       {
@@ -93808,6 +99880,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -93829,6 +99909,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -93928,6 +100016,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -93949,6 +100045,14 @@
         "location": {
           "startColumn": 162,
           "endColumn": 181
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 181,
+          "endColumn": 182
         }
       },
       {
@@ -93984,6 +100088,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 212,
+          "endColumn": 213
+        }
+      },
+      {
         "type": "common_word",
         "value": "PhpParser",
         "location": {
@@ -93997,6 +100109,14 @@
         "location": {
           "startColumn": 223,
           "endColumn": 227
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 227,
+          "endColumn": 228
         }
       },
       {
@@ -94061,6 +100181,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -94082,6 +100210,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -94181,6 +100317,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -94202,6 +100346,14 @@
         "location": {
           "startColumn": 152,
           "endColumn": 171
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 171,
+          "endColumn": 172
         }
       },
       {
@@ -94237,6 +100389,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 202,
+          "endColumn": 203
+        }
+      },
+      {
         "type": "common_word",
         "value": "PhpParser",
         "location": {
@@ -94250,6 +100410,14 @@
         "location": {
           "startColumn": 213,
           "endColumn": 217
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 217,
+          "endColumn": 218
         }
       },
       {
@@ -94314,6 +100482,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -94338,11 +100514,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 43,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -94442,6 +100634,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -94463,6 +100663,14 @@
         "location": {
           "startColumn": 157,
           "endColumn": 176
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
         }
       },
       {
@@ -94498,6 +100706,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 207,
+          "endColumn": 208
+        }
+      },
+      {
         "type": "common_word",
         "value": "PhpParser",
         "location": {
@@ -94511,6 +100727,14 @@
         "location": {
           "startColumn": 218,
           "endColumn": 222
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 222,
+          "endColumn": 223
         }
       },
       {
@@ -94575,6 +100799,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -94596,6 +100828,14 @@
         "location": {
           "startColumn": 24,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -94695,11 +100935,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 136,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -94772,11 +101028,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 18,
+          "endColumn": 19
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 19,
           "endColumn": 25
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -94876,6 +101148,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "common_word",
         "value": "PHPStan",
         "location": {
@@ -94897,6 +101177,14 @@
         "location": {
           "startColumn": 136,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -94932,6 +101220,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 186,
+          "endColumn": 187
+        }
+      },
+      {
         "type": "common_word",
         "value": "PhpParser",
         "location": {
@@ -94945,6 +101241,14 @@
         "location": {
           "startColumn": 197,
           "endColumn": 201
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 201,
+          "endColumn": 202
         }
       },
       {
@@ -95105,6 +101409,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -95126,6 +101438,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -95294,6 +101614,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -95315,6 +101643,14 @@
         "location": {
           "startColumn": 96,
           "endColumn": 99
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
         }
       },
       {
@@ -95387,6 +101723,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -95424,6 +101768,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -95523,6 +101875,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -95552,6 +101912,14 @@
         "location": {
           "startColumn": 151,
           "endColumn": 169
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 169,
+          "endColumn": 170
         }
       },
       {
@@ -95608,6 +101976,22 @@
         "location": {
           "startColumn": 213,
           "endColumn": 214
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 214,
+          "endColumn": 215
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 215,
+          "endColumn": 216
         }
       },
       {
@@ -95680,6 +102064,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -95709,6 +102101,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -95808,6 +102208,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -95829,6 +102237,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 143
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
         }
       },
       {
@@ -95877,6 +102293,22 @@
         "location": {
           "startColumn": 178,
           "endColumn": 179
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 179,
+          "endColumn": 180
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 180,
+          "endColumn": 181
         }
       },
       {
@@ -96045,6 +102477,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -96066,6 +102506,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -96319,6 +102767,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -96513,6 +102969,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -97647,6 +104111,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
+        }
+      },
+      {
         "type": "common_word",
         "value": "key",
         "location": {
@@ -97660,6 +104132,14 @@
         "location": {
           "startColumn": 133,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
         }
       },
       {
@@ -97687,6 +104167,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -97711,6 +104199,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
+        }
+      },
+      {
         "type": "common_word",
         "value": "TArray",
         "location": {
@@ -97732,6 +104228,22 @@
         "location": {
           "startColumn": 172,
           "endColumn": 177
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 177,
+          "endColumn": 178
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
         }
       },
       {
@@ -98347,6 +104859,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -98387,6 +104907,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 164,
+          "endColumn": 165
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -98408,6 +104936,22 @@
         "location": {
           "startColumn": 172,
           "endColumn": 177
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 177,
+          "endColumn": 178
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
         }
       },
       {
@@ -98560,6 +105104,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -98592,6 +105144,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -98613,6 +105173,14 @@
         "location": {
           "startColumn": 173,
           "endColumn": 178
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 178,
+          "endColumn": 179
         }
       },
       {
@@ -98898,6 +105466,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -99044,6 +105620,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -99228,6 +105812,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -99249,6 +105841,14 @@
         "location": {
           "startColumn": 158,
           "endColumn": 163
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
         }
       },
       {
@@ -99425,6 +106025,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -99446,6 +106054,14 @@
         "location": {
           "startColumn": 151,
           "endColumn": 156
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
         }
       },
       {
@@ -99622,6 +106238,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -99643,6 +106267,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -99819,6 +106451,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -99840,6 +106480,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -100016,6 +106664,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -100037,6 +106693,14 @@
         "location": {
           "startColumn": 149,
           "endColumn": 154
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
         }
       },
       {
@@ -100213,6 +106877,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 142
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -100234,6 +106906,14 @@
         "location": {
           "startColumn": 148,
           "endColumn": 153
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
         }
       },
       {
@@ -100878,6 +107558,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -100899,6 +107587,14 @@
         "location": {
           "startColumn": 161,
           "endColumn": 166
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 166,
+          "endColumn": 167
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Missing.snap
+++ b/test/__snapshots__/2.2.x/Missing.snap
@@ -495,6 +495,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -593,6 +601,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -697,6 +713,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -795,6 +819,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -992,6 +1024,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -1090,6 +1130,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -1194,6 +1242,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -1292,6 +1348,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -2233,6 +2297,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -2286,6 +2358,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -2475,6 +2555,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -2528,6 +2616,14 @@
         "location": {
           "startColumn": 118,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Operators.snap
+++ b/test/__snapshots__/2.2.x/Operators.snap
@@ -51,6 +51,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -75,11 +83,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -91,11 +123,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -232,6 +280,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -256,11 +312,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -272,11 +352,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -309,6 +405,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -902,6 +1014,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -918,11 +1046,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "''",
         "location": {
           "startColumn": 47,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -1548,6 +1692,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -1572,11 +1724,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -1588,11 +1764,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -1697,6 +1889,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -1718,6 +1926,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -1745,11 +1961,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -1761,11 +2001,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -1878,6 +2134,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -1902,11 +2166,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -1918,11 +2206,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -2059,6 +2363,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -2083,11 +2395,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -2099,11 +2435,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -2136,6 +2488,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -2761,6 +3129,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -2785,11 +3161,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -2801,11 +3201,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -2910,6 +3326,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -2931,6 +3363,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -2958,11 +3398,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -2974,11 +3438,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -3091,6 +3571,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -3115,11 +3603,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -3131,11 +3643,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -3272,6 +3800,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -3296,11 +3832,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -3312,11 +3872,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -3349,6 +3925,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -4519,6 +5111,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -4543,11 +5143,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -4559,11 +5183,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -4700,6 +5340,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -4724,11 +5372,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -4740,11 +5412,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -4777,6 +5465,22 @@
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -5301,6 +6005,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -5325,11 +6037,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 86,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -5341,11 +6077,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -5450,6 +6202,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -5471,6 +6239,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -5498,11 +6274,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 66,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -5514,11 +6314,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 75,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -5857,6 +6673,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -5881,11 +6705,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -5897,11 +6745,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -6006,6 +6870,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -6027,6 +6907,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -6054,11 +6942,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -6070,11 +6982,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -6187,6 +7115,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -6211,11 +7147,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -6227,11 +7187,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -6368,11 +7344,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 36,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -7232,6 +8232,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -7463,6 +8471,22 @@
         "location": {
           "startColumn": 37,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -8415,6 +9439,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -8439,11 +9471,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -8455,11 +9511,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -8673,6 +9745,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -8697,11 +9777,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -8713,11 +9817,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -8854,6 +9974,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -8878,11 +10006,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -8894,11 +10046,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -8931,6 +10099,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -10428,6 +11612,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -10452,11 +11644,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -10468,11 +11684,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -10678,6 +11910,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -10699,6 +11947,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -10726,11 +11982,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -10742,11 +12022,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -10859,6 +12155,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -10883,11 +12187,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -10899,11 +12227,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -11040,6 +12384,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -11064,11 +12416,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -11080,11 +12456,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -11117,6 +12509,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -11306,11 +12714,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 35,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -11412,6 +12836,30 @@
         "location": {
           "startColumn": 29,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -11976,6 +13424,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -12000,11 +13456,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -12016,11 +13496,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -12125,6 +13621,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -12146,6 +13658,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -12173,11 +13693,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -12189,11 +13733,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -12407,6 +13967,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -12431,11 +13999,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -12447,11 +14039,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -12588,6 +14196,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -12612,11 +14228,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -12628,11 +14268,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -12665,6 +14321,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -13303,6 +14975,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -14372,6 +16052,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -14396,11 +16084,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -14412,11 +16124,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -14521,6 +16249,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -14542,6 +16286,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -14569,11 +16321,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -14585,11 +16361,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -14702,6 +16494,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -14726,11 +16526,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -14742,11 +16566,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -14883,6 +16723,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -14907,11 +16755,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -14923,11 +16795,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -14960,6 +16848,22 @@
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -15585,6 +17489,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -15609,11 +17521,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 86,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -15625,11 +17561,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -15734,6 +17686,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -15755,6 +17723,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -15782,11 +17758,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 66,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -15798,11 +17798,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 75,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -16016,6 +18032,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -16040,11 +18064,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -16056,11 +18104,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -16197,6 +18261,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -16221,11 +18293,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 53,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -16237,11 +18333,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -16274,6 +18386,22 @@
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -16899,6 +19027,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -16923,11 +19059,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 86,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -16939,11 +19099,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 95,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -17048,6 +19224,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -17069,6 +19261,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -17096,11 +19296,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 66,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -17112,11 +19336,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 75,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -17330,6 +19570,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -17354,11 +19602,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -17370,11 +19642,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -17511,6 +19799,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -17535,11 +19831,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -17551,11 +19871,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -17588,6 +19924,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -18011,6 +20363,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -18035,11 +20395,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -18051,11 +20435,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -18160,6 +20560,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -18181,6 +20597,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -18208,11 +20632,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -18224,11 +20672,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -18341,6 +20805,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -18365,11 +20837,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -18381,11 +20877,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -18522,6 +21034,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -18546,11 +21066,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 52,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -18562,11 +21106,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -18599,6 +21159,22 @@
         "location": {
           "startColumn": 82,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -19224,6 +21800,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -19248,11 +21832,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -19264,11 +21872,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 94,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -19373,6 +21997,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "and",
         "location": {
@@ -19394,6 +22034,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -19421,11 +22069,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 65,
           "endColumn": 69
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -19437,11 +22109,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -19543,6 +22231,14 @@
         "location": {
           "startColumn": 18,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       },
       {
@@ -19782,6 +22478,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -19827,11 +22539,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 23,
           "endColumn": 27
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
         }
       },
       {
@@ -19843,11 +22571,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 34,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -19859,11 +22603,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 45,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -20198,6 +22958,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -20434,6 +23202,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -20479,11 +23263,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 23,
           "endColumn": 27
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
         }
       },
       {
@@ -20495,11 +23295,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 34,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -20511,11 +23327,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 45,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -20951,6 +23783,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -20959,11 +23799,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 44,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -21073,6 +23937,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -21403,6 +24275,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -21512,11 +24392,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -21626,6 +24522,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -22049,11 +24953,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 52,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -22163,6 +25083,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -22373,6 +25301,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -22990,6 +25926,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -23099,11 +26043,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 50,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -23213,6 +26173,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -23527,11 +26495,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 53,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -23641,6 +26625,14 @@
         "location": {
           "startColumn": 47,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -23854,6 +26846,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -23944,6 +26944,14 @@
         "location": {
           "startColumn": 34,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -24157,11 +27165,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 39,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -24178,6 +27202,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -24941,6 +27973,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -25212,11 +28252,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 29,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -25228,11 +28284,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -25244,11 +28316,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 51,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -25778,6 +28866,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -26049,11 +29145,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 29,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -26065,11 +29177,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -26081,11 +29209,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 51,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -26530,6 +29674,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -26801,6 +29953,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "results",
         "location": {
@@ -26886,11 +30054,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "bool",
         "location": {
           "startColumn": 29,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -26902,11 +30086,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -26918,11 +30118,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 51,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {

--- a/test/__snapshots__/2.2.x/PhpDoc.snap
+++ b/test/__snapshots__/2.2.x/PhpDoc.snap
@@ -35,6 +35,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "barProp",
         "location": {
@@ -553,6 +561,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -702,6 +718,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "static",
         "location": {
@@ -742,6 +766,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "for",
         "location": {
@@ -755,6 +787,14 @@
         "location": {
           "startColumn": 89,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -806,11 +846,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 123,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -1040,6 +1096,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1053,6 +1117,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -1309,6 +1381,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1322,6 +1402,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -1554,6 +1642,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1567,6 +1663,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -1839,6 +1943,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "contravariant",
         "location": {
@@ -1852,6 +1964,14 @@
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -2108,6 +2228,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2121,6 +2249,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -2393,6 +2529,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2406,6 +2550,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -2654,6 +2806,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2667,6 +2827,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -2955,6 +3123,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "covariant",
         "location": {
@@ -2968,6 +3144,14 @@
         "location": {
           "startColumn": 107,
           "endColumn": 110
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
         }
       },
       {
@@ -4244,6 +4428,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "InvalidArgumentException",
         "location": {
@@ -4265,6 +4457,14 @@
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -4292,6 +4492,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -4305,6 +4513,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -4537,11 +4753,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "InvalidArgumentException",
         "location": {
           "startColumn": 51,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -4750,6 +4982,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -4787,6 +5027,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -5011,6 +5259,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -5048,6 +5304,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -5248,6 +5512,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -5285,6 +5557,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -5525,6 +5805,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -5562,6 +5850,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -5786,6 +6082,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -5823,6 +6127,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -6055,11 +6367,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -6268,11 +6596,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -6457,11 +6801,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -6686,11 +7046,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -6899,11 +7275,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -7120,6 +7512,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -7157,6 +7557,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -7381,11 +7789,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 33,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
         }
       },
       {
@@ -7594,11 +8018,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 33,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -7807,11 +8247,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 47,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -8036,11 +8492,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 47,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -8265,11 +8737,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 39,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -8486,11 +8974,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 39,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -8723,6 +9227,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -8744,6 +9256,14 @@
         "location": {
           "startColumn": 61,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -9763,6 +10283,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -9928,11 +10456,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -10077,6 +10621,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -10098,6 +10650,14 @@
         "location": {
           "startColumn": 79,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -10290,6 +10850,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "TypeAlias",
         "location": {
@@ -10311,6 +10879,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -10527,11 +11103,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 88,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -10910,6 +11502,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -10939,6 +11539,14 @@
         "location": {
           "startColumn": 106,
           "endColumn": 113
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
         }
       },
       {
@@ -11256,6 +11864,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -11309,6 +11925,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -11501,6 +12125,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -11522,6 +12154,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -11722,6 +12362,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -11743,6 +12391,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -11927,6 +12583,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -11980,6 +12644,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -12430,11 +13102,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 57,
           "endColumn": 60
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -12571,6 +13259,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -12691,11 +13387,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
           "startColumn": 93,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -12755,11 +13475,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 134,
           "endColumn": 137
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
         }
       },
       {
@@ -12853,6 +13589,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -13226,11 +13970,27 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "B",
         "location": {
           "startColumn": 41,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -13428,6 +14188,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -13798,6 +14566,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -13819,6 +14595,14 @@
         "location": {
           "startColumn": 85,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -14734,6 +15518,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -14755,6 +15547,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -14939,6 +15739,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -14960,6 +15768,14 @@
         "location": {
           "startColumn": 83,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -15168,6 +15984,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -15189,6 +16013,14 @@
         "location": {
           "startColumn": 80,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -15381,6 +16213,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -15402,6 +16242,14 @@
         "location": {
           "startColumn": 76,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -16131,6 +16979,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -16152,6 +17008,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 76
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -16503,6 +17367,14 @@
         "location": {
           "startColumn": 31,
           "endColumn": 36
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -18582,6 +19454,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'numeric'",
         "location": {
@@ -18603,6 +19483,22 @@
         "location": {
           "startColumn": 63,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -18638,6 +19534,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'names'",
         "location": {
@@ -18659,6 +19563,22 @@
         "location": {
           "startColumn": 102,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 109,
+          "endColumn": 110
         }
       },
       {
@@ -18691,6 +19611,38 @@
         "location": {
           "startColumn": 123,
           "endColumn": 127
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
         }
       },
       {
@@ -19101,11 +20053,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -19742,6 +20710,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -19763,6 +20739,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -19899,11 +20883,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 70,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -20101,11 +21101,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 44,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -20479,11 +21495,27 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "B",
         "location": {
           "startColumn": 42,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -20676,6 +21708,14 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -20697,6 +21737,14 @@
         "location": {
           "startColumn": 44,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -20873,6 +21921,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -20902,6 +21958,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -21062,6 +22126,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21115,6 +22187,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -21283,6 +22363,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21304,6 +22392,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -21464,6 +22560,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21485,6 +22589,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -21645,6 +22757,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -21698,6 +22818,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -21858,6 +22986,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "TypeAlias",
         "location": {
@@ -21879,6 +23015,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -22055,6 +23199,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -22076,6 +23228,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -22265,6 +23425,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -22667,6 +23835,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -22787,11 +23963,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "TKey",
         "location": {
           "startColumn": 73,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -22851,11 +24051,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 114,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -22925,6 +24141,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -23444,6 +24668,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "IteratorAggregate",
         "location": {
@@ -23545,6 +24777,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "Throwable",
         "location": {
@@ -23643,6 +24883,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -23752,6 +25000,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -24074,6 +25330,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "InvalidThrowsPhpDocMergeInherited",
         "location": {
@@ -24183,6 +25447,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "ThrowsWithRequire",
         "location": {
@@ -24289,6 +25561,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -24770,6 +26050,14 @@
         "location": {
           "startColumn": 29,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -25666,6 +26954,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -25868,6 +27164,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -26076,6 +27380,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -26121,6 +27433,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -26576,6 +27896,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -26757,11 +28085,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 130,
           "endColumn": 133
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -27353,6 +28697,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -27893,11 +29245,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 123,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -29074,11 +30442,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 75,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -30566,6 +31950,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -30752,6 +32144,14 @@
         "location": {
           "startColumn": 36,
           "endColumn": 39
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -31114,6 +32514,14 @@
         "location": {
           "startColumn": 37,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -31527,6 +32935,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "T",
         "location": {
@@ -31548,6 +32964,14 @@
         "location": {
           "startColumn": 43,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -31716,6 +33140,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "TInvalid",
         "location": {
@@ -31745,6 +33177,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -31897,6 +33337,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -31918,6 +33366,14 @@
         "location": {
           "startColumn": 48,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -32086,6 +33542,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "TypeAlias",
         "location": {
@@ -32107,6 +33571,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -32323,11 +33795,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -32427,6 +33915,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -32464,6 +33960,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -32536,6 +34040,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "E",
         "location": {
@@ -32565,6 +34077,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -32624,6 +34144,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericSubtype",
         "location": {
@@ -32637,6 +34165,14 @@
         "location": {
           "startColumn": 147,
           "endColumn": 154
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
         }
       },
       {
@@ -32709,6 +34245,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericSubtype",
         "location": {
@@ -32722,6 +34266,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -32781,6 +34333,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "GenericSubtype",
         "location": {
@@ -32794,6 +34354,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -32858,6 +34426,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -32879,6 +34455,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 45
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -32999,6 +34583,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -33020,6 +34612,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -33071,6 +34671,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -33092,6 +34700,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 90
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -33172,6 +34788,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -33249,6 +34873,14 @@
         "location": {
           "startColumn": 99,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -33337,6 +34969,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -33417,6 +35057,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -33486,11 +35134,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "Traversable",
         "location": {
           "startColumn": 32,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -33515,6 +35179,22 @@
         "location": {
           "startColumn": 51,
           "endColumn": 57
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -33566,11 +35246,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
           "startColumn": 89,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -33582,11 +35278,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 101,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -33651,6 +35371,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -33659,11 +35387,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 38,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -33715,11 +35467,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
           "startColumn": 73,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -33731,11 +35499,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 85,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -33800,6 +35592,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -33808,11 +35608,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 38,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -33864,11 +35688,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
           "startColumn": 76,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -33880,11 +35720,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 88,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -33949,11 +35813,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 32,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -34005,6 +35885,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -34026,6 +35914,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -34090,11 +35986,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 32,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -34146,6 +36058,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -34167,6 +36087,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -34231,11 +36159,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 32,
           "endColumn": 35
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
         }
       },
       {
@@ -34287,11 +36231,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 65,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -34356,11 +36316,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 32,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -34412,11 +36388,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 68,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -34481,11 +36473,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 32,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -34537,6 +36545,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "id",
         "location": {
@@ -34558,6 +36574,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -34622,11 +36646,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 32,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -34678,11 +36718,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 67,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -34707,6 +36763,22 @@
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -34771,11 +36843,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 32,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -34827,11 +36915,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 67,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
         }
       },
       {
@@ -34896,11 +37000,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 32,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -34960,6 +37088,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
         "type": "common_word",
         "value": "id",
         "location": {
@@ -34981,6 +37117,22 @@
         "location": {
           "startColumn": 77,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -35053,11 +37205,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -35109,6 +37277,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -35130,6 +37306,14 @@
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -35194,11 +37378,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -35250,11 +37450,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 68,
           "endColumn": 71
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
         }
       },
       {
@@ -35319,6 +37535,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "numeric",
         "location": {
@@ -35332,6 +37556,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 46
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
         }
       },
       {
@@ -35383,6 +37615,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "lowercase",
         "location": {
@@ -35396,6 +37636,14 @@
         "location": {
           "startColumn": 87,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -35415,6 +37663,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "uppercase",
         "location": {
@@ -35428,6 +37684,14 @@
         "location": {
           "startColumn": 119,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -35612,6 +37876,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
+        }
+      },
+      {
         "type": "common_word",
         "value": "lowercase",
         "location": {
@@ -35625,6 +37897,14 @@
         "location": {
           "startColumn": 105,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -35875,6 +38155,22 @@
         "location": {
           "startColumn": 60,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -36282,11 +38578,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 31,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -36343,6 +38655,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -36466,6 +38786,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -36527,11 +38855,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 31,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -36588,6 +38932,14 @@
         "location": {
           "startColumn": 69,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -36711,6 +39063,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
@@ -36772,11 +39132,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 31,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -36836,6 +39212,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -36889,6 +39273,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -36953,11 +39345,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 31,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -37017,6 +39425,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -37070,6 +39486,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -37206,6 +39630,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -37331,6 +39763,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
@@ -37352,6 +39792,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -37756,6 +40204,14 @@
         "location": {
           "startColumn": 26,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -38259,11 +40715,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 137,
           "endColumn": 145
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
         }
       },
       {
@@ -38671,6 +41143,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -38953,6 +41433,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -38974,6 +41462,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -39206,6 +41702,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39227,6 +41731,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -39459,6 +41971,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39480,6 +42000,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -39688,6 +42216,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39709,6 +42245,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -39957,6 +42501,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -39978,6 +42530,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -40210,6 +42770,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40231,6 +42799,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -40471,6 +43047,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -40492,6 +43076,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -40724,11 +43316,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 47,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -40961,11 +43569,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 61,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -41214,11 +43838,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
           "startColumn": 53,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -41459,6 +44099,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41480,6 +44128,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -41712,6 +44368,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41733,6 +44397,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -41965,6 +44637,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -41986,6 +44666,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -42194,6 +44882,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42215,6 +44911,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -42463,6 +45167,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42484,6 +45196,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -42716,6 +45436,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -42737,6 +45465,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 79
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
         }
       },
       {
@@ -42985,6 +45721,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "InvalidArgumentException",
         "location": {
@@ -43006,6 +45750,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Playground.snap
+++ b/test/__snapshots__/2.2.x/Playground.snap
@@ -2735,11 +2735,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 118,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Properties.snap
+++ b/test/__snapshots__/2.2.x/Properties.snap
@@ -3067,6 +3067,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -3638,11 +3646,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "ReflectionClass",
         "location": {
           "startColumn": 59,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -5420,6 +5444,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "TestAccessProperties",
         "location": {
@@ -5510,6 +5542,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -5861,6 +5901,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -5901,6 +5949,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -5914,6 +5970,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -5986,6 +6050,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -6026,6 +6098,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -6039,6 +6119,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 61
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
         }
       },
       {
@@ -6111,11 +6199,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "hello",
         "location": {
           "startColumn": 39,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -6132,6 +6236,14 @@
         "location": {
           "startColumn": 47,
           "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -6528,6 +6640,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -6687,6 +6807,14 @@
         "location": {
           "startColumn": 39,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -11735,6 +11863,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -11865,6 +12001,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -11886,6 +12030,14 @@
         "location": {
           "startColumn": 45,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -11971,6 +12123,14 @@
         "location": {
           "startColumn": 54,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -12067,6 +12227,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -12160,6 +12328,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -12234,6 +12410,14 @@
         "location": {
           "startColumn": 52,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -12436,6 +12620,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -12635,6 +12827,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -12712,6 +12912,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "false",
         "location": {
@@ -12786,6 +12994,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -17215,11 +17431,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 101,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
         }
       },
       {
@@ -17412,6 +17644,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -17425,6 +17665,14 @@
         "location": {
           "startColumn": 125,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -17617,6 +17865,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -17630,6 +17886,14 @@
         "location": {
           "startColumn": 122,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
         }
       },
       {
@@ -17718,6 +17982,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "class",
         "location": {
@@ -17731,6 +18003,14 @@
         "location": {
           "startColumn": 24,
           "endColumn": 30
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {
@@ -18724,6 +19004,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "callable",
         "location": {
@@ -18761,6 +19049,14 @@
         "location": {
           "startColumn": 68,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
         }
       },
       {
@@ -18820,6 +19116,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -18876,6 +19180,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -18929,6 +19241,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -18993,6 +19313,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "AppendedArrayItem",
         "location": {
@@ -19006,6 +19334,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -19049,6 +19385,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "AppendedArrayItem",
         "location": {
@@ -19065,6 +19409,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
+        }
+      },
+      {
         "type": "common_word",
         "value": "AppendedArrayItem",
         "location": {
@@ -19078,6 +19430,14 @@
         "location": {
           "startColumn": 143,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -19142,6 +19502,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "callable",
         "location": {
@@ -19179,6 +19547,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -19238,11 +19614,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 102,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -19267,6 +19659,22 @@
         "location": {
           "startColumn": 134,
           "endColumn": 147
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 147,
+          "endColumn": 148
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -19323,6 +19731,14 @@
         "location": {
           "startColumn": 167,
           "endColumn": 168
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 168,
+          "endColumn": 169
         }
       },
       {
@@ -19387,6 +19803,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "callable",
         "location": {
@@ -19424,6 +19848,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -19483,11 +19915,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 102,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -19512,6 +19960,22 @@
         "location": {
           "startColumn": 115,
           "endColumn": 128
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 129
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 129,
+          "endColumn": 130
         }
       },
       {
@@ -19568,6 +20032,14 @@
         "location": {
           "startColumn": 148,
           "endColumn": 149
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 149,
+          "endColumn": 150
         }
       },
       {
@@ -19632,6 +20104,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
+        }
+      },
+      {
         "type": "common_word",
         "value": "callable",
         "location": {
@@ -19669,6 +20149,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -19728,11 +20216,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 102,
           "endColumn": 107
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
         }
       },
       {
@@ -19773,6 +20277,22 @@
         "location": {
           "startColumn": 114,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -19829,6 +20349,14 @@
         "location": {
           "startColumn": 135,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -19893,11 +20421,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 49,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -19941,6 +20485,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -19949,11 +20501,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 81,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -20018,6 +20586,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -20039,6 +20615,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -20082,11 +20666,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 83,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -20111,6 +20711,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
         }
       },
       {
@@ -20175,6 +20783,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -20196,6 +20812,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -20239,11 +20863,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 89,
           "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -20268,6 +20908,14 @@
         "location": {
           "startColumn": 101,
           "endColumn": 106
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
         }
       },
       {
@@ -20332,6 +20980,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -20340,11 +20996,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 57,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -20369,6 +21041,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -20428,11 +21108,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 103,
           "endColumn": 104
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -20444,11 +21140,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 107,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -20473,6 +21185,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -20537,6 +21257,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -20545,11 +21273,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 57,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -20574,6 +21318,14 @@
         "location": {
           "startColumn": 62,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -20633,6 +21385,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -20654,6 +21414,14 @@
         "location": {
           "startColumn": 108,
           "endColumn": 114
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
         }
       },
       {
@@ -20997,6 +21765,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -21018,6 +21794,14 @@
         "location": {
           "startColumn": 39,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -21061,11 +21845,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 65,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -21106,6 +21906,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -21178,6 +21986,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -21199,6 +22015,14 @@
         "location": {
           "startColumn": 53,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -21242,11 +22066,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -21274,6 +22114,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "mixed",
         "location": {
@@ -21282,11 +22130,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 109,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
         }
       },
       {
@@ -21375,11 +22247,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 47,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -21439,11 +22327,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -21471,6 +22375,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -21484,6 +22396,14 @@
         "location": {
           "startColumn": 98,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -21806,11 +22726,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 47,
           "endColumn": 50
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
         }
       },
       {
@@ -21854,11 +22790,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 74,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -21955,11 +22907,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 48,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -22003,11 +22971,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 75,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -22088,6 +23072,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -22128,11 +23128,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 64,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -22213,6 +23229,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -22253,11 +23285,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 64,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -22338,6 +23386,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -22378,11 +23434,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 59,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -22442,6 +23522,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -22466,11 +23554,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 108
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 108,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
         }
       },
       {
@@ -22660,11 +23772,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 39,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -22708,6 +23836,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -22716,11 +23852,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 71,
           "endColumn": 77
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -22801,11 +23953,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 34,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -22865,11 +24033,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 75,
           "endColumn": 78
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
         }
       },
       {
@@ -22897,6 +24081,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -22910,6 +24102,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -22982,6 +24182,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23003,6 +24211,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -23030,11 +24246,43 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -23078,6 +24326,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23099,6 +24355,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -23126,6 +24390,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -23134,11 +24406,43 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 126,
           "endColumn": 132
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -23211,6 +24515,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23232,6 +24544,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -23259,11 +24579,43 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -23307,6 +24659,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23328,6 +24688,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -23355,6 +24723,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -23363,11 +24739,43 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 124,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -23440,6 +24848,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23461,6 +24877,14 @@
         "location": {
           "startColumn": 42,
           "endColumn": 47
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
         }
       },
       {
@@ -23488,11 +24912,43 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 62,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -23536,6 +24992,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -23557,6 +25021,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -23584,11 +25056,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 120,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -23600,11 +25088,43 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 132,
           "endColumn": 135
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -23693,11 +25213,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 40,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
         }
       },
       {
@@ -23757,11 +25293,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 80,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -23866,6 +25418,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -23887,6 +25447,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -23954,6 +25522,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
@@ -23975,6 +25551,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 119
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
         }
       },
       {
@@ -24079,6 +25663,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -24100,6 +25692,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -24167,6 +25767,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -24188,6 +25796,14 @@
         "location": {
           "startColumn": 112,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -24292,6 +25908,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -24313,6 +25937,14 @@
         "location": {
           "startColumn": 59,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -24380,6 +26012,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
@@ -24401,6 +26041,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -24489,6 +26137,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -24510,6 +26166,14 @@
         "location": {
           "startColumn": 56,
           "endColumn": 65
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -24569,6 +26233,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
@@ -24590,6 +26262,14 @@
         "location": {
           "startColumn": 109,
           "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -24662,6 +26342,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -24702,6 +26390,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -24723,6 +26419,22 @@
         "location": {
           "startColumn": 107,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -24782,6 +26494,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -24822,6 +26542,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 197,
+          "endColumn": 198
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -24846,6 +26574,22 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 219,
+          "endColumn": 220
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 220,
+          "endColumn": 221
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -24867,6 +26611,14 @@
         "location": {
           "startColumn": 229,
           "endColumn": 254
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 254,
+          "endColumn": 255
         }
       },
       {
@@ -24907,6 +26659,22 @@
         "location": {
           "startColumn": 268,
           "endColumn": 281
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 281,
+          "endColumn": 282
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 282,
+          "endColumn": 283
         }
       },
       {
@@ -24995,6 +26763,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -25075,11 +26851,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 85,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -25104,6 +26896,14 @@
         "location": {
           "startColumn": 97,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -25176,11 +26976,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 37,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -25232,6 +27056,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "Bug",
         "location": {
@@ -25256,11 +27088,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 83,
           "endColumn": 86
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 87
         }
       },
       {
@@ -25333,11 +27181,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 37,
           "endColumn": 40
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -25389,6 +27261,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -25397,11 +27277,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 74,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
         }
       },
       {
@@ -25474,6 +27370,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
         "type": "common_word",
         "value": "name",
         "location": {
@@ -25530,6 +27434,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -25567,6 +27479,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
         }
       },
       {
@@ -25623,6 +27543,14 @@
         "location": {
           "startColumn": 111,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -25695,11 +27623,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 51,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -25759,6 +27703,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -25815,11 +27775,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 115,
           "endColumn": 120
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
         }
       },
       {
@@ -25879,11 +27855,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 155,
           "endColumn": 158
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 158,
+          "endColumn": 159
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 159,
+          "endColumn": 160
         }
       },
       {
@@ -25972,6 +27972,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
         "type": "common_word",
         "value": "name",
         "location": {
@@ -26028,6 +28036,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -26065,6 +28081,14 @@
         "location": {
           "startColumn": 88,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -26121,6 +28145,14 @@
         "location": {
           "startColumn": 113,
           "endColumn": 124
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 124,
+          "endColumn": 125
         }
       },
       {
@@ -26209,11 +28241,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 53,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -26273,6 +28321,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -26329,11 +28393,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 117,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -26393,11 +28473,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 157
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 157,
           "endColumn": 160
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 160,
+          "endColumn": 161
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 161,
+          "endColumn": 162
         }
       },
       {
@@ -26486,11 +28590,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 53,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -26550,6 +28670,22 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
         "type": "rparen",
         "value": ")",
         "location": {
@@ -26606,11 +28742,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 117,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -26670,11 +28822,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 151,
           "endColumn": 154
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -26755,6 +28931,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -26776,6 +28960,22 @@
         "location": {
           "startColumn": 53,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
         }
       },
       {
@@ -26859,6 +29059,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -26880,6 +29088,14 @@
         "location": {
           "startColumn": 118,
           "endColumn": 123
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -26952,6 +29168,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -26973,6 +29197,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 34
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -27218,6 +29450,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -27239,6 +29479,14 @@
         "location": {
           "startColumn": 118,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -27290,6 +29538,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 193,
+          "endColumn": 194
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -27311,6 +29567,14 @@
         "location": {
           "startColumn": 199,
           "endColumn": 205
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 205,
+          "endColumn": 206
         }
       },
       {
@@ -27383,6 +29647,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -27404,6 +29676,14 @@
         "location": {
           "startColumn": 110,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
         }
       },
       {
@@ -27455,6 +29735,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 181,
+          "endColumn": 182
+        }
+      },
+      {
         "type": "lparen",
         "value": "(",
         "location": {
@@ -27468,6 +29756,14 @@
         "location": {
           "startColumn": 183,
           "endColumn": 186
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 186,
+          "endColumn": 187
         }
       },
       {
@@ -27500,6 +29796,14 @@
         "location": {
           "startColumn": 196,
           "endColumn": 201
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 201,
+          "endColumn": 202
         }
       },
       {
@@ -27564,11 +29868,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 53,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -27620,6 +29940,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -27641,6 +29969,14 @@
         "location": {
           "startColumn": 81,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -27705,6 +30041,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -27726,6 +30070,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -27769,11 +30121,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 80,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -27785,11 +30153,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 84,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -27862,6 +30246,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -27883,6 +30275,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -27926,11 +30326,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 80,
           "endColumn": 81
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
         }
       },
       {
@@ -27942,11 +30358,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 84,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -28019,6 +30451,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -28040,6 +30480,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -28083,6 +30531,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -28091,11 +30547,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 82,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -28168,6 +30640,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -28189,6 +30669,14 @@
         "location": {
           "startColumn": 58,
           "endColumn": 59
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
         }
       },
       {
@@ -28232,6 +30720,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -28240,11 +30736,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 82,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -30763,6 +33275,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -30784,6 +33304,22 @@
         "location": {
           "startColumn": 85,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -31316,6 +33852,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "PropertiesAssignedTypes",
         "location": {
@@ -31329,6 +33873,22 @@
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -31348,6 +33908,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "PropertiesAssignedTypes",
         "location": {
@@ -31361,6 +33929,22 @@
         "location": {
           "startColumn": 127,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -31497,6 +34081,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "PropertiesAssignedTypes",
         "location": {
@@ -31510,6 +34102,22 @@
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -31529,6 +34137,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "PropertiesAssignedTypes",
         "location": {
@@ -31542,6 +34158,22 @@
         "location": {
           "startColumn": 127,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -31678,6 +34310,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "PropertiesAssignedTypes",
         "location": {
@@ -31691,6 +34331,22 @@
         "location": {
           "startColumn": 88,
           "endColumn": 91
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
         }
       },
       {
@@ -31710,6 +34366,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "common_word",
         "value": "PropertiesAssignedTypes",
         "location": {
@@ -31723,6 +34387,22 @@
         "location": {
           "startColumn": 127,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -31790,6 +34470,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 190,
+          "endColumn": 191
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -31819,6 +34507,14 @@
         "location": {
           "startColumn": 220,
           "endColumn": 223
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 223,
+          "endColumn": 224
         }
       },
       {
@@ -32202,11 +34898,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 60,
           "endColumn": 66
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
         }
       },
       {
@@ -32311,6 +35023,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
@@ -32319,11 +35039,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 66,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -32383,11 +35127,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 106,
+          "endColumn": 107
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
           "startColumn": 107,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -32399,11 +35159,35 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 120,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -32468,6 +35252,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 60,
+          "endColumn": 61
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
@@ -32476,11 +35268,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 66,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -32585,6 +35401,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
@@ -32606,6 +35430,14 @@
         "location": {
           "startColumn": 55,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -32649,6 +35481,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -32670,6 +35510,14 @@
         "location": {
           "startColumn": 84,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -32734,6 +35582,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -32755,6 +35611,14 @@
         "location": {
           "startColumn": 57,
           "endColumn": 58
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
         }
       },
       {
@@ -32798,6 +35662,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "min",
         "location": {
@@ -32819,6 +35691,14 @@
         "location": {
           "startColumn": 86,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -33024,11 +35904,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 80,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -33199,6 +36095,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
         }
       },
       {
@@ -34733,11 +37637,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 47,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -34850,11 +37770,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 47,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
         }
       },
       {
@@ -35031,11 +37967,27 @@
         }
       },
       {
+        "type": "lbracket",
+        "value": "[",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "common_word",
         "value": "Override",
         "location": {
           "startColumn": 114,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rbracket",
+        "value": "]",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -35108,11 +38060,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 53,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -35156,11 +38124,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 81,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -35188,6 +38172,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -35201,6 +38193,14 @@
         "location": {
           "startColumn": 94,
           "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
         }
       },
       {
@@ -35265,6 +38265,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
@@ -35273,11 +38281,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 65,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -35321,6 +38353,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -35329,11 +38369,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 100,
           "endColumn": 103
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
         }
       },
       {
@@ -35361,6 +38417,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 110,
+          "endColumn": 111
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -35374,6 +38438,22 @@
         "location": {
           "startColumn": 113,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -35454,11 +38534,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 64,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -35502,11 +38598,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 92,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -36866,6 +39978,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -36906,6 +40026,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -36919,6 +40047,14 @@
         "location": {
           "startColumn": 32,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -36983,6 +40119,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 15,
+          "endColumn": 16
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -37004,6 +40148,22 @@
         "location": {
           "startColumn": 21,
           "endColumn": 24
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 26
         }
       },
       {
@@ -40881,11 +44041,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
           "startColumn": 59,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
         }
       },
       {
@@ -40953,11 +44129,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "object",
         "location": {
           "startColumn": 105,
           "endColumn": 111
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
         }
       },
       {
@@ -41086,6 +44278,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -41107,6 +44307,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -41182,6 +44390,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
@@ -41203,6 +44419,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 144
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
         }
       },
       {
@@ -41331,6 +44555,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -41352,6 +44584,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -41427,6 +44667,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -41448,6 +44696,14 @@
         "location": {
           "startColumn": 137,
           "endColumn": 143
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
         }
       },
       {
@@ -41576,6 +44832,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -41597,6 +44861,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
         }
       },
       {
@@ -41672,6 +44944,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
@@ -41693,6 +44973,14 @@
         "location": {
           "startColumn": 138,
           "endColumn": 146
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
         }
       },
       {
@@ -41805,6 +45093,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
         "type": "common_word",
         "value": "stdClass",
         "location": {
@@ -41826,6 +45122,14 @@
         "location": {
           "startColumn": 75,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {
@@ -41893,6 +45197,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
         "type": "common_word",
         "value": "Exception",
         "location": {
@@ -41914,6 +45226,14 @@
         "location": {
           "startColumn": 134,
           "endColumn": 142
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 143
         }
       },
       {
@@ -41994,6 +45314,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 47,
+          "endColumn": 48
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -42015,6 +45343,14 @@
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -42055,6 +45391,14 @@
         "location": {
           "startColumn": 71,
           "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -42494,6 +45838,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -42515,6 +45867,14 @@
         "location": {
           "startColumn": 92,
           "endColumn": 98
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 99
         }
       },
       {
@@ -42590,11 +45950,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 145
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 145,
           "endColumn": 148
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 149
         }
       },
       {
@@ -42619,6 +45995,14 @@
         "location": {
           "startColumn": 157,
           "endColumn": 163
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 163,
+          "endColumn": 164
         }
       },
       {
@@ -43140,6 +46524,14 @@
         "location": {
           "startColumn": 64,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Regexp.snap
+++ b/test/__snapshots__/2.2.x/Regexp.snap
@@ -75,6 +75,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
+        }
+      },
+      {
         "type": "common_word",
         "value": "to",
         "location": {
@@ -322,6 +330,14 @@
         "location": {
           "startColumn": 60,
           "endColumn": 64
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
         }
       },
       {
@@ -636,6 +652,14 @@
         "location": {
           "startColumn": 100,
           "endColumn": 101
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -977,6 +1001,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -1158,6 +1190,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -1336,6 +1376,14 @@
         "location": {
           "startColumn": 95,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {

--- a/test/__snapshots__/2.2.x/TooWideTypehints.snap
+++ b/test/__snapshots__/2.2.x/TooWideTypehints.snap
@@ -1179,6 +1179,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -1344,6 +1352,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 68
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -1506,6 +1522,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 68
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -4395,6 +4419,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -4541,6 +4573,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -4693,6 +4733,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$b",
         "location": {
@@ -4839,6 +4887,14 @@
         "location": {
           "startColumn": 73,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
         }
       },
       {
@@ -4991,6 +5047,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -5137,6 +5201,14 @@
         "location": {
           "startColumn": 65,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
         }
       },
       {
@@ -5289,6 +5361,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -5435,6 +5515,14 @@
         "location": {
           "startColumn": 72,
           "endColumn": 74
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
         }
       },
       {
@@ -5587,6 +5675,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -5736,6 +5832,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -5882,6 +5986,14 @@
         "location": {
           "startColumn": 70,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
         }
       },
       {
@@ -7534,11 +7646,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 33,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -7563,6 +7691,22 @@
         "location": {
           "startColumn": 44,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -7646,11 +7790,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 134,
           "endColumn": 139
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
         }
       },
       {
@@ -7675,6 +7835,22 @@
         "location": {
           "startColumn": 145,
           "endColumn": 150
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
         }
       },
       {
@@ -7739,11 +7915,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 33,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -7768,6 +7960,22 @@
         "location": {
           "startColumn": 44,
           "endColumn": 48
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -7835,11 +8043,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 134,
+          "endColumn": 135
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 135,
           "endColumn": 140
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 140,
+          "endColumn": 141
         }
       },
       {
@@ -7864,6 +8088,22 @@
         "location": {
           "startColumn": 146,
           "endColumn": 151
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 152
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 152,
+          "endColumn": 153
         }
       },
       {
@@ -7925,6 +8165,14 @@
         "location": {
           "startColumn": 38,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -8109,6 +8357,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -8287,6 +8543,14 @@
         "location": {
           "startColumn": 41,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
         }
       },
       {
@@ -8471,6 +8735,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -8652,6 +8924,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -8809,11 +9089,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 18,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       },
       {
@@ -8838,6 +9134,22 @@
         "location": {
           "startColumn": 29,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -8921,11 +9233,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 119,
+          "endColumn": 120
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 120,
           "endColumn": 125
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
         }
       },
       {
@@ -8950,6 +9278,22 @@
         "location": {
           "startColumn": 131,
           "endColumn": 136
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
         }
       },
       {
@@ -8990,11 +9334,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 18,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       },
       {
@@ -9019,6 +9379,22 @@
         "location": {
           "startColumn": 29,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -9086,11 +9462,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 121,
           "endColumn": 126
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
         }
       },
       {
@@ -9115,6 +9507,22 @@
         "location": {
           "startColumn": 132,
           "endColumn": 137
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 137,
+          "endColumn": 138
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 139
         }
       },
       {
@@ -9155,11 +9563,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 18,
           "endColumn": 23
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 23,
+          "endColumn": 24
         }
       },
       {
@@ -9171,11 +9595,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 28,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -9243,6 +9691,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 121
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -9251,11 +9707,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 127,
           "endColumn": 130
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 130,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
         }
       },
       {
@@ -9296,6 +9776,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9320,6 +9808,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -9328,11 +9824,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 35,
           "endColumn": 41
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
         }
       },
       {
@@ -9400,6 +9912,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9424,6 +9944,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 143,
+          "endColumn": 144
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -9432,11 +9960,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 150,
+          "endColumn": 151
+        }
+      },
+      {
         "type": "common_word",
         "value": "true",
         "location": {
           "startColumn": 151,
           "endColumn": 155
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 155,
+          "endColumn": 156
         }
       },
       {
@@ -10044,11 +10588,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 11,
           "endColumn": 16
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
         }
       },
       {
@@ -10073,6 +10633,22 @@
         "location": {
           "startColumn": 22,
           "endColumn": 26
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
         }
       },
       {
@@ -10156,11 +10732,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 100,
           "endColumn": 105
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 106
         }
       },
       {
@@ -10185,6 +10777,22 @@
         "location": {
           "startColumn": 111,
           "endColumn": 116
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Traits.snap
+++ b/test/__snapshots__/2.2.x/Traits.snap
@@ -660,6 +660,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -729,6 +737,14 @@
         "location": {
           "startColumn": 173,
           "endColumn": 176
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 176,
+          "endColumn": 177
         }
       },
       {
@@ -857,6 +873,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 128
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -918,6 +942,14 @@
         "location": {
           "startColumn": 165,
           "endColumn": 168
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 168,
+          "endColumn": 169
         }
       },
       {
@@ -1735,6 +1767,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 84
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
         }
       },
       {

--- a/test/__snapshots__/2.2.x/Variables.snap
+++ b/test/__snapshots__/2.2.x/Variables.snap
@@ -492,6 +492,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 17
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -582,6 +590,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
         }
       },
       {
@@ -694,6 +710,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
         "type": "common_word",
         "value": "VariableCloning",
         "location": {
@@ -707,6 +731,14 @@
         "location": {
           "startColumn": 82,
           "endColumn": 85
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
         }
       },
       {
@@ -837,6 +869,14 @@
         "location": {
           "startColumn": 13,
           "endColumn": 21
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
         }
       },
       {
@@ -1405,6 +1445,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "common_word",
         "value": "categoryKeys",
         "location": {
@@ -1429,11 +1477,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 57,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -1469,11 +1533,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 82,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
         }
       },
       {
@@ -1538,6 +1626,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 36
+        }
+      },
+      {
         "type": "common_word",
         "value": "categoryKeys",
         "location": {
@@ -1562,11 +1658,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 56,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
         }
       },
       {
@@ -1602,11 +1714,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
           "startColumn": 81,
           "endColumn": 87
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
         }
       },
       {
@@ -1671,6 +1807,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -1692,6 +1836,14 @@
         "location": {
           "startColumn": 46,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 49,
+          "endColumn": 50
         }
       },
       {
@@ -2085,6 +2237,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 9,
+          "endColumn": 10
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -2292,6 +2452,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -2369,6 +2545,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 28
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -2435,6 +2627,22 @@
         "location": {
           "startColumn": 14,
           "endColumn": 19
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
         }
       },
       {
@@ -2539,6 +2747,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -2568,6 +2792,22 @@
         "location": {
           "startColumn": 35,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -2640,6 +2880,22 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 20,
+          "endColumn": 21
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -2669,6 +2925,22 @@
         "location": {
           "startColumn": 35,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
         }
       },
       {
@@ -2741,6 +3013,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "bar",
         "location": {
@@ -2762,6 +3042,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
         }
       },
       {
@@ -2890,6 +3178,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "dim",
         "location": {
@@ -2954,6 +3250,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -3010,6 +3314,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -3034,11 +3346,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 79,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -3079,6 +3407,30 @@
         "location": {
           "startColumn": 97,
           "endColumn": 102
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
         }
       },
       {
@@ -3207,6 +3559,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "dim",
         "location": {
@@ -3271,6 +3631,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -3327,6 +3695,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -3351,11 +3727,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 79,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -3399,6 +3791,30 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -3428,6 +3844,22 @@
         "location": {
           "startColumn": 119,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -3524,6 +3956,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "dim",
         "location": {
@@ -3588,6 +4028,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 41,
+          "endColumn": 42
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -3644,6 +4092,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -3668,11 +4124,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 79,
           "endColumn": 83
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
         }
       },
       {
@@ -3716,6 +4188,30 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 103,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -3745,6 +4241,22 @@
         "location": {
           "startColumn": 119,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 123,
+          "endColumn": 124
         }
       },
       {
@@ -3841,6 +4353,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "dim",
         "location": {
@@ -3905,6 +4425,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -3961,6 +4489,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 81
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -3985,11 +4521,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 89,
           "endColumn": 93
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
         }
       },
       {
@@ -4033,6 +4585,30 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 114
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -4062,6 +4638,22 @@
         "location": {
           "startColumn": 129,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
         }
       },
       {
@@ -4134,6 +4726,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "dim",
         "location": {
@@ -4198,6 +4798,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -4254,6 +4862,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -4278,11 +4894,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 92,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -4323,6 +4955,30 @@
         "location": {
           "startColumn": 110,
           "endColumn": 115
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
         }
       },
       {
@@ -4427,6 +5083,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "dim",
         "location": {
@@ -4491,6 +5155,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 55
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -4547,6 +5219,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
         "type": "common_word",
         "value": "a",
         "location": {
@@ -4571,11 +5251,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 92,
           "endColumn": 96
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
         }
       },
       {
@@ -4619,6 +5315,30 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 116,
+          "endColumn": 117
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 118
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -4648,6 +5368,22 @@
         "location": {
           "startColumn": 132,
           "endColumn": 134
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 136
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 136,
+          "endColumn": 137
         }
       },
       {
@@ -4720,6 +5456,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 22
+        }
+      },
+      {
         "type": "common_word",
         "value": "foo",
         "location": {
@@ -4741,6 +5485,14 @@
         "location": {
           "startColumn": 27,
           "endColumn": 33
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
         }
       },
       {
@@ -4869,6 +5621,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -4957,11 +5717,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 58,
           "endColumn": 63
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
         }
       },
       {
@@ -5034,6 +5818,14 @@
         "location": {
           "startColumn": 90,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -5138,6 +5930,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -5175,6 +5975,14 @@
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -5279,6 +6087,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -5319,6 +6135,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -5348,6 +6172,22 @@
         "location": {
           "startColumn": 47,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -5420,6 +6260,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
@@ -5460,6 +6308,14 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "on",
         "location": {
@@ -5489,6 +6345,22 @@
         "location": {
           "startColumn": 47,
           "endColumn": 49
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -5561,6 +6433,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -5569,11 +6449,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -5593,11 +6489,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 41,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -5617,11 +6529,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -5726,6 +6662,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -5734,11 +6678,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -5758,11 +6718,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 41,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -5782,11 +6758,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -5819,6 +6819,22 @@
         "location": {
           "startColumn": 68,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -5891,6 +6907,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -5899,11 +6923,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
         "type": "number",
         "value": "1",
         "location": {
           "startColumn": 31,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -5923,11 +6963,27 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
           "startColumn": 41,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -5947,11 +7003,35 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 51
+        }
+      },
+      {
         "type": "number",
         "value": "3",
         "location": {
           "startColumn": 51,
           "endColumn": 52
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
         }
       },
       {
@@ -5984,6 +7064,22 @@
         "location": {
           "startColumn": 68,
           "endColumn": 70
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -6056,6 +7152,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "unique",
         "location": {
@@ -6077,6 +7181,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -6205,6 +7317,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 25
+        }
+      },
+      {
         "type": "common_word",
         "value": "unique",
         "location": {
@@ -6226,6 +7346,14 @@
         "location": {
           "startColumn": 33,
           "endColumn": 37
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 38
         }
       },
       {
@@ -6258,6 +7386,22 @@
         "location": {
           "startColumn": 52,
           "endColumn": 54
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -6354,6 +7498,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "''",
         "location": {
@@ -6410,11 +7562,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 37,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -6559,11 +7727,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 26,
+          "endColumn": 27
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 27,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
         }
       },
       {
@@ -6575,11 +7759,35 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
           "startColumn": 40,
           "endColumn": 44
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
         }
       },
       {
@@ -6612,6 +7820,22 @@
         "location": {
           "startColumn": 60,
           "endColumn": 62
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
         }
       },
       {
@@ -6708,6 +7932,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "''",
         "location": {
@@ -6764,11 +7996,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 37,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -6897,6 +8145,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "''",
         "location": {
@@ -6953,11 +8209,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 37
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'foo'",
         "location": {
           "startColumn": 37,
           "endColumn": 42
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 43
         }
       },
       {
@@ -7083,6 +8355,14 @@
         "location": {
           "startColumn": 12,
           "endColumn": 17
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
         }
       },
       {
@@ -7222,6 +8502,14 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 64
+        }
+      },
+      {
         "type": "colon",
         "value": ":",
         "location": {
@@ -7235,6 +8523,14 @@
         "location": {
           "startColumn": 66,
           "endColumn": 72
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
         }
       },
       {
@@ -7363,6 +8659,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -7451,11 +8755,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -7528,6 +8856,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -7656,6 +8992,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "common_word",
         "value": "string",
         "location": {
@@ -7725,6 +9069,14 @@
         "location": {
           "startColumn": 50,
           "endColumn": 56
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
         }
       },
       {
@@ -7853,6 +9205,14 @@
         }
       },
       {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 17,
+          "endColumn": 18
+        }
+      },
+      {
         "type": "number",
         "value": "2",
         "location": {
@@ -7941,11 +9301,35 @@
         }
       },
       {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 46
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
           "startColumn": 46,
           "endColumn": 51
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 52
         }
       },
       {
@@ -8018,6 +9402,14 @@
         "location": {
           "startColumn": 78,
           "endColumn": 82
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -8162,6 +9554,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
@@ -8183,6 +9583,14 @@
         "location": {
           "startColumn": 35,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 39
         }
       },
       {
@@ -8215,6 +9623,22 @@
         "location": {
           "startColumn": 53,
           "endColumn": 55
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
         }
       },
       {
@@ -8327,6 +9751,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
         "type": "common_word",
         "value": "PR",
         "location": {
@@ -8348,6 +9780,14 @@
         "location": {
           "startColumn": 40,
           "endColumn": 43
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 44
         }
       },
       {
@@ -8449,6 +9889,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -8585,6 +10033,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -8718,6 +10174,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -8822,6 +10286,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -8856,6 +10328,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -8976,6 +10456,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -9048,11 +10536,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 91,
           "endColumn": 94
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 95
         }
       },
       {
@@ -9072,6 +10576,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "number",
         "value": "0",
         "location": {
@@ -9080,11 +10592,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 104,
+          "endColumn": 105
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 105,
           "endColumn": 108
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
         }
       },
       {
@@ -9112,6 +10640,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 115,
+          "endColumn": 116
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -9125,6 +10661,14 @@
         "location": {
           "startColumn": 118,
           "endColumn": 121
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
         }
       },
       {
@@ -9154,6 +10698,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -9229,11 +10781,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 92,
           "endColumn": 95
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 96
         }
       },
       {
@@ -9269,6 +10837,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 112,
+          "endColumn": 113
+        }
+      },
+      {
         "type": "single_quoted_string",
         "value": "'str'",
         "location": {
@@ -9277,11 +10853,27 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 119,
           "endColumn": 122
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 123
         }
       },
       {
@@ -9311,6 +10903,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -9386,6 +10986,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 92
+        }
+      },
+      {
         "type": "common_word",
         "value": "list",
         "location": {
@@ -9394,11 +11002,35 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 96,
+          "endColumn": 97
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 97,
           "endColumn": 100
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 100,
+          "endColumn": 101
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 102
         }
       },
       {
@@ -9418,6 +11050,14 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 108,
+          "endColumn": 109
+        }
+      },
+      {
         "type": "common_word",
         "value": "array",
         "location": {
@@ -9426,11 +11066,27 @@
         }
       },
       {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 114,
+          "endColumn": 115
+        }
+      },
+      {
         "type": "common_word",
         "value": "int",
         "location": {
           "startColumn": 115,
           "endColumn": 118
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 119
         }
       },
       {
@@ -9458,6 +11114,14 @@
         }
       },
       {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
         "type": "comma",
         "value": ",",
         "location": {
@@ -9471,6 +11135,22 @@
         "location": {
           "startColumn": 128,
           "endColumn": 131
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 131,
+          "endColumn": 132
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
         }
       },
       {
@@ -9500,6 +11180,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -9620,6 +11308,14 @@
         }
       },
       {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
+        }
+      },
+      {
         "type": "variable_name",
         "value": "$p",
         "location": {
@@ -9708,6 +11404,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -9742,6 +11446,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -9833,6 +11545,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -9867,6 +11587,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -9958,6 +11686,14 @@
         }
       },
       {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
         "type": "common_word",
         "value": "null",
         "location": {
@@ -9992,6 +11728,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -10109,6 +11853,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -10242,6 +11994,14 @@
         "location": {
           "startColumn": 0,
           "endColumn": 9
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 10,
+          "endColumn": 11
         }
       },
       {
@@ -10583,6 +12343,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -10849,6 +12625,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 58,
+          "endColumn": 59
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 60
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -10982,6 +12774,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -11104,6 +12912,22 @@
         "location": {
           "startColumn": 73,
           "endColumn": 75
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 77
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
         }
       },
       {
@@ -11232,6 +13056,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 75
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 75,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -11357,6 +13197,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 70,
+          "endColumn": 71
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 72
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -11479,6 +13335,22 @@
         "location": {
           "startColumn": 65,
           "endColumn": 67
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
         }
       },
       {
@@ -12184,6 +14056,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -12732,6 +14620,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -12862,6 +14766,22 @@
         "location": {
           "startColumn": 86,
           "endColumn": 88
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 90,
+          "endColumn": 91
         }
       },
       {
@@ -12998,6 +14918,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 88
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -13131,6 +15067,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 83,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 85
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -13261,6 +15213,22 @@
         "location": {
           "startColumn": 78,
           "endColumn": 80
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 82
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
         }
       },
       {
@@ -15163,6 +17131,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -16024,6 +18008,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
         "type": "common_word",
         "value": "always",
         "location": {
@@ -16130,6 +18130,22 @@
         "location": {
           "startColumn": 25,
           "endColumn": 27
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
         }
       },
       {
@@ -17323,6 +19339,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
+        }
+      },
+      {
         "type": "common_word",
         "value": "always",
         "location": {
@@ -17429,6 +19461,22 @@
         "location": {
           "startColumn": 27,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -17846,6 +19894,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
+        }
+      },
+      {
         "type": "common_word",
         "value": "is",
         "location": {
@@ -17928,6 +19992,22 @@
         "location": {
           "startColumn": 36,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -18159,6 +20239,22 @@
         "location": {
           "startColumn": 27,
           "endColumn": 29
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 32
         }
       },
       {
@@ -19282,6 +21378,22 @@
         }
       },
       {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
+        }
+      },
+      {
         "type": "common_word",
         "value": "always",
         "location": {
@@ -19388,6 +21500,22 @@
         "location": {
           "startColumn": 30,
           "endColumn": 32
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 35
         }
       },
       {
@@ -19972,6 +22100,22 @@
         "location": {
           "startColumn": 36,
           "endColumn": 38
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 39,
+          "endColumn": 40
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 41
         }
       },
       {
@@ -21214,6 +23358,22 @@
         "location": {
           "startColumn": 26,
           "endColumn": 28
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 30
+        }
+      },
+      {
+        "type": "question",
+        "value": "?",
+        "location": {
+          "startColumn": 30,
+          "endColumn": 31
         }
       },
       {

--- a/test/format.spec.ts
+++ b/test/format.spec.ts
@@ -947,6 +947,11 @@ describe('test formatted results', () => {
         location: { startColumn: 29, endColumn: 34 },
       },
       {
+        type: 'lbrace',
+        value: '{',
+        location: { startColumn: 34, endColumn: 35 },
+      },
+      {
         type: 'common_word',
         value: 'b',
         location: { startColumn: 35, endColumn: 36 },
@@ -962,9 +967,69 @@ describe('test formatted results', () => {
         location: { startColumn: 38, endColumn: 39 },
       },
       {
+        type: 'rbrace',
+        value: '}',
+        location: { startColumn: 39, endColumn: 40 },
+      },
+      {
         type: 'period',
         value: '.',
         location: { startColumn: 40, endColumn: 41 },
+      },
+    ];
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('parse type delimiters in generic type', () => {
+    const message = 'Parameter expects array<int, string>.';
+    const result = parse(message);
+
+    const expected = [
+      {
+        type: 'common_word',
+        value: 'Parameter',
+        location: { startColumn: 0, endColumn: 9 },
+      },
+      {
+        type: 'common_word',
+        value: 'expects',
+        location: { startColumn: 10, endColumn: 17 },
+      },
+      {
+        type: 'common_word',
+        value: 'array',
+        location: { startColumn: 18, endColumn: 23 },
+      },
+      {
+        type: 'langle',
+        value: '<',
+        location: { startColumn: 23, endColumn: 24 },
+      },
+      {
+        type: 'common_word',
+        value: 'int',
+        location: { startColumn: 24, endColumn: 27 },
+      },
+      {
+        type: 'comma',
+        value: ',',
+        location: { startColumn: 27, endColumn: 28 },
+      },
+      {
+        type: 'common_word',
+        value: 'string',
+        location: { startColumn: 29, endColumn: 35 },
+      },
+      {
+        type: 'rangle',
+        value: '>',
+        location: { startColumn: 35, endColumn: 36 },
+      },
+      {
+        type: 'period',
+        value: '.',
+        location: { startColumn: 36, endColumn: 37 },
       },
     ];
 

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -172,6 +172,45 @@ describe('sample test', () => {
       m: 'Result of || is always the same as the left operand, because the right operand "+" is always truthy.',
       assertions: [['DoubleQuotedString:"+"', true]],
     },
+    {
+      name: 'parse generic type delimiters',
+      m: 'Method should return array<int, string>.',
+      assertions: [
+        ['langle:<', true],
+        ['rangle:>', true],
+      ],
+    },
+    {
+      name: 'parse array shape delimiters',
+      m: 'Offset does not exist on array{key: string}.',
+      assertions: [
+        ['lbrace:{', true],
+        ['rbrace:}', true],
+      ],
+    },
+    {
+      name: 'parse array type brackets',
+      m: 'Parameter expects int[], string given.',
+      assertions: [
+        ['lbracket:[', true],
+        ['rbracket:]', true],
+      ],
+    },
+    {
+      name: 'parse union and intersection type operators',
+      m: 'Parameter expects int|string|null.',
+      assertions: [['pipe:|', true]],
+    },
+    {
+      name: 'parse intersection type',
+      m: 'Call to method on ArrayAccess&Foo.',
+      assertions: [['ampersand:&', true]],
+    },
+    {
+      name: 'parse question mark for nullable',
+      m: 'Offset exists on array{foo?: string}.',
+      assertions: [['question:?', true]],
+    },
   ] satisfies DataSet[];
 
   test.each(dataSet)('$name', ({ m, assertions }) => {


### PR DESCRIPTION
## Summary

Add flat tokens for type syntax delimiters, preparing for structured type parser.

| Token | Symbol | Usage |
|-------|--------|-------|
| `langle` / `rangle` | `<` `>` | Generic types (`array<int, string>`, `int<0, max>`) |
| `lbrace` / `rbrace` | `{` `}` | Array/object shapes (`array{key: value}`, `object{foo: int}`) |
| `lbracket` / `rbracket` | `[` `]` | Array types (`int[]`, `string[][]`) |
| `pipe` | `\|` | Union types (`Type1\|Type2`) |
| `ampersand` | `&` | Intersection types (`Type1&Type2`) |
| `question` | `?` | Nullable / optional keys (`foo?: string`) |

These are added as flat tokens (not structurally grouped). The next step is to define parser rules that combine these tokens into structured type nodes.

## Test plan

- [x] All 81 tests pass
- [x] Parser tests for each new token
- [x] Format test for generic type `array<int, string>` with correct locations
- [x] Updated existing format test for `array{b: 1}` with `lbrace`/`rbrace`
- [x] 20 snapshot categories updated
- [x] Biome check passes

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A