### PR TITLE
Add ellipsis token (...)

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -24,6 +24,7 @@ export type Word = {
     | 'pipe'
     | 'ampersand'
     | 'question'
+    | 'ellipsis'
     | 'period';
   value: string;
   location: {
@@ -73,6 +74,7 @@ export function format(errorMessageCst: CstNode): Word[] {
     { tokenType: 'pipe', nodes: sentenceNode?.children?.pipe },
     { tokenType: 'ampersand', nodes: sentenceNode?.children?.ampersand },
     { tokenType: 'question', nodes: sentenceNode?.children?.question },
+    { tokenType: 'ellipsis', nodes: sentenceNode?.children?.ellipsis },
     { tokenType: 'period', nodes: sentenceNode?.children?.period },
   ] as const;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,6 +41,11 @@ const tokens = {
     group: Lexer.SKIPPED,
     line_breaks: false,
   }),
+  ELLIPSIS: createToken({
+    name: 'ellipsis',
+    pattern: '...',
+    line_breaks: false,
+  }),
   PERIOD: createToken({ name: 'period', pattern: '.', line_breaks: false }),
   COMMA: createToken({ name: 'comma', pattern: ',', line_breaks: false }),
   LPAREN: createToken({ name: 'lparen', pattern: '(', line_breaks: false }),
@@ -116,6 +121,7 @@ export class Parser extends CstParser {
         { ALT: () => this.CONSUME(tokens.PIPE) },
         { ALT: () => this.CONSUME(tokens.AMPERSAND) },
         { ALT: () => this.CONSUME(tokens.QUESTION) },
+        { ALT: () => this.CONSUME(tokens.ELLIPSIS) },
       ]);
     });
     this.CONSUME(tokens.PERIOD);

--- a/test/__snapshots__/2.2.x/Arrays.snap
+++ b/test/__snapshots__/2.2.x/Arrays.snap
@@ -9211,11 +9211,27 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 118,
-          "endColumn": 119
+          "startColumn": 122,
+          "endColumn": 123
         }
       }
     ]
@@ -11010,11 +11026,27 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 118,
+          "endColumn": 121
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 121,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 118,
-          "endColumn": 119
+          "startColumn": 122,
+          "endColumn": 123
         }
       }
     ]

--- a/test/__snapshots__/2.2.x/Functions.snap
+++ b/test/__snapshots__/2.2.x/Functions.snap
@@ -17526,11 +17526,395 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 242,
+          "endColumn": 245
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 245,
+          "endColumn": 246
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 246,
+          "endColumn": 247
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "but",
+        "location": {
+          "startColumn": 248,
+          "endColumn": 251
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "returns",
+        "location": {
+          "startColumn": 252,
+          "endColumn": 259
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 260,
+          "endColumn": 265
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 265,
+          "endColumn": 266
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 266,
+          "endColumn": 271
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 271,
+          "endColumn": 272
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "id",
+        "location": {
+          "startColumn": 272,
+          "endColumn": 274
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 274,
+          "endColumn": 275
+        }
+      },
+      {
+        "type": "number",
+        "value": "1",
+        "location": {
+          "startColumn": 276,
+          "endColumn": 277
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 277,
+          "endColumn": 278
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "created",
+        "location": {
+          "startColumn": 279,
+          "endColumn": 286
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 286,
+          "endColumn": 287
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "DateTimeImmutable",
+        "location": {
+          "startColumn": 288,
+          "endColumn": 305
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 305,
+          "endColumn": 306
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "updated",
+        "location": {
+          "startColumn": 307,
+          "endColumn": 314
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 314,
+          "endColumn": 315
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "DateTimeImmutable",
+        "location": {
+          "startColumn": 316,
+          "endColumn": 333
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 333,
+          "endColumn": 334
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "valid",
+        "location": {
+          "startColumn": 335,
+          "endColumn": 340
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "from",
+        "location": {
+          "startColumn": 341,
+          "endColumn": 345
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 345,
+          "endColumn": 346
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "DateTimeImmutable",
+        "location": {
+          "startColumn": 347,
+          "endColumn": 364
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 364,
+          "endColumn": 365
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "valid",
+        "location": {
+          "startColumn": 366,
+          "endColumn": 371
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "till",
+        "location": {
+          "startColumn": 372,
+          "endColumn": 376
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 376,
+          "endColumn": 377
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "DateTimeImmutable",
+        "location": {
+          "startColumn": 378,
+          "endColumn": 395
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 395,
+          "endColumn": 396
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 397,
+          "endColumn": 403
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 403,
+          "endColumn": 404
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'string'",
+        "location": {
+          "startColumn": 405,
+          "endColumn": 413
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 413,
+          "endColumn": 414
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "other",
+        "location": {
+          "startColumn": 415,
+          "endColumn": 420
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 421,
+          "endColumn": 427
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 427,
+          "endColumn": 428
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'string'",
+        "location": {
+          "startColumn": 429,
+          "endColumn": 437
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 437,
+          "endColumn": 438
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "another",
+        "location": {
+          "startColumn": 439,
+          "endColumn": 446
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 447,
+          "endColumn": 453
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 453,
+          "endColumn": 454
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'string'",
+        "location": {
+          "startColumn": 455,
+          "endColumn": 463
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 463,
+          "endColumn": 464
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 465,
+          "endColumn": 468
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 468,
+          "endColumn": 469
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 469,
+          "endColumn": 470
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 242,
-          "endColumn": 243
+          "startColumn": 470,
+          "endColumn": 471
         }
       }
     ]
@@ -51329,11 +51713,51 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 122,
+          "endColumn": 125
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 125,
+          "endColumn": 126
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 128,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 137
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 122,
-          "endColumn": 123
+          "startColumn": 137,
+          "endColumn": 138
         }
       }
     ]
@@ -63220,11 +63644,123 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$arg1",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 21
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "max",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 49
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 55
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 61
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 68
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 76,
+          "endColumn": 77
         }
       }
     ]
@@ -63249,11 +63785,123 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$arg1",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 21
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "min",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 37
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 38,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 49
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 55
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 61
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 68
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 69
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 69,
+          "endColumn": 70
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 71,
+          "endColumn": 76
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 76,
+          "endColumn": 77
         }
       }
     ]
@@ -63278,11 +63926,123 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$foo",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "closure",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 31
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 39
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "CallCallables",
+        "location": {
+          "startColumn": 40,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Foo",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 58
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 59,
+          "endColumn": 64
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 64,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "CallCallables",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Foo",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 82
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 89
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 89,
+          "endColumn": 90
         }
       }
     ]
@@ -77432,11 +78192,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$foo",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 32
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "FunctionWithVariadicParameters\\foo",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 75
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 79
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 87
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 93,
+          "endColumn": 94
         }
       }
     ]
@@ -77461,11 +78301,163 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$values",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 26
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 35
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "printf",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 42
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 50
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "bool",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 55
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "float",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 61
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 65
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 65,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 72
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 72,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "null",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 77
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 77,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "UnpackOperator",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Foo",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 97
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 103,
+          "endColumn": 104
         }
       }
     ]
@@ -77490,11 +78482,163 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$values",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 26
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 35
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "sprintf",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "bool",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "float",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "null",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "UnpackOperator",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Foo",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -77519,11 +78663,195 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$values",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 26
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 35
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "sprintf",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "bool",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "float",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "null",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 89
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 89,
+          "endColumn": 90
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 91,
+          "endColumn": 97
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -77548,11 +78876,179 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$values",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 26
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 27,
+          "endColumn": 35
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "sprintf",
+        "location": {
+          "startColumn": 36,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "bool",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 56
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 56,
+          "endColumn": 57
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "float",
+        "location": {
+          "startColumn": 57,
+          "endColumn": 62
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 62,
+          "endColumn": 63
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 63,
+          "endColumn": 66
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 66,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 67,
+          "endColumn": 73
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 73,
+          "endColumn": 74
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "null",
+        "location": {
+          "startColumn": 74,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 79
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 80,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 99
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 99,
+          "endColumn": 100
         }
       }
     ]
@@ -93782,11 +95278,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$foo",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 20
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 21,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "function",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 32
+        }
+      },
+      {
+        "type": "function_name",
+        "value": "FunctionWithVariadicParameters\\foo",
+        "location": {
+          "startColumn": 33,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 75
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 79
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 80
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "null",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 91
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 91,
+          "endColumn": 92
         }
       }
     ]

--- a/test/__snapshots__/2.2.x/Methods.snap
+++ b/test/__snapshots__/2.2.x/Methods.snap
@@ -25755,11 +25755,9659 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 1194,
+          "endColumn": 1197
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1197,
+          "endColumn": 1198
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1198,
+          "endColumn": 1199
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Baranya",
+        "location": {
+          "startColumn": 1200,
+          "endColumn": 1207
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1207,
+          "endColumn": 1208
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1209,
+          "endColumn": 1212
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 1213,
+          "endColumn": 1218
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1219,
+          "endColumn": 1224
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 1224,
+          "endColumn": 1225
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 1225,
+          "endColumn": 1232
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1233,
+          "endColumn": 1239
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 1239,
+          "endColumn": 1240
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1240,
+          "endColumn": 1243
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 1244,
+          "endColumn": 1249
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1250,
+          "endColumn": 1256
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1256,
+          "endColumn": 1257
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1258,
+          "endColumn": 1261
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 1262,
+          "endColumn": 1267
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1268,
+          "endColumn": 1273
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 1273,
+          "endColumn": 1274
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 1274,
+          "endColumn": 1281
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1282,
+          "endColumn": 1288
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 1288,
+          "endColumn": 1289
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1289,
+          "endColumn": 1292
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 1293,
+          "endColumn": 1298
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1299,
+          "endColumn": 1305
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1305,
+          "endColumn": 1306
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1307,
+          "endColumn": 1310
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 1311,
+          "endColumn": 1316
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1317,
+          "endColumn": 1322
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 1322,
+          "endColumn": 1323
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 1323,
+          "endColumn": 1326
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 1326,
+          "endColumn": 1327
+        }
+      },
+      {
+        "type": "number",
+        "value": "0",
+        "location": {
+          "startColumn": 1327,
+          "endColumn": 1328
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1328,
+          "endColumn": 1329
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "max",
+        "location": {
+          "startColumn": 1330,
+          "endColumn": 1333
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 1333,
+          "endColumn": 1334
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 1334,
+          "endColumn": 1335
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 1335,
+          "endColumn": 1336
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 1336,
+          "endColumn": 1343
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1344,
+          "endColumn": 1350
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 1350,
+          "endColumn": 1351
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1351,
+          "endColumn": 1354
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 1355,
+          "endColumn": 1360
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1361,
+          "endColumn": 1367
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 1367,
+          "endColumn": 1368
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1368,
+          "endColumn": 1369
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "float",
+        "location": {
+          "startColumn": 1370,
+          "endColumn": 1375
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 1375,
+          "endColumn": 1376
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 1376,
+          "endColumn": 1377
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 1377,
+          "endColumn": 1384
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1385,
+          "endColumn": 1391
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 1391,
+          "endColumn": 1392
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 1392,
+          "endColumn": 1395
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 1396,
+          "endColumn": 1401
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 1402,
+          "endColumn": 1408
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 1408,
+          "endColumn": 1409
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 1409,
+          "endColumn": 1410
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 1410,
+          "endColumn": 1411
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 1411,
+          "endColumn": 1412
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1412,
+          "endColumn": 1413
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 1414,
+          "endColumn": 1415
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "k",
+        "location": {
+          "startColumn": 1416,
+          "endColumn": 1417
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "s",
+        "location": {
+          "startColumn": 1418,
+          "endColumn": 1419
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1419,
+          "endColumn": 1420
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1421,
+          "endColumn": 1426
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1426,
+          "endColumn": 1427
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Alm",
+        "location": {
+          "startColumn": 1427,
+          "endColumn": 1430
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "skamar",
+        "location": {
+          "startColumn": 1431,
+          "endColumn": 1437
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "s",
+        "location": {
+          "startColumn": 1438,
+          "endColumn": 1439
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1439,
+          "endColumn": 1440
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1441,
+          "endColumn": 1446
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1446,
+          "endColumn": 1447
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 1447,
+          "endColumn": 1461
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1461,
+          "endColumn": 1462
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1463,
+          "endColumn": 1468
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1468,
+          "endColumn": 1469
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 4.'",
+        "location": {
+          "startColumn": 1469,
+          "endColumn": 1479
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1479,
+          "endColumn": 1480
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1480,
+          "endColumn": 1481
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 1482,
+          "endColumn": 1493
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1493,
+          "endColumn": 1494
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1495,
+          "endColumn": 1500
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1500,
+          "endColumn": 1501
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 1501,
+          "endColumn": 1504
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1504,
+          "endColumn": 1505
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.4617785",
+        "location": {
+          "startColumn": 1506,
+          "endColumn": 1516
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1516,
+          "endColumn": 1517
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 1518,
+          "endColumn": 1521
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1521,
+          "endColumn": 1522
+        }
+      },
+      {
+        "type": "number",
+        "value": "21.092448",
+        "location": {
+          "startColumn": 1523,
+          "endColumn": 1532
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1532,
+          "endColumn": 1533
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1533,
+          "endColumn": 1534
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1534,
+          "endColumn": 1535
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Battonya",
+        "location": {
+          "startColumn": 1536,
+          "endColumn": 1544
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1544,
+          "endColumn": 1545
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1546,
+          "endColumn": 1551
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1551,
+          "endColumn": 1552
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 1552,
+          "endColumn": 1566
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1566,
+          "endColumn": 1567
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1568,
+          "endColumn": 1573
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1573,
+          "endColumn": 1574
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 4.'",
+        "location": {
+          "startColumn": 1574,
+          "endColumn": 1584
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1584,
+          "endColumn": 1585
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1585,
+          "endColumn": 1586
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 1587,
+          "endColumn": 1598
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1598,
+          "endColumn": 1599
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1600,
+          "endColumn": 1605
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1605,
+          "endColumn": 1606
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 1606,
+          "endColumn": 1609
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1609,
+          "endColumn": 1610
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.2902462",
+        "location": {
+          "startColumn": 1611,
+          "endColumn": 1621
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1621,
+          "endColumn": 1622
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 1623,
+          "endColumn": 1626
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1626,
+          "endColumn": 1627
+        }
+      },
+      {
+        "type": "number",
+        "value": "21.0199215",
+        "location": {
+          "startColumn": 1628,
+          "endColumn": 1638
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1638,
+          "endColumn": 1639
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1639,
+          "endColumn": 1640
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1640,
+          "endColumn": 1641
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 1642,
+          "endColumn": 1643
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "k",
+        "location": {
+          "startColumn": 1644,
+          "endColumn": 1645
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "s",
+        "location": {
+          "startColumn": 1646,
+          "endColumn": 1647
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1647,
+          "endColumn": 1648
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1649,
+          "endColumn": 1654
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1654,
+          "endColumn": 1655
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 1655,
+          "endColumn": 1669
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1669,
+          "endColumn": 1670
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1671,
+          "endColumn": 1676
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1676,
+          "endColumn": 1677
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 2.'",
+        "location": {
+          "startColumn": 1677,
+          "endColumn": 1687
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1687,
+          "endColumn": 1688
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1688,
+          "endColumn": 1689
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 1690,
+          "endColumn": 1701
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1701,
+          "endColumn": 1702
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1703,
+          "endColumn": 1708
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1708,
+          "endColumn": 1709
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 1709,
+          "endColumn": 1712
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1712,
+          "endColumn": 1713
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.6704899",
+        "location": {
+          "startColumn": 1714,
+          "endColumn": 1724
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1724,
+          "endColumn": 1725
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 1726,
+          "endColumn": 1729
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1729,
+          "endColumn": 1730
+        }
+      },
+      {
+        "type": "number",
+        "value": "21.0434996",
+        "location": {
+          "startColumn": 1731,
+          "endColumn": 1741
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1741,
+          "endColumn": 1742
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1742,
+          "endColumn": 1743
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1743,
+          "endColumn": 1744
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 1745,
+          "endColumn": 1746
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "k",
+        "location": {
+          "startColumn": 1747,
+          "endColumn": 1748
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "scsaba",
+        "location": {
+          "startColumn": 1749,
+          "endColumn": 1755
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1755,
+          "endColumn": 1756
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1757,
+          "endColumn": 1762
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1762,
+          "endColumn": 1763
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 1763,
+          "endColumn": 1777
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1777,
+          "endColumn": 1778
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1779,
+          "endColumn": 1784
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1784,
+          "endColumn": 1785
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 1.'",
+        "location": {
+          "startColumn": 1785,
+          "endColumn": 1795
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1795,
+          "endColumn": 1796
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1796,
+          "endColumn": 1797
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 1798,
+          "endColumn": 1809
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1809,
+          "endColumn": 1810
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1811,
+          "endColumn": 1816
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1816,
+          "endColumn": 1817
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 1817,
+          "endColumn": 1820
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1820,
+          "endColumn": 1821
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.6735939",
+        "location": {
+          "startColumn": 1822,
+          "endColumn": 1832
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1832,
+          "endColumn": 1833
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 1834,
+          "endColumn": 1837
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1837,
+          "endColumn": 1838
+        }
+      },
+      {
+        "type": "number",
+        "value": "21.0877309",
+        "location": {
+          "startColumn": 1839,
+          "endColumn": 1849
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1849,
+          "endColumn": 1850
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1850,
+          "endColumn": 1851
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1851,
+          "endColumn": 1852
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 1853,
+          "endColumn": 1854
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "k",
+        "location": {
+          "startColumn": 1855,
+          "endColumn": 1856
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "ss",
+        "location": {
+          "startColumn": 1857,
+          "endColumn": 1859
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "mson",
+        "location": {
+          "startColumn": 1860,
+          "endColumn": 1864
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1864,
+          "endColumn": 1865
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1866,
+          "endColumn": 1871
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1871,
+          "endColumn": 1872
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 1872,
+          "endColumn": 1886
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1886,
+          "endColumn": 1887
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1888,
+          "endColumn": 1893
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1893,
+          "endColumn": 1894
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 4.'",
+        "location": {
+          "startColumn": 1894,
+          "endColumn": 1904
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1904,
+          "endColumn": 1905
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1905,
+          "endColumn": 1906
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 1907,
+          "endColumn": 1918
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1918,
+          "endColumn": 1919
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1920,
+          "endColumn": 1925
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1925,
+          "endColumn": 1926
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 1926,
+          "endColumn": 1929
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1929,
+          "endColumn": 1930
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.4208677",
+        "location": {
+          "startColumn": 1931,
+          "endColumn": 1941
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1941,
+          "endColumn": 1942
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 1943,
+          "endColumn": 1946
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1946,
+          "endColumn": 1947
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.6176498",
+        "location": {
+          "startColumn": 1948,
+          "endColumn": 1958
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1958,
+          "endColumn": 1959
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 1959,
+          "endColumn": 1960
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 1960,
+          "endColumn": 1961
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 1962,
+          "endColumn": 1963
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "k",
+        "location": {
+          "startColumn": 1964,
+          "endColumn": 1965
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "sszentandr",
+        "location": {
+          "startColumn": 1966,
+          "endColumn": 1976
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "s",
+        "location": {
+          "startColumn": 1977,
+          "endColumn": 1978
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 1978,
+          "endColumn": 1979
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 1980,
+          "endColumn": 1985
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 1985,
+          "endColumn": 1986
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 1986,
+          "endColumn": 2000
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2000,
+          "endColumn": 2001
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2002,
+          "endColumn": 2007
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2007,
+          "endColumn": 2008
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 2.'",
+        "location": {
+          "startColumn": 2008,
+          "endColumn": 2018
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2018,
+          "endColumn": 2019
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2019,
+          "endColumn": 2020
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 2021,
+          "endColumn": 2032
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2032,
+          "endColumn": 2033
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2034,
+          "endColumn": 2039
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2039,
+          "endColumn": 2040
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 2040,
+          "endColumn": 2043
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2043,
+          "endColumn": 2044
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.8715996",
+        "location": {
+          "startColumn": 2045,
+          "endColumn": 2055
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2055,
+          "endColumn": 2056
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 2057,
+          "endColumn": 2060
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2060,
+          "endColumn": 2061
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.48336",
+        "location": {
+          "startColumn": 2062,
+          "endColumn": 2070
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2070,
+          "endColumn": 2071
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2071,
+          "endColumn": 2072
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2072,
+          "endColumn": 2073
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 2074,
+          "endColumn": 2075
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lmegyer",
+        "location": {
+          "startColumn": 2076,
+          "endColumn": 2083
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2083,
+          "endColumn": 2084
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2085,
+          "endColumn": 2090
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2090,
+          "endColumn": 2091
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 2091,
+          "endColumn": 2105
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2105,
+          "endColumn": 2106
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2107,
+          "endColumn": 2112
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2112,
+          "endColumn": 2113
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 3.'",
+        "location": {
+          "startColumn": 2113,
+          "endColumn": 2123
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2123,
+          "endColumn": 2124
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2124,
+          "endColumn": 2125
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 2126,
+          "endColumn": 2137
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2137,
+          "endColumn": 2138
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2139,
+          "endColumn": 2144
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2144,
+          "endColumn": 2145
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 2145,
+          "endColumn": 2148
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2148,
+          "endColumn": 2149
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.8726019",
+        "location": {
+          "startColumn": 2150,
+          "endColumn": 2160
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2160,
+          "endColumn": 2161
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 2162,
+          "endColumn": 2165
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2165,
+          "endColumn": 2166
+        }
+      },
+      {
+        "type": "number",
+        "value": "21.1832832",
+        "location": {
+          "startColumn": 2167,
+          "endColumn": 2177
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2177,
+          "endColumn": 2178
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2178,
+          "endColumn": 2179
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2179,
+          "endColumn": 2180
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Biharugra",
+        "location": {
+          "startColumn": 2181,
+          "endColumn": 2190
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2190,
+          "endColumn": 2191
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2192,
+          "endColumn": 2197
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2197,
+          "endColumn": 2198
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 2198,
+          "endColumn": 2212
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2212,
+          "endColumn": 2213
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2214,
+          "endColumn": 2219
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2219,
+          "endColumn": 2220
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Békés 3.'",
+        "location": {
+          "startColumn": 2220,
+          "endColumn": 2230
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2230,
+          "endColumn": 2231
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2231,
+          "endColumn": 2232
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 2233,
+          "endColumn": 2244
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2244,
+          "endColumn": 2245
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2246,
+          "endColumn": 2251
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2251,
+          "endColumn": 2252
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 2252,
+          "endColumn": 2255
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2255,
+          "endColumn": 2256
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.9691009",
+        "location": {
+          "startColumn": 2257,
+          "endColumn": 2267
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2267,
+          "endColumn": 2268
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 2269,
+          "endColumn": 2272
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2272,
+          "endColumn": 2273
+        }
+      },
+      {
+        "type": "number",
+        "value": "21.5987651",
+        "location": {
+          "startColumn": 2274,
+          "endColumn": 2284
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2284,
+          "endColumn": 2285
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2285,
+          "endColumn": 2286
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2286,
+          "endColumn": 2287
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 2288,
+          "endColumn": 2291
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2291,
+          "endColumn": 2292
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2292,
+          "endColumn": 2293
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Borsod",
+        "location": {
+          "startColumn": 2294,
+          "endColumn": 2300
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Aba",
+        "location": {
+          "startColumn": 2301,
+          "endColumn": 2304
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "j",
+        "location": {
+          "startColumn": 2305,
+          "endColumn": 2306
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Zempl",
+        "location": {
+          "startColumn": 2307,
+          "endColumn": 2312
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "n",
+        "location": {
+          "startColumn": 2313,
+          "endColumn": 2314
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2314,
+          "endColumn": 2315
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2316,
+          "endColumn": 2319
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 2320,
+          "endColumn": 2325
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2326,
+          "endColumn": 2331
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 2331,
+          "endColumn": 2332
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 2332,
+          "endColumn": 2339
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2340,
+          "endColumn": 2346
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 2346,
+          "endColumn": 2347
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2347,
+          "endColumn": 2350
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 2351,
+          "endColumn": 2356
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2357,
+          "endColumn": 2363
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2363,
+          "endColumn": 2364
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2365,
+          "endColumn": 2368
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 2369,
+          "endColumn": 2374
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2375,
+          "endColumn": 2380
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 2380,
+          "endColumn": 2381
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 2381,
+          "endColumn": 2388
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2389,
+          "endColumn": 2395
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 2395,
+          "endColumn": 2396
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2396,
+          "endColumn": 2399
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 2400,
+          "endColumn": 2405
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2406,
+          "endColumn": 2412
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2412,
+          "endColumn": 2413
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2414,
+          "endColumn": 2417
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "empty",
+        "location": {
+          "startColumn": 2418,
+          "endColumn": 2423
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2424,
+          "endColumn": 2429
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 2429,
+          "endColumn": 2430
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 2430,
+          "endColumn": 2433
+        }
+      },
+      {
+        "type": "langle",
+        "value": "<",
+        "location": {
+          "startColumn": 2433,
+          "endColumn": 2434
+        }
+      },
+      {
+        "type": "number",
+        "value": "0",
+        "location": {
+          "startColumn": 2434,
+          "endColumn": 2435
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2435,
+          "endColumn": 2436
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "max",
+        "location": {
+          "startColumn": 2437,
+          "endColumn": 2440
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 2440,
+          "endColumn": 2441
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 2441,
+          "endColumn": 2442
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 2442,
+          "endColumn": 2443
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 2443,
+          "endColumn": 2450
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2451,
+          "endColumn": 2457
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 2457,
+          "endColumn": 2458
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2458,
+          "endColumn": 2461
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 2462,
+          "endColumn": 2467
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2468,
+          "endColumn": 2474
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 2474,
+          "endColumn": 2475
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2475,
+          "endColumn": 2476
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "float",
+        "location": {
+          "startColumn": 2477,
+          "endColumn": 2482
+        }
+      },
+      {
+        "type": "pipe",
+        "value": "|",
+        "location": {
+          "startColumn": 2482,
+          "endColumn": 2483
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 2483,
+          "endColumn": 2484
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "literal",
+        "location": {
+          "startColumn": 2484,
+          "endColumn": 2491
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2492,
+          "endColumn": 2498
+        }
+      },
+      {
+        "type": "ampersand",
+        "value": "&",
+        "location": {
+          "startColumn": 2498,
+          "endColumn": 2499
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 2499,
+          "endColumn": 2502
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "falsy",
+        "location": {
+          "startColumn": 2503,
+          "endColumn": 2508
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 2509,
+          "endColumn": 2515
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 2515,
+          "endColumn": 2516
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 2516,
+          "endColumn": 2517
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 2517,
+          "endColumn": 2518
+        }
+      },
+      {
+        "type": "rangle",
+        "value": ">",
+        "location": {
+          "startColumn": 2518,
+          "endColumn": 2519
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2519,
+          "endColumn": 2520
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Budapest",
+        "location": {
+          "startColumn": 2521,
+          "endColumn": 2529
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2529,
+          "endColumn": 2530
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2531,
+          "endColumn": 2536
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2536,
+          "endColumn": 2537
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest I. ker.'",
+        "location": {
+          "startColumn": 2537,
+          "endColumn": 2555
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2555,
+          "endColumn": 2556
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2557,
+          "endColumn": 2562
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2562,
+          "endColumn": 2563
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 2563,
+          "endColumn": 2577
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2577,
+          "endColumn": 2578
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2579,
+          "endColumn": 2584
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2584,
+          "endColumn": 2585
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 01.'",
+        "location": {
+          "startColumn": 2585,
+          "endColumn": 2599
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2599,
+          "endColumn": 2600
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2600,
+          "endColumn": 2601
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 2602,
+          "endColumn": 2613
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2613,
+          "endColumn": 2614
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2615,
+          "endColumn": 2620
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2620,
+          "endColumn": 2621
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 2621,
+          "endColumn": 2624
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2624,
+          "endColumn": 2625
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.4968219",
+        "location": {
+          "startColumn": 2626,
+          "endColumn": 2636
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2636,
+          "endColumn": 2637
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 2638,
+          "endColumn": 2641
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2641,
+          "endColumn": 2642
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.037458",
+        "location": {
+          "startColumn": 2643,
+          "endColumn": 2652
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2652,
+          "endColumn": 2653
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2653,
+          "endColumn": 2654
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2654,
+          "endColumn": 2655
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest II. ker.'",
+        "location": {
+          "startColumn": 2656,
+          "endColumn": 2675
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2675,
+          "endColumn": 2676
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2677,
+          "endColumn": 2682
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2682,
+          "endColumn": 2683
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 2683,
+          "endColumn": 2697
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2697,
+          "endColumn": 2698
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2699,
+          "endColumn": 2704
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2704,
+          "endColumn": 2705
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 03.'",
+        "location": {
+          "startColumn": 2705,
+          "endColumn": 2719
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2719,
+          "endColumn": 2720
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 04.'",
+        "location": {
+          "startColumn": 2721,
+          "endColumn": 2735
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2735,
+          "endColumn": 2736
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2736,
+          "endColumn": 2737
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 2738,
+          "endColumn": 2749
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2749,
+          "endColumn": 2750
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2751,
+          "endColumn": 2756
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2756,
+          "endColumn": 2757
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 2757,
+          "endColumn": 2760
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2760,
+          "endColumn": 2761
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5393329",
+        "location": {
+          "startColumn": 2762,
+          "endColumn": 2772
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2772,
+          "endColumn": 2773
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 2774,
+          "endColumn": 2777
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2777,
+          "endColumn": 2778
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.986934",
+        "location": {
+          "startColumn": 2779,
+          "endColumn": 2788
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2788,
+          "endColumn": 2789
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2789,
+          "endColumn": 2790
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2790,
+          "endColumn": 2791
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest III. ker.'",
+        "location": {
+          "startColumn": 2792,
+          "endColumn": 2812
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2812,
+          "endColumn": 2813
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2814,
+          "endColumn": 2819
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2819,
+          "endColumn": 2820
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 2820,
+          "endColumn": 2834
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2834,
+          "endColumn": 2835
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2836,
+          "endColumn": 2841
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2841,
+          "endColumn": 2842
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 04.'",
+        "location": {
+          "startColumn": 2842,
+          "endColumn": 2856
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2856,
+          "endColumn": 2857
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 10.'",
+        "location": {
+          "startColumn": 2858,
+          "endColumn": 2872
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2872,
+          "endColumn": 2873
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2873,
+          "endColumn": 2874
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 2875,
+          "endColumn": 2886
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2886,
+          "endColumn": 2887
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2888,
+          "endColumn": 2893
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2893,
+          "endColumn": 2894
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 2894,
+          "endColumn": 2897
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2897,
+          "endColumn": 2898
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5671768",
+        "location": {
+          "startColumn": 2899,
+          "endColumn": 2909
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2909,
+          "endColumn": 2910
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 2911,
+          "endColumn": 2914
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2914,
+          "endColumn": 2915
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.0368517",
+        "location": {
+          "startColumn": 2916,
+          "endColumn": 2926
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2926,
+          "endColumn": 2927
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 2927,
+          "endColumn": 2928
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2928,
+          "endColumn": 2929
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest IV. ker.'",
+        "location": {
+          "startColumn": 2930,
+          "endColumn": 2949
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2949,
+          "endColumn": 2950
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2951,
+          "endColumn": 2956
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2956,
+          "endColumn": 2957
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 2957,
+          "endColumn": 2971
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 2971,
+          "endColumn": 2972
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 2973,
+          "endColumn": 2978
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 2978,
+          "endColumn": 2979
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 11.'",
+        "location": {
+          "startColumn": 2979,
+          "endColumn": 2993
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 2993,
+          "endColumn": 2994
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 12.'",
+        "location": {
+          "startColumn": 2995,
+          "endColumn": 3009
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3009,
+          "endColumn": 3010
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3010,
+          "endColumn": 3011
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3012,
+          "endColumn": 3023
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3023,
+          "endColumn": 3024
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3025,
+          "endColumn": 3030
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3030,
+          "endColumn": 3031
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3031,
+          "endColumn": 3034
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3034,
+          "endColumn": 3035
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5648915",
+        "location": {
+          "startColumn": 3036,
+          "endColumn": 3046
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3046,
+          "endColumn": 3047
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3048,
+          "endColumn": 3051
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3051,
+          "endColumn": 3052
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.0913149",
+        "location": {
+          "startColumn": 3053,
+          "endColumn": 3063
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3063,
+          "endColumn": 3064
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3064,
+          "endColumn": 3065
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3065,
+          "endColumn": 3066
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest V. ker.'",
+        "location": {
+          "startColumn": 3067,
+          "endColumn": 3085
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3085,
+          "endColumn": 3086
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3087,
+          "endColumn": 3092
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3092,
+          "endColumn": 3093
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3093,
+          "endColumn": 3107
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3107,
+          "endColumn": 3108
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3109,
+          "endColumn": 3114
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3114,
+          "endColumn": 3115
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 01.'",
+        "location": {
+          "startColumn": 3115,
+          "endColumn": 3129
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3129,
+          "endColumn": 3130
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3130,
+          "endColumn": 3131
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3132,
+          "endColumn": 3143
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3143,
+          "endColumn": 3144
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3145,
+          "endColumn": 3150
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3150,
+          "endColumn": 3151
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3151,
+          "endColumn": 3154
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3154,
+          "endColumn": 3155
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5002319",
+        "location": {
+          "startColumn": 3156,
+          "endColumn": 3166
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3166,
+          "endColumn": 3167
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3168,
+          "endColumn": 3171
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3171,
+          "endColumn": 3172
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.0520181",
+        "location": {
+          "startColumn": 3173,
+          "endColumn": 3183
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3183,
+          "endColumn": 3184
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3184,
+          "endColumn": 3185
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3185,
+          "endColumn": 3186
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest VI. ker.'",
+        "location": {
+          "startColumn": 3187,
+          "endColumn": 3206
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3206,
+          "endColumn": 3207
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3208,
+          "endColumn": 3213
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3213,
+          "endColumn": 3214
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3214,
+          "endColumn": 3228
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3228,
+          "endColumn": 3229
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3230,
+          "endColumn": 3235
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3235,
+          "endColumn": 3236
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 05.'",
+        "location": {
+          "startColumn": 3236,
+          "endColumn": 3250
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3250,
+          "endColumn": 3251
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3251,
+          "endColumn": 3252
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3253,
+          "endColumn": 3264
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3264,
+          "endColumn": 3265
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3266,
+          "endColumn": 3271
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3271,
+          "endColumn": 3272
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3272,
+          "endColumn": 3275
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3275,
+          "endColumn": 3276
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.509863",
+        "location": {
+          "startColumn": 3277,
+          "endColumn": 3286
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3286,
+          "endColumn": 3287
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3288,
+          "endColumn": 3291
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3291,
+          "endColumn": 3292
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.0625813",
+        "location": {
+          "startColumn": 3293,
+          "endColumn": 3303
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3303,
+          "endColumn": 3304
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3304,
+          "endColumn": 3305
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3305,
+          "endColumn": 3306
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest VII. ker.'",
+        "location": {
+          "startColumn": 3307,
+          "endColumn": 3327
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3327,
+          "endColumn": 3328
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3329,
+          "endColumn": 3334
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3334,
+          "endColumn": 3335
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3335,
+          "endColumn": 3349
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3349,
+          "endColumn": 3350
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3351,
+          "endColumn": 3356
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3356,
+          "endColumn": 3357
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 05.'",
+        "location": {
+          "startColumn": 3357,
+          "endColumn": 3371
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3371,
+          "endColumn": 3372
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3372,
+          "endColumn": 3373
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3374,
+          "endColumn": 3385
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3385,
+          "endColumn": 3386
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3387,
+          "endColumn": 3392
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3392,
+          "endColumn": 3393
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3393,
+          "endColumn": 3396
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3396,
+          "endColumn": 3397
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5027289",
+        "location": {
+          "startColumn": 3398,
+          "endColumn": 3408
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3408,
+          "endColumn": 3409
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3410,
+          "endColumn": 3413
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3413,
+          "endColumn": 3414
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.073376",
+        "location": {
+          "startColumn": 3415,
+          "endColumn": 3424
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3424,
+          "endColumn": 3425
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3425,
+          "endColumn": 3426
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3426,
+          "endColumn": 3427
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest VIII. ker.'",
+        "location": {
+          "startColumn": 3428,
+          "endColumn": 3449
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3449,
+          "endColumn": 3450
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3451,
+          "endColumn": 3456
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3456,
+          "endColumn": 3457
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3457,
+          "endColumn": 3471
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3471,
+          "endColumn": 3472
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3473,
+          "endColumn": 3478
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3478,
+          "endColumn": 3479
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 01.'",
+        "location": {
+          "startColumn": 3479,
+          "endColumn": 3493
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3493,
+          "endColumn": 3494
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Budapest 06.'",
+        "location": {
+          "startColumn": 3495,
+          "endColumn": 3509
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3509,
+          "endColumn": 3510
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3510,
+          "endColumn": 3511
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3512,
+          "endColumn": 3523
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3523,
+          "endColumn": 3524
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3525,
+          "endColumn": 3530
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3530,
+          "endColumn": 3531
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3531,
+          "endColumn": 3534
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3534,
+          "endColumn": 3535
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.4894184",
+        "location": {
+          "startColumn": 3536,
+          "endColumn": 3546
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3546,
+          "endColumn": 3547
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3548,
+          "endColumn": 3551
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3551,
+          "endColumn": 3552
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.070668",
+        "location": {
+          "startColumn": 3553,
+          "endColumn": 3562
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3562,
+          "endColumn": 3563
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3563,
+          "endColumn": 3564
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3564,
+          "endColumn": 3565
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 3566,
+          "endColumn": 3569
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3569,
+          "endColumn": 3570
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3570,
+          "endColumn": 3571
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Csongr",
+        "location": {
+          "startColumn": 3572,
+          "endColumn": 3578
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "d",
+        "location": {
+          "startColumn": 3579,
+          "endColumn": 3580
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Csan",
+        "location": {
+          "startColumn": 3581,
+          "endColumn": 3585
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "d",
+        "location": {
+          "startColumn": 3586,
+          "endColumn": 3587
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3587,
+          "endColumn": 3588
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3589,
+          "endColumn": 3594
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3594,
+          "endColumn": 3595
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Algy",
+        "location": {
+          "startColumn": 3595,
+          "endColumn": 3599
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3600,
+          "endColumn": 3601
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3602,
+          "endColumn": 3607
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3607,
+          "endColumn": 3608
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3608,
+          "endColumn": 3622
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3622,
+          "endColumn": 3623
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3624,
+          "endColumn": 3629
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3629,
+          "endColumn": 3630
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 4.'",
+        "location": {
+          "startColumn": 3630,
+          "endColumn": 3650
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3650,
+          "endColumn": 3651
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3651,
+          "endColumn": 3652
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3653,
+          "endColumn": 3664
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3664,
+          "endColumn": 3665
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3666,
+          "endColumn": 3671
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3671,
+          "endColumn": 3672
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3672,
+          "endColumn": 3675
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3675,
+          "endColumn": 3676
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.3329625",
+        "location": {
+          "startColumn": 3677,
+          "endColumn": 3687
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3687,
+          "endColumn": 3688
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3689,
+          "endColumn": 3692
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3692,
+          "endColumn": 3693
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.207889",
+        "location": {
+          "startColumn": 3694,
+          "endColumn": 3703
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3703,
+          "endColumn": 3704
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3704,
+          "endColumn": 3705
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3705,
+          "endColumn": 3706
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Ambr",
+        "location": {
+          "startColumn": 3707,
+          "endColumn": 3711
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "zfalva",
+        "location": {
+          "startColumn": 3712,
+          "endColumn": 3718
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3718,
+          "endColumn": 3719
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3720,
+          "endColumn": 3725
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3725,
+          "endColumn": 3726
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3726,
+          "endColumn": 3740
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3740,
+          "endColumn": 3741
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3742,
+          "endColumn": 3747
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3747,
+          "endColumn": 3748
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 4.'",
+        "location": {
+          "startColumn": 3748,
+          "endColumn": 3768
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3768,
+          "endColumn": 3769
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3769,
+          "endColumn": 3770
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3771,
+          "endColumn": 3782
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3782,
+          "endColumn": 3783
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3784,
+          "endColumn": 3789
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3789,
+          "endColumn": 3790
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3790,
+          "endColumn": 3793
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3793,
+          "endColumn": 3794
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.3501417",
+        "location": {
+          "startColumn": 3795,
+          "endColumn": 3805
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3805,
+          "endColumn": 3806
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3807,
+          "endColumn": 3810
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3810,
+          "endColumn": 3811
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.7313995",
+        "location": {
+          "startColumn": 3812,
+          "endColumn": 3822
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3822,
+          "endColumn": 3823
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3823,
+          "endColumn": 3824
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3824,
+          "endColumn": 3825
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Ap",
+        "location": {
+          "startColumn": 3826,
+          "endColumn": 3828
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "tfalva",
+        "location": {
+          "startColumn": 3829,
+          "endColumn": 3835
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3835,
+          "endColumn": 3836
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3837,
+          "endColumn": 3842
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3842,
+          "endColumn": 3843
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3843,
+          "endColumn": 3857
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3857,
+          "endColumn": 3858
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3859,
+          "endColumn": 3864
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3864,
+          "endColumn": 3865
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 4.'",
+        "location": {
+          "startColumn": 3865,
+          "endColumn": 3885
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3885,
+          "endColumn": 3886
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3886,
+          "endColumn": 3887
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 3888,
+          "endColumn": 3899
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3899,
+          "endColumn": 3900
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3901,
+          "endColumn": 3906
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3906,
+          "endColumn": 3907
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 3907,
+          "endColumn": 3910
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3910,
+          "endColumn": 3911
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.173317",
+        "location": {
+          "startColumn": 3912,
+          "endColumn": 3921
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3921,
+          "endColumn": 3922
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 3923,
+          "endColumn": 3926
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3926,
+          "endColumn": 3927
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.5800472",
+        "location": {
+          "startColumn": 3928,
+          "endColumn": 3938
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3938,
+          "endColumn": 3939
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 3939,
+          "endColumn": 3940
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 3940,
+          "endColumn": 3941
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "rp",
+        "location": {
+          "startColumn": 3943,
+          "endColumn": 3945
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "dhalom",
+        "location": {
+          "startColumn": 3946,
+          "endColumn": 3952
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3952,
+          "endColumn": 3953
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3954,
+          "endColumn": 3959
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3959,
+          "endColumn": 3960
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 3960,
+          "endColumn": 3974
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 3974,
+          "endColumn": 3975
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 3976,
+          "endColumn": 3981
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 3981,
+          "endColumn": 3982
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 3.'",
+        "location": {
+          "startColumn": 3982,
+          "endColumn": 4002
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4002,
+          "endColumn": 4003
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4003,
+          "endColumn": 4004
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4005,
+          "endColumn": 4016
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4016,
+          "endColumn": 4017
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4018,
+          "endColumn": 4023
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4023,
+          "endColumn": 4024
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4024,
+          "endColumn": 4027
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4027,
+          "endColumn": 4028
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.6158286",
+        "location": {
+          "startColumn": 4029,
+          "endColumn": 4039
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4039,
+          "endColumn": 4040
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4041,
+          "endColumn": 4044
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4044,
+          "endColumn": 4045
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.547733",
+        "location": {
+          "startColumn": 4046,
+          "endColumn": 4055
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4055,
+          "endColumn": 4056
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4056,
+          "endColumn": 4057
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4057,
+          "endColumn": 4058
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "sotthalom",
+        "location": {
+          "startColumn": 4060,
+          "endColumn": 4069
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4069,
+          "endColumn": 4070
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4071,
+          "endColumn": 4076
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4076,
+          "endColumn": 4077
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4077,
+          "endColumn": 4091
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4091,
+          "endColumn": 4092
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4093,
+          "endColumn": 4098
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4098,
+          "endColumn": 4099
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 2.'",
+        "location": {
+          "startColumn": 4099,
+          "endColumn": 4119
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4119,
+          "endColumn": 4120
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4120,
+          "endColumn": 4121
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4122,
+          "endColumn": 4133
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4133,
+          "endColumn": 4134
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4135,
+          "endColumn": 4140
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4140,
+          "endColumn": 4141
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4141,
+          "endColumn": 4144
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4144,
+          "endColumn": 4145
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.1995983",
+        "location": {
+          "startColumn": 4146,
+          "endColumn": 4156
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4156,
+          "endColumn": 4157
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4158,
+          "endColumn": 4161
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4161,
+          "endColumn": 4162
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.7833756",
+        "location": {
+          "startColumn": 4163,
+          "endColumn": 4173
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4173,
+          "endColumn": 4174
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4174,
+          "endColumn": 4175
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4175,
+          "endColumn": 4176
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Baks",
+        "location": {
+          "startColumn": 4177,
+          "endColumn": 4181
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4181,
+          "endColumn": 4182
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4183,
+          "endColumn": 4188
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4188,
+          "endColumn": 4189
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4189,
+          "endColumn": 4203
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4203,
+          "endColumn": 4204
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4205,
+          "endColumn": 4210
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4210,
+          "endColumn": 4211
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 3.'",
+        "location": {
+          "startColumn": 4211,
+          "endColumn": 4231
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4231,
+          "endColumn": 4232
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4232,
+          "endColumn": 4233
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4234,
+          "endColumn": 4245
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4245,
+          "endColumn": 4246
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4247,
+          "endColumn": 4252
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4252,
+          "endColumn": 4253
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4253,
+          "endColumn": 4256
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4256,
+          "endColumn": 4257
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.5518708",
+        "location": {
+          "startColumn": 4258,
+          "endColumn": 4268
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4268,
+          "endColumn": 4269
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4270,
+          "endColumn": 4273
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4273,
+          "endColumn": 4274
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.1064166",
+        "location": {
+          "startColumn": 4275,
+          "endColumn": 4285
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4285,
+          "endColumn": 4286
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4286,
+          "endColumn": 4287
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4287,
+          "endColumn": 4288
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Bal",
+        "location": {
+          "startColumn": 4289,
+          "endColumn": 4292
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "stya",
+        "location": {
+          "startColumn": 4293,
+          "endColumn": 4297
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4297,
+          "endColumn": 4298
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4299,
+          "endColumn": 4304
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4304,
+          "endColumn": 4305
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4305,
+          "endColumn": 4319
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4319,
+          "endColumn": 4320
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4321,
+          "endColumn": 4326
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4326,
+          "endColumn": 4327
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 3.'",
+        "location": {
+          "startColumn": 4327,
+          "endColumn": 4347
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4347,
+          "endColumn": 4348
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4348,
+          "endColumn": 4349
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4350,
+          "endColumn": 4361
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4361,
+          "endColumn": 4362
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4363,
+          "endColumn": 4368
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4368,
+          "endColumn": 4369
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4369,
+          "endColumn": 4372
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4372,
+          "endColumn": 4373
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.4261828",
+        "location": {
+          "startColumn": 4374,
+          "endColumn": 4384
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4384,
+          "endColumn": 4385
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4386,
+          "endColumn": 4389
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4389,
+          "endColumn": 4390
+        }
+      },
+      {
+        "type": "number",
+        "value": "20.004933",
+        "location": {
+          "startColumn": 4391,
+          "endColumn": 4400
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4400,
+          "endColumn": 4401
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4401,
+          "endColumn": 4402
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4402,
+          "endColumn": 4403
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Bord",
+        "location": {
+          "startColumn": 4404,
+          "endColumn": 4408
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "ny",
+        "location": {
+          "startColumn": 4409,
+          "endColumn": 4411
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4411,
+          "endColumn": 4412
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4413,
+          "endColumn": 4418
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4418,
+          "endColumn": 4419
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4419,
+          "endColumn": 4433
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4433,
+          "endColumn": 4434
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4435,
+          "endColumn": 4440
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4440,
+          "endColumn": 4441
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Csongrád-Csanád 2.'",
+        "location": {
+          "startColumn": 4441,
+          "endColumn": 4461
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4461,
+          "endColumn": 4462
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4462,
+          "endColumn": 4463
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4464,
+          "endColumn": 4475
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4475,
+          "endColumn": 4476
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4477,
+          "endColumn": 4482
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4482,
+          "endColumn": 4483
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4483,
+          "endColumn": 4486
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4486,
+          "endColumn": 4487
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.3194213",
+        "location": {
+          "startColumn": 4488,
+          "endColumn": 4498
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4498,
+          "endColumn": 4499
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4500,
+          "endColumn": 4503
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4503,
+          "endColumn": 4504
+        }
+      },
+      {
+        "type": "number",
+        "value": "19.9227063",
+        "location": {
+          "startColumn": 4505,
+          "endColumn": 4515
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4515,
+          "endColumn": 4516
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4516,
+          "endColumn": 4517
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4517,
+          "endColumn": 4518
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 4519,
+          "endColumn": 4522
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4522,
+          "endColumn": 4523
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4523,
+          "endColumn": 4524
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Fej",
+        "location": {
+          "startColumn": 4525,
+          "endColumn": 4528
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "r",
+        "location": {
+          "startColumn": 4529,
+          "endColumn": 4530
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4530,
+          "endColumn": 4531
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4532,
+          "endColumn": 4537
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4537,
+          "endColumn": 4538
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Aba",
+        "location": {
+          "startColumn": 4538,
+          "endColumn": 4541
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4541,
+          "endColumn": 4542
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4543,
+          "endColumn": 4548
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4548,
+          "endColumn": 4549
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4549,
+          "endColumn": 4563
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4563,
+          "endColumn": 4564
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4565,
+          "endColumn": 4570
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4570,
+          "endColumn": 4571
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 5.'",
+        "location": {
+          "startColumn": 4571,
+          "endColumn": 4581
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4581,
+          "endColumn": 4582
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4582,
+          "endColumn": 4583
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4584,
+          "endColumn": 4595
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4595,
+          "endColumn": 4596
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4597,
+          "endColumn": 4602
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4602,
+          "endColumn": 4603
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4603,
+          "endColumn": 4606
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4606,
+          "endColumn": 4607
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.0328193",
+        "location": {
+          "startColumn": 4608,
+          "endColumn": 4618
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4618,
+          "endColumn": 4619
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4620,
+          "endColumn": 4623
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4623,
+          "endColumn": 4624
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.522359",
+        "location": {
+          "startColumn": 4625,
+          "endColumn": 4634
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4634,
+          "endColumn": 4635
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4635,
+          "endColumn": 4636
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4636,
+          "endColumn": 4637
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Adony",
+        "location": {
+          "startColumn": 4638,
+          "endColumn": 4643
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4643,
+          "endColumn": 4644
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4645,
+          "endColumn": 4650
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4650,
+          "endColumn": 4651
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4651,
+          "endColumn": 4665
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4665,
+          "endColumn": 4666
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4667,
+          "endColumn": 4672
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4672,
+          "endColumn": 4673
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 4.'",
+        "location": {
+          "startColumn": 4673,
+          "endColumn": 4683
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4683,
+          "endColumn": 4684
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4684,
+          "endColumn": 4685
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4686,
+          "endColumn": 4697
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4697,
+          "endColumn": 4698
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4699,
+          "endColumn": 4704
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4704,
+          "endColumn": 4705
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4705,
+          "endColumn": 4708
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4708,
+          "endColumn": 4709
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.119831",
+        "location": {
+          "startColumn": 4710,
+          "endColumn": 4719
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4719,
+          "endColumn": 4720
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4721,
+          "endColumn": 4724
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4724,
+          "endColumn": 4725
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.8612469",
+        "location": {
+          "startColumn": 4726,
+          "endColumn": 4736
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4736,
+          "endColumn": 4737
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4737,
+          "endColumn": 4738
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4738,
+          "endColumn": 4739
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Alap",
+        "location": {
+          "startColumn": 4740,
+          "endColumn": 4744
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4744,
+          "endColumn": 4745
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4746,
+          "endColumn": 4751
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4751,
+          "endColumn": 4752
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4752,
+          "endColumn": 4766
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4766,
+          "endColumn": 4767
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4768,
+          "endColumn": 4773
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4773,
+          "endColumn": 4774
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 5.'",
+        "location": {
+          "startColumn": 4774,
+          "endColumn": 4784
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4784,
+          "endColumn": 4785
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4785,
+          "endColumn": 4786
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4787,
+          "endColumn": 4798
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4798,
+          "endColumn": 4799
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4800,
+          "endColumn": 4805
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4805,
+          "endColumn": 4806
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4806,
+          "endColumn": 4809
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4809,
+          "endColumn": 4810
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.8075763",
+        "location": {
+          "startColumn": 4811,
+          "endColumn": 4821
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4821,
+          "endColumn": 4822
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4823,
+          "endColumn": 4826
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4826,
+          "endColumn": 4827
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.684028",
+        "location": {
+          "startColumn": 4828,
+          "endColumn": 4837
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4837,
+          "endColumn": 4838
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4838,
+          "endColumn": 4839
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4839,
+          "endColumn": 4840
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Alcs",
+        "location": {
+          "startColumn": 4841,
+          "endColumn": 4845
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "tdoboz",
+        "location": {
+          "startColumn": 4846,
+          "endColumn": 4852
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4852,
+          "endColumn": 4853
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4854,
+          "endColumn": 4859
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4859,
+          "endColumn": 4860
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4860,
+          "endColumn": 4874
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4874,
+          "endColumn": 4875
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4876,
+          "endColumn": 4881
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4881,
+          "endColumn": 4882
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 3.'",
+        "location": {
+          "startColumn": 4882,
+          "endColumn": 4892
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4892,
+          "endColumn": 4893
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4893,
+          "endColumn": 4894
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 4895,
+          "endColumn": 4906
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4906,
+          "endColumn": 4907
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4908,
+          "endColumn": 4913
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4913,
+          "endColumn": 4914
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 4914,
+          "endColumn": 4917
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4917,
+          "endColumn": 4918
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.4277067",
+        "location": {
+          "startColumn": 4919,
+          "endColumn": 4929
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4929,
+          "endColumn": 4930
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 4931,
+          "endColumn": 4934
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4934,
+          "endColumn": 4935
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.6030325",
+        "location": {
+          "startColumn": 4936,
+          "endColumn": 4946
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4946,
+          "endColumn": 4947
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 4947,
+          "endColumn": 4948
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 4948,
+          "endColumn": 4949
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Als",
+        "location": {
+          "startColumn": 4950,
+          "endColumn": 4953
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "szentiv",
+        "location": {
+          "startColumn": 4954,
+          "endColumn": 4961
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "n",
+        "location": {
+          "startColumn": 4962,
+          "endColumn": 4963
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4963,
+          "endColumn": 4964
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4965,
+          "endColumn": 4970
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4970,
+          "endColumn": 4971
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 4971,
+          "endColumn": 4985
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 4985,
+          "endColumn": 4986
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 4987,
+          "endColumn": 4992
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 4992,
+          "endColumn": 4993
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 5.'",
+        "location": {
+          "startColumn": 4993,
+          "endColumn": 5003
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5003,
+          "endColumn": 5004
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5004,
+          "endColumn": 5005
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5006,
+          "endColumn": 5017
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5017,
+          "endColumn": 5018
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5019,
+          "endColumn": 5024
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5024,
+          "endColumn": 5025
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5025,
+          "endColumn": 5028
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5028,
+          "endColumn": 5029
+        }
+      },
+      {
+        "type": "number",
+        "value": "46.7910573",
+        "location": {
+          "startColumn": 5030,
+          "endColumn": 5040
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5040,
+          "endColumn": 5041
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5042,
+          "endColumn": 5045
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5045,
+          "endColumn": 5046
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.732161",
+        "location": {
+          "startColumn": 5047,
+          "endColumn": 5056
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5056,
+          "endColumn": 5057
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5057,
+          "endColumn": 5058
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5058,
+          "endColumn": 5059
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Bakonycsernye",
+        "location": {
+          "startColumn": 5060,
+          "endColumn": 5073
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5073,
+          "endColumn": 5074
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5075,
+          "endColumn": 5080
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5080,
+          "endColumn": 5081
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5081,
+          "endColumn": 5095
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5095,
+          "endColumn": 5096
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5097,
+          "endColumn": 5102
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5102,
+          "endColumn": 5103
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 2.'",
+        "location": {
+          "startColumn": 5103,
+          "endColumn": 5113
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5113,
+          "endColumn": 5114
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5114,
+          "endColumn": 5115
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5116,
+          "endColumn": 5127
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5127,
+          "endColumn": 5128
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5129,
+          "endColumn": 5134
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5134,
+          "endColumn": 5135
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5135,
+          "endColumn": 5138
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5138,
+          "endColumn": 5139
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.321719",
+        "location": {
+          "startColumn": 5140,
+          "endColumn": 5149
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5149,
+          "endColumn": 5150
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5151,
+          "endColumn": 5154
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5154,
+          "endColumn": 5155
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.0907379",
+        "location": {
+          "startColumn": 5156,
+          "endColumn": 5166
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5166,
+          "endColumn": 5167
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5167,
+          "endColumn": 5168
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5168,
+          "endColumn": 5169
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Bakonyk",
+        "location": {
+          "startColumn": 5170,
+          "endColumn": 5177
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "ti",
+        "location": {
+          "startColumn": 5178,
+          "endColumn": 5180
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5180,
+          "endColumn": 5181
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5182,
+          "endColumn": 5187
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5187,
+          "endColumn": 5188
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5188,
+          "endColumn": 5202
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5202,
+          "endColumn": 5203
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5204,
+          "endColumn": 5209
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5209,
+          "endColumn": 5210
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 2.'",
+        "location": {
+          "startColumn": 5210,
+          "endColumn": 5220
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5220,
+          "endColumn": 5221
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5221,
+          "endColumn": 5222
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5223,
+          "endColumn": 5234
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5234,
+          "endColumn": 5235
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5236,
+          "endColumn": 5241
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5241,
+          "endColumn": 5242
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5242,
+          "endColumn": 5245
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5245,
+          "endColumn": 5246
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.2458464",
+        "location": {
+          "startColumn": 5247,
+          "endColumn": 5257
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5257,
+          "endColumn": 5258
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5259,
+          "endColumn": 5262
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5262,
+          "endColumn": 5263
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.195769",
+        "location": {
+          "startColumn": 5264,
+          "endColumn": 5273
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5273,
+          "endColumn": 5274
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5274,
+          "endColumn": 5275
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5275,
+          "endColumn": 5276
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Balinka",
+        "location": {
+          "startColumn": 5277,
+          "endColumn": 5284
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5284,
+          "endColumn": 5285
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5286,
+          "endColumn": 5291
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5291,
+          "endColumn": 5292
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5292,
+          "endColumn": 5306
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5306,
+          "endColumn": 5307
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5308,
+          "endColumn": 5313
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5313,
+          "endColumn": 5314
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Fejér 2.'",
+        "location": {
+          "startColumn": 5314,
+          "endColumn": 5324
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5324,
+          "endColumn": 5325
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5325,
+          "endColumn": 5326
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5327,
+          "endColumn": 5338
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5338,
+          "endColumn": 5339
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5340,
+          "endColumn": 5345
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5345,
+          "endColumn": 5346
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5346,
+          "endColumn": 5349
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5349,
+          "endColumn": 5350
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.3135736",
+        "location": {
+          "startColumn": 5351,
+          "endColumn": 5361
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5361,
+          "endColumn": 5362
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5363,
+          "endColumn": 5366
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5366,
+          "endColumn": 5367
+        }
+      },
+      {
+        "type": "number",
+        "value": "18.1907168",
+        "location": {
+          "startColumn": 5368,
+          "endColumn": 5378
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5378,
+          "endColumn": 5379
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5379,
+          "endColumn": 5380
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5380,
+          "endColumn": 5381
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 5382,
+          "endColumn": 5385
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5385,
+          "endColumn": 5386
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5386,
+          "endColumn": 5387
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Gy",
+        "location": {
+          "startColumn": 5388,
+          "endColumn": 5390
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "r",
+        "location": {
+          "startColumn": 5391,
+          "endColumn": 5392
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Moson",
+        "location": {
+          "startColumn": 5393,
+          "endColumn": 5398
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Sopron",
+        "location": {
+          "startColumn": 5399,
+          "endColumn": 5405
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5405,
+          "endColumn": 5406
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5407,
+          "endColumn": 5412
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5412,
+          "endColumn": 5413
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Abda",
+        "location": {
+          "startColumn": 5413,
+          "endColumn": 5417
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5417,
+          "endColumn": 5418
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5419,
+          "endColumn": 5424
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5424,
+          "endColumn": 5425
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5425,
+          "endColumn": 5439
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5439,
+          "endColumn": 5440
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5441,
+          "endColumn": 5446
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5446,
+          "endColumn": 5447
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 5.'",
+        "location": {
+          "startColumn": 5447,
+          "endColumn": 5469
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5469,
+          "endColumn": 5470
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5470,
+          "endColumn": 5471
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5472,
+          "endColumn": 5483
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5483,
+          "endColumn": 5484
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5485,
+          "endColumn": 5490
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5490,
+          "endColumn": 5491
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5491,
+          "endColumn": 5494
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5494,
+          "endColumn": 5495
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.6962149",
+        "location": {
+          "startColumn": 5496,
+          "endColumn": 5506
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5506,
+          "endColumn": 5507
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5508,
+          "endColumn": 5511
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5511,
+          "endColumn": 5512
+        }
+      },
+      {
+        "type": "number",
+        "value": "17.5445786",
+        "location": {
+          "startColumn": 5513,
+          "endColumn": 5523
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5523,
+          "endColumn": 5524
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5524,
+          "endColumn": 5525
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5525,
+          "endColumn": 5526
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Acsalag",
+        "location": {
+          "startColumn": 5527,
+          "endColumn": 5534
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5534,
+          "endColumn": 5535
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5536,
+          "endColumn": 5541
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5541,
+          "endColumn": 5542
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5542,
+          "endColumn": 5556
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5556,
+          "endColumn": 5557
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5558,
+          "endColumn": 5563
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5563,
+          "endColumn": 5564
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 3.'",
+        "location": {
+          "startColumn": 5564,
+          "endColumn": 5586
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5586,
+          "endColumn": 5587
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5587,
+          "endColumn": 5588
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5589,
+          "endColumn": 5600
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5600,
+          "endColumn": 5601
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5602,
+          "endColumn": 5607
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5607,
+          "endColumn": 5608
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5608,
+          "endColumn": 5611
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5611,
+          "endColumn": 5612
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.676095",
+        "location": {
+          "startColumn": 5613,
+          "endColumn": 5622
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5622,
+          "endColumn": 5623
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5624,
+          "endColumn": 5627
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5627,
+          "endColumn": 5628
+        }
+      },
+      {
+        "type": "number",
+        "value": "17.1977771",
+        "location": {
+          "startColumn": 5629,
+          "endColumn": 5639
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5639,
+          "endColumn": 5640
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5640,
+          "endColumn": 5641
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5641,
+          "endColumn": 5642
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "gfalva",
+        "location": {
+          "startColumn": 5644,
+          "endColumn": 5650
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5650,
+          "endColumn": 5651
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5652,
+          "endColumn": 5657
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5657,
+          "endColumn": 5658
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5658,
+          "endColumn": 5672
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5672,
+          "endColumn": 5673
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5674,
+          "endColumn": 5679
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5679,
+          "endColumn": 5680
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 4.'",
+        "location": {
+          "startColumn": 5680,
+          "endColumn": 5702
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5702,
+          "endColumn": 5703
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5703,
+          "endColumn": 5704
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5705,
+          "endColumn": 5716
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5716,
+          "endColumn": 5717
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5718,
+          "endColumn": 5723
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5723,
+          "endColumn": 5724
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5724,
+          "endColumn": 5727
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5727,
+          "endColumn": 5728
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.688862",
+        "location": {
+          "startColumn": 5729,
+          "endColumn": 5738
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5738,
+          "endColumn": 5739
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5740,
+          "endColumn": 5743
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5743,
+          "endColumn": 5744
+        }
+      },
+      {
+        "type": "number",
+        "value": "16.5110233",
+        "location": {
+          "startColumn": 5745,
+          "endColumn": 5755
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5755,
+          "endColumn": 5756
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5756,
+          "endColumn": 5757
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5757,
+          "endColumn": 5758
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Agyagosszerg",
+        "location": {
+          "startColumn": 5759,
+          "endColumn": 5771
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "ny",
+        "location": {
+          "startColumn": 5772,
+          "endColumn": 5774
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5774,
+          "endColumn": 5775
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5776,
+          "endColumn": 5781
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5781,
+          "endColumn": 5782
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5782,
+          "endColumn": 5796
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5796,
+          "endColumn": 5797
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5798,
+          "endColumn": 5803
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5803,
+          "endColumn": 5804
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 3.'",
+        "location": {
+          "startColumn": 5804,
+          "endColumn": 5826
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5826,
+          "endColumn": 5827
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5827,
+          "endColumn": 5828
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5829,
+          "endColumn": 5840
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5840,
+          "endColumn": 5841
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5842,
+          "endColumn": 5847
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5847,
+          "endColumn": 5848
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5848,
+          "endColumn": 5851
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5851,
+          "endColumn": 5852
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.608545",
+        "location": {
+          "startColumn": 5853,
+          "endColumn": 5862
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5862,
+          "endColumn": 5863
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5864,
+          "endColumn": 5867
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5867,
+          "endColumn": 5868
+        }
+      },
+      {
+        "type": "number",
+        "value": "16.9409912",
+        "location": {
+          "startColumn": 5869,
+          "endColumn": 5879
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5879,
+          "endColumn": 5880
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5880,
+          "endColumn": 5881
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5881,
+          "endColumn": 5882
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "rp",
+        "location": {
+          "startColumn": 5884,
+          "endColumn": 5886
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "s",
+        "location": {
+          "startColumn": 5887,
+          "endColumn": 5888
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5888,
+          "endColumn": 5889
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5890,
+          "endColumn": 5895
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5895,
+          "endColumn": 5896
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 5896,
+          "endColumn": 5910
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5910,
+          "endColumn": 5911
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5912,
+          "endColumn": 5917
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5917,
+          "endColumn": 5918
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 3.'",
+        "location": {
+          "startColumn": 5918,
+          "endColumn": 5940
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5940,
+          "endColumn": 5941
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5941,
+          "endColumn": 5942
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 5943,
+          "endColumn": 5954
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5954,
+          "endColumn": 5955
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 5956,
+          "endColumn": 5961
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 5961,
+          "endColumn": 5962
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 5962,
+          "endColumn": 5965
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5965,
+          "endColumn": 5966
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5134127",
+        "location": {
+          "startColumn": 5967,
+          "endColumn": 5977
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5977,
+          "endColumn": 5978
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 5979,
+          "endColumn": 5982
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 5982,
+          "endColumn": 5983
+        }
+      },
+      {
+        "type": "number",
+        "value": "17.3931579",
+        "location": {
+          "startColumn": 5984,
+          "endColumn": 5994
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5994,
+          "endColumn": 5995
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 5995,
+          "endColumn": 5996
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 5996,
+          "endColumn": 5997
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "sv",
+        "location": {
+          "startColumn": 5999,
+          "endColumn": 6001
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "nyr",
+        "location": {
+          "startColumn": 6002,
+          "endColumn": 6005
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "r",
+        "location": {
+          "startColumn": 6006,
+          "endColumn": 6007
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6008,
+          "endColumn": 6009
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6010,
+          "endColumn": 6015
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6015,
+          "endColumn": 6016
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 6016,
+          "endColumn": 6030
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6030,
+          "endColumn": 6031
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6032,
+          "endColumn": 6037
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6037,
+          "endColumn": 6038
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 5.'",
+        "location": {
+          "startColumn": 6038,
+          "endColumn": 6060
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6060,
+          "endColumn": 6061
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6061,
+          "endColumn": 6062
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 6063,
+          "endColumn": 6074
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6074,
+          "endColumn": 6075
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6076,
+          "endColumn": 6081
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6081,
+          "endColumn": 6082
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 6082,
+          "endColumn": 6085
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6085,
+          "endColumn": 6086
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.8287695",
+        "location": {
+          "startColumn": 6087,
+          "endColumn": 6097
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6097,
+          "endColumn": 6098
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 6099,
+          "endColumn": 6102
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6102,
+          "endColumn": 6103
+        }
+      },
+      {
+        "type": "number",
+        "value": "17.499195",
+        "location": {
+          "startColumn": 6104,
+          "endColumn": 6113
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6113,
+          "endColumn": 6114
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6114,
+          "endColumn": 6115
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6115,
+          "endColumn": 6116
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "Bab",
+        "location": {
+          "startColumn": 6117,
+          "endColumn": 6120
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "t",
+        "location": {
+          "startColumn": 6121,
+          "endColumn": 6122
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6122,
+          "endColumn": 6123
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6124,
+          "endColumn": 6129
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6129,
+          "endColumn": 6130
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 6130,
+          "endColumn": 6144
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6144,
+          "endColumn": 6145
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6146,
+          "endColumn": 6151
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6151,
+          "endColumn": 6152
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 3.'",
+        "location": {
+          "startColumn": 6152,
+          "endColumn": 6174
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6174,
+          "endColumn": 6175
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6175,
+          "endColumn": 6176
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 6177,
+          "endColumn": 6188
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6188,
+          "endColumn": 6189
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6190,
+          "endColumn": 6195
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6195,
+          "endColumn": 6196
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 6196,
+          "endColumn": 6199
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6199,
+          "endColumn": 6200
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5752269",
+        "location": {
+          "startColumn": 6201,
+          "endColumn": 6211
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6211,
+          "endColumn": 6212
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 6213,
+          "endColumn": 6216
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6216,
+          "endColumn": 6217
+        }
+      },
+      {
+        "type": "number",
+        "value": "17.0758604",
+        "location": {
+          "startColumn": 6218,
+          "endColumn": 6228
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6228,
+          "endColumn": 6229
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6229,
+          "endColumn": 6230
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6230,
+          "endColumn": 6231
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "B",
+        "location": {
+          "startColumn": 6232,
+          "endColumn": 6233
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "gyogszov",
+        "location": {
+          "startColumn": 6234,
+          "endColumn": 6242
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "t",
+        "location": {
+          "startColumn": 6243,
+          "endColumn": 6244
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6244,
+          "endColumn": 6245
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6246,
+          "endColumn": 6251
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6251,
+          "endColumn": 6252
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "constituencies",
+        "location": {
+          "startColumn": 6252,
+          "endColumn": 6266
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6266,
+          "endColumn": 6267
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6268,
+          "endColumn": 6273
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6273,
+          "endColumn": 6274
+        }
+      },
+      {
+        "type": "single_quoted_string",
+        "value": "'Győr-Moson-Sopron 3.'",
+        "location": {
+          "startColumn": 6274,
+          "endColumn": 6296
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6296,
+          "endColumn": 6297
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6297,
+          "endColumn": 6298
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "coordinates",
+        "location": {
+          "startColumn": 6299,
+          "endColumn": 6310
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6310,
+          "endColumn": 6311
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 6312,
+          "endColumn": 6317
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 6317,
+          "endColumn": 6318
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lat",
+        "location": {
+          "startColumn": 6318,
+          "endColumn": 6321
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6321,
+          "endColumn": 6322
+        }
+      },
+      {
+        "type": "number",
+        "value": "47.5866036",
+        "location": {
+          "startColumn": 6323,
+          "endColumn": 6333
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6333,
+          "endColumn": 6334
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "lng",
+        "location": {
+          "startColumn": 6335,
+          "endColumn": 6338
+        }
+      },
+      {
+        "type": "colon",
+        "value": ":",
+        "location": {
+          "startColumn": 6338,
+          "endColumn": 6339
+        }
+      },
+      {
+        "type": "number",
+        "value": "17.3617273",
+        "location": {
+          "startColumn": 6340,
+          "endColumn": 6350
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6350,
+          "endColumn": 6351
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6351,
+          "endColumn": 6352
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6352,
+          "endColumn": 6353
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 6354,
+          "endColumn": 6357
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6357,
+          "endColumn": 6358
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 6358,
+          "endColumn": 6359
+        }
+      },
+      {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 6360,
+          "endColumn": 6363
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 6363,
+          "endColumn": 6364
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 1194,
-          "endColumn": 1195
+          "startColumn": 6364,
+          "endColumn": 6365
         }
       }
     ]
@@ -49567,11 +59215,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$args",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 50
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "NamedArgumentsMethod\\Foo::doIpsum()",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 96
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 111
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 42,
-          "endColumn": 43
+          "startColumn": 122,
+          "endColumn": 123
         }
       }
     ]
@@ -49737,11 +59465,35 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 50,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 53,
+          "endColumn": 54
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "argument",
+        "location": {
+          "startColumn": 55,
+          "endColumn": 63
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 50,
-          "endColumn": 51
+          "startColumn": 63,
+          "endColumn": 64
         }
       }
     ]
@@ -49798,11 +59550,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 42,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$args",
+        "location": {
+          "startColumn": 45,
+          "endColumn": 50
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 51,
+          "endColumn": 53
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 54,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "NamedArgumentsMethod\\Foo::doIpsum()",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 96
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 97,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 111
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 111,
+          "endColumn": 112
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 113,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 122
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 42,
-          "endColumn": 43
+          "startColumn": 122,
+          "endColumn": 123
         }
       }
     ]
@@ -81230,11 +91062,67 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 142,
+          "endColumn": 145
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 146
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 146,
+          "endColumn": 147
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "array",
+        "location": {
+          "startColumn": 148,
+          "endColumn": 153
+        }
+      },
+      {
+        "type": "lbrace",
+        "value": "{",
+        "location": {
+          "startColumn": 153,
+          "endColumn": 154
+        }
+      },
+      {
+        "type": "rbrace",
+        "value": "}",
+        "location": {
+          "startColumn": 154,
+          "endColumn": 155
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 156,
+          "endColumn": 161
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 142,
-          "endColumn": 143
+          "startColumn": 161,
+          "endColumn": 162
         }
       }
     ]
@@ -89465,11 +99353,179 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$everything",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 32
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "LessParametersVariadics\\Baz::doFoo()",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 80
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "is",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 83
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "not",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 87
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "contravariant",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 101
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "with",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 106
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "parameter",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "parameter_number",
+        "value": "#2",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 119
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$parameters",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 131
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 132,
+          "endColumn": 133
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 139
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 139,
+          "endColumn": 140
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 141,
+          "endColumn": 143
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 144,
+          "endColumn": 150
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "LessParametersVariadics\\Foo::doFoo()",
+        "location": {
+          "startColumn": 151,
+          "endColumn": 187
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 187,
+          "endColumn": 188
         }
       }
     ]
@@ -89494,11 +99550,179 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$everything",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 29
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 29,
+          "endColumn": 32
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 36
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 37,
+          "endColumn": 43
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "LessParametersVariadics\\Baz::doFoo()",
+        "location": {
+          "startColumn": 44,
+          "endColumn": 80
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "is",
+        "location": {
+          "startColumn": 81,
+          "endColumn": 83
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "not",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 87
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "contravariant",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 101
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "with",
+        "location": {
+          "startColumn": 102,
+          "endColumn": 106
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "parameter",
+        "location": {
+          "startColumn": 107,
+          "endColumn": 116
+        }
+      },
+      {
+        "type": "parameter_number",
+        "value": "#3",
+        "location": {
+          "startColumn": 117,
+          "endColumn": 119
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$here",
+        "location": {
+          "startColumn": 120,
+          "endColumn": 125
+        }
+      },
+      {
+        "type": "lparen",
+        "value": "(",
+        "location": {
+          "startColumn": 126,
+          "endColumn": 127
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 127,
+          "endColumn": 133
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 133,
+          "endColumn": 134
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 135,
+          "endColumn": 137
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 138,
+          "endColumn": 144
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "LessParametersVariadics\\Foo::doFoo()",
+        "location": {
+          "startColumn": 145,
+          "endColumn": 181
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 181,
+          "endColumn": 182
         }
       }
     ]
@@ -89523,11 +99747,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Bar::anotherVariadicStrings()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 99
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 110,
+          "endColumn": 111
         }
       }
     ]
@@ -89552,11 +99856,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Bar::variadicStrings()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 77
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 97
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 103,
+          "endColumn": 104
         }
       }
     ]
@@ -92426,11 +102810,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Bar::anotherVariadicStrings()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 84
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 85,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 99
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 100
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 101,
+          "endColumn": 104
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 105,
+          "endColumn": 110
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 110,
+          "endColumn": 111
         }
       }
     ]
@@ -92455,11 +102919,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Bar::variadicStrings()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 77
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 78,
+          "endColumn": 85
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 86,
+          "endColumn": 92
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 92,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 94,
+          "endColumn": 97
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 98,
+          "endColumn": 103
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 103,
+          "endColumn": 104
         }
       }
     ]
@@ -92484,11 +103028,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Foo::doVariadicString()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -93114,11 +103738,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$args",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 21
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 31
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "NamedArgumentsMethod\\Foo::doIpsum()",
+        "location": {
+          "startColumn": 32,
+          "endColumn": 67
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 68,
+          "endColumn": 75
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 76,
+          "endColumn": 82
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 82,
+          "endColumn": 83
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 84,
+          "endColumn": 87
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 88,
+          "endColumn": 93
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 93,
+          "endColumn": 94
         }
       }
     ]
@@ -93143,11 +103847,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Foo::doVariadicString()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -93491,11 +104275,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Foo::doVariadicString()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -93677,11 +104541,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Foo::doVariadicString()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -93807,11 +104751,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 13,
+          "endColumn": 16
+        }
+      },
+      {
+        "type": "variable_name",
+        "value": "$strings",
+        "location": {
+          "startColumn": 16,
+          "endColumn": 24
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "of",
+        "location": {
+          "startColumn": 25,
+          "endColumn": 27
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "method",
+        "location": {
+          "startColumn": 28,
+          "endColumn": 34
+        }
+      },
+      {
+        "type": "method_name",
+        "value": "CallVariadicMethods\\Foo::doVariadicString()",
+        "location": {
+          "startColumn": 35,
+          "endColumn": 78
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "expects",
+        "location": {
+          "startColumn": 79,
+          "endColumn": 86
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "string",
+        "location": {
+          "startColumn": 87,
+          "endColumn": 93
+        }
+      },
+      {
+        "type": "comma",
+        "value": ",",
+        "location": {
+          "startColumn": 93,
+          "endColumn": 94
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "int",
+        "location": {
+          "startColumn": 95,
+          "endColumn": 98
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "given",
+        "location": {
+          "startColumn": 99,
+          "endColumn": 104
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 13,
-          "endColumn": 14
+          "startColumn": 104,
+          "endColumn": 105
         }
       }
     ]
@@ -109986,11 +121010,91 @@
         }
       },
       {
+        "type": "ellipsis",
+        "value": "...",
+        "location": {
+          "startColumn": 19,
+          "endColumn": 22
+        }
+      },
+      {
+        "type": "rparen",
+        "value": ")",
+        "location": {
+          "startColumn": 22,
+          "endColumn": 23
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "cannot",
+        "location": {
+          "startColumn": 24,
+          "endColumn": 30
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "be",
+        "location": {
+          "startColumn": 31,
+          "endColumn": 33
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "followed",
+        "location": {
+          "startColumn": 34,
+          "endColumn": 42
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "by",
+        "location": {
+          "startColumn": 43,
+          "endColumn": 45
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "a",
+        "location": {
+          "startColumn": 46,
+          "endColumn": 47
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "non",
+        "location": {
+          "startColumn": 48,
+          "endColumn": 51
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "unpacked",
+        "location": {
+          "startColumn": 52,
+          "endColumn": 60
+        }
+      },
+      {
+        "type": "common_word",
+        "value": "argument",
+        "location": {
+          "startColumn": 61,
+          "endColumn": 69
+        }
+      },
+      {
         "type": "period",
         "value": ".",
         "location": {
-          "startColumn": 19,
-          "endColumn": 20
+          "startColumn": 69,
+          "endColumn": 70
         }
       }
     ]

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -211,6 +211,11 @@ describe('sample test', () => {
       m: 'Offset exists on array{foo?: string}.',
       assertions: [['question:?', true]],
     },
+    {
+      name: 'parse ellipsis in variadic parameter',
+      m: 'Parameter #1 ...$arg1 of function max expects non-empty-array, array{} given.',
+      assertions: [['ellipsis:...', true]],
+    },
   ] satisfies DataSet[];
 
   test.each(dataSet)('$name', ({ m, assertions }) => {


### PR DESCRIPTION
## Summary

Add `...` (ellipsis) as a token for variadic parameters and spread operators in PHPStan error messages.

Examples:
- `Parameter #1 ...$arg1 of function max expects non-empty-array, array{} given.`
- `array{foo?: string, bar?: string, ...}`

### Note

`ELLIPSIS` is defined before `PERIOD` in the lexer to ensure `...` is matched as a single token instead of three `.` tokens.

## Test plan

- [x] All 82 tests pass
- [x] Parser test: `...` detected in variadic parameter message
- [x] 3 snapshot categories updated
- [x] Biome + tsc pass

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A