### PR TITLE
perf: reuse Parser instance (67x faster)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { format, type Word } from './format.js';
 import { lexer, Parser } from './parser.js';
 
+const parser = new Parser();
+
 export function parse(errorMessage: string): Word[] {
-  const parser = new Parser();
   const lexingResult = lexer.tokenize(errorMessage);
   parser.input = lexingResult.tokens;
   const cst = parser.errorMessage();


### PR DESCRIPTION
## Summary

Reuse a single Parser instance instead of creating one per `parse()` call.

### Problem

Benchmark revealed that `new Parser()` (which runs `performSelfAnalysis` and builds lookahead tables) accounted for **95% of runtime**. It was called 4594 times per benchmark iteration.

### Fix

One line change: move `new Parser()` to module scope.

```typescript
// Before
export function parse(errorMessage: string): Word[] {
  const parser = new Parser();
  // ...

// After
const parser = new Parser();
export function parse(errorMessage: string): Word[] {
  // ...
```

Chevrotain's `parser.input` setter calls `reset()` internally, so reuse is safe.

### Results

| | Mean (ms) | Per message (ms) | Improvement |
|---|----------|-----------------|-------------|
| Before | 11876 | 2.585 | - |
| **After** | **177** | **0.039** | **67x faster** |

## Test plan

- [x] All 82 tests pass
- [x] Biome + tsc pass
- [x] vitest suite completes in 2.5s (previously 14-20s)

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A