### PR TITLE
Fix StaticMethodName to match in any context

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -17,7 +17,7 @@ const tokens = {
   }),
   STATIC_METHOD_NAME: createToken({
     name: 'StaticMethodName',
-    pattern: /(?<!(T|t)he (M|m)ethod )(?<=(M|m)ethod )(\w+(\\[\w]+)*::\w+\(\))/,
+    pattern: /[a-zA-Z]\w*(\\[a-zA-Z]\w*)*::\w+\(\)/,
     line_breaks: false,
   }),
   METHOD_NAME: createToken({

--- a/test/__snapshots__/2.2.x/Api.snap
+++ b/test/__snapshots__/2.2.x/Api.snap
@@ -591,50 +591,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "method_name",
+        "value": "PHPStan\\Type\\ObjectType::getTemplateType()",
         "location": {
           "startColumn": 8,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Type",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ObjectType",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "getTemplateType",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 49,
           "endColumn": 50
         }
       },
@@ -732,50 +692,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "method_name",
+        "value": "PHPStan\\Type\\Type::getTemplateType()",
         "location": {
           "startColumn": 8,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Type",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Type",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "getTemplateType",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 43,
           "endColumn": 44
         }
       },
@@ -865,50 +785,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "method_name",
+        "value": "PHPStan\\Command\\CommandHelper::begin()",
         "location": {
           "startColumn": 8,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Command",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CommandHelper",
-        "location": {
-          "startColumn": 24,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "begin",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 45,
           "endColumn": 46
         }
       },
@@ -990,50 +870,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "method_name",
+        "value": "PHPStan\\Node\\InClassNode::__construct()",
         "location": {
           "startColumn": 8,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Node",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "InClassNode",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 46,
           "endColumn": 47
         }
       },
@@ -1115,58 +955,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "method_name",
+        "value": "PHPStan\\Rules\\Debug\\DumpTypeRule::getNodeType()",
         "location": {
           "startColumn": 8,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Rules",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Debug",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DumpTypeRule",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "getNodeType",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 54,
           "endColumn": 55
         }
       },
@@ -1248,58 +1040,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "method_name",
+        "value": "PHPStan\\Type\\Php\\ArrayKeyDynamicReturnTypeExtension::isFunctionSupported()",
         "location": {
           "startColumn": 8,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Type",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Php",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ArrayKeyDynamicReturnTypeExtension",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "isFunctionSupported",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 80
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 80,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 81,
           "endColumn": 82
         }
       },

--- a/test/__snapshots__/2.2.x/Classes.snap
+++ b/test/__snapshots__/2.2.x/Classes.snap
@@ -6768,42 +6768,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestInstantiation",
+        "type": "method_name",
+        "value": "TestInstantiation\\ProtectedConstructorClass::__construct()",
         "location": {
           "startColumn": 107,
-          "endColumn": 124
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ProtectedConstructorClass",
-        "location": {
-          "startColumn": 125,
-          "endColumn": 150
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 154,
-          "endColumn": 163
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 163,
-          "endColumn": 164
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 164,
           "endColumn": 165
         }
       },
@@ -6885,42 +6853,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestInstantiation",
+        "type": "method_name",
+        "value": "TestInstantiation\\PrivateConstructorClass::__construct()",
         "location": {
           "startColumn": 98,
-          "endColumn": 115
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateConstructorClass",
-        "location": {
-          "startColumn": 116,
-          "endColumn": 139
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 143,
-          "endColumn": 152
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 152,
-          "endColumn": 153
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 153,
           "endColumn": 154
         }
       },
@@ -7002,42 +6938,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestInstantiation",
+        "type": "method_name",
+        "value": "TestInstantiation\\PrivateConstructorClass::__construct()",
         "location": {
           "startColumn": 91,
-          "endColumn": 108
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateConstructorClass",
-        "location": {
-          "startColumn": 109,
-          "endColumn": 132
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 136,
-          "endColumn": 145
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 145,
-          "endColumn": 146
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 146,
           "endColumn": 147
         }
       },
@@ -7119,42 +7023,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestInstantiation",
+        "type": "method_name",
+        "value": "TestInstantiation\\ProtectedConstructorClass::__construct()",
         "location": {
           "startColumn": 95,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ProtectedConstructorClass",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 138
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 142,
-          "endColumn": 151
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 151,
-          "endColumn": 152
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 152,
           "endColumn": 153
         }
       },
@@ -38894,42 +38766,10 @@
     "input": "TestInstantiation\\InstantiatingClass::doFoo() calls new parent but TestInstantiation\\InstantiatingClass does not extend any class.",
     "tokens": [
       {
-        "type": "common_word",
-        "value": "TestInstantiation",
+        "type": "method_name",
+        "value": "TestInstantiation\\InstantiatingClass::doFoo()",
         "location": {
           "startColumn": 0,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "InstantiatingClass",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "doFoo",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 44,
           "endColumn": 45
         }
       },

--- a/test/__snapshots__/2.2.x/Constants.snap
+++ b/test/__snapshots__/2.2.x/Constants.snap
@@ -4419,50 +4419,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FinalPrivateConstants",
+        "type": "method_name",
+        "value": "FinalPrivateConstants\\User::FINAL_PRIVATE()",
         "location": {
           "startColumn": 17,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "User",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FINAL",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PRIVATE",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 59,
           "endColumn": 60
         }
       },

--- a/test/__snapshots__/2.2.x/DeadCode.snap
+++ b/test/__snapshots__/2.2.x/DeadCode.snap
@@ -40,42 +40,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CallToStaticMethodWithoutImpurePoints",
+        "type": "method_name",
+        "value": "CallToStaticMethodWithoutImpurePoints\\SubSubY::mySubSubFunc()",
         "location": {
           "startColumn": 8,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SubSubY",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "mySubSubFunc",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 67
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 67,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 68,
           "endColumn": 69
         }
       },
@@ -165,42 +133,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CallToStaticMethodWithoutImpurePoints",
+        "type": "method_name",
+        "value": "CallToStaticMethodWithoutImpurePoints\\X::myFunc()",
         "location": {
           "startColumn": 8,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "X",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "myFunc",
-        "location": {
-          "startColumn": 49,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 56,
           "endColumn": 57
         }
       },
@@ -290,42 +226,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CallToStaticMethodWithoutImpurePoints",
+        "type": "method_name",
+        "value": "CallToStaticMethodWithoutImpurePoints\\y::myFunc()",
         "location": {
           "startColumn": 8,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "y",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "myFunc",
-        "location": {
-          "startColumn": 49,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 56,
           "endColumn": 57
         }
       },

--- a/test/__snapshots__/2.2.x/Methods.snap
+++ b/test/__snapshots__/2.2.x/Methods.snap
@@ -869,50 +869,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "method_name",
+        "value": "Bug7434\\Contract::method()",
         "location": {
           "startColumn": 8,
-          "endColumn": 11
-        }
-      },
-      {
-        "type": "number",
-        "value": "7434",
-        "location": {
-          "startColumn": 11,
-          "endColumn": 15
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Contract",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "method",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 33,
           "endColumn": 34
         }
       },
@@ -1066,42 +1026,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConstructorStatementNoSideEffects",
+        "type": "method_name",
+        "value": "ConstructorStatementNoSideEffects\\ConstructorWithPure::__construct()",
         "location": {
           "startColumn": 8,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ConstructorWithPure",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 65,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 74,
-          "endColumn": 75
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 75,
           "endColumn": 76
         }
       },
@@ -1191,42 +1119,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConstructorStatementNoSideEffects",
+        "type": "method_name",
+        "value": "ConstructorStatementNoSideEffects\\ConstructorWithPureAndThrowsVoid::__construct()",
         "location": {
           "startColumn": 8,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ConstructorWithPureAndThrowsVoid",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 78,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 87,
-          "endColumn": 88
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 88,
           "endColumn": 89
         }
       },
@@ -1316,34 +1212,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Exception",
+        "type": "method_name",
+        "value": "Exception::__construct()",
         "location": {
           "startColumn": 8,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "construct",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 31,
           "endColumn": 32
         }
       },
@@ -1433,42 +1305,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "NamedArgumentRenamedParameter",
+        "type": "method_name",
+        "value": "NamedArgumentRenamedParameter\\Foo::doFoo()",
         "location": {
           "startColumn": 8,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "doFoo",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 49,
           "endColumn": 50
         }
       },
@@ -1856,34 +1696,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "mixed",
+        "type": "method_name",
+        "value": "mixed::bar()",
         "location": {
           "startColumn": 77,
-          "endColumn": 82
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "bar",
-        "location": {
-          "startColumn": 84,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 87,
-          "endColumn": 88
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 88,
           "endColumn": 89
         }
       },
@@ -3469,42 +3285,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Test",
+        "type": "method_name",
+        "value": "Test\\WithFooMethod::bar()",
         "location": {
           "startColumn": 47,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithFooMethod",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "bar",
-        "location": {
-          "startColumn": 67,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 70,
-          "endColumn": 71
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 71,
           "endColumn": 72
         }
       },
@@ -3578,42 +3362,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Test",
+        "type": "method_name",
+        "value": "Test\\WithFooMethod::bar()",
         "location": {
           "startColumn": 53,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithFooMethod",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 71
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "bar",
-        "location": {
-          "startColumn": 73,
-          "endColumn": 76
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 76,
-          "endColumn": 77
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 77,
           "endColumn": 78
         }
       },
@@ -5006,42 +4758,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CallStaticMethods",
+        "type": "method_name",
+        "value": "CallStaticMethods\\Foo::nonexistentMethod()",
         "location": {
           "startColumn": 40,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "nonexistentMethod",
-        "location": {
-          "startColumn": 63,
-          "endColumn": 80
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 80,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 81,
           "endColumn": 82
         }
       },
@@ -5139,34 +4859,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnitEnum",
+        "type": "method_name",
+        "value": "UnitEnum::from()",
         "location": {
           "startColumn": 46,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "from",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 60,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 61,
           "endColumn": 62
         }
       },
@@ -5264,34 +4960,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnitEnum",
+        "type": "method_name",
+        "value": "UnitEnum::from()",
         "location": {
           "startColumn": 47,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "from",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 62,
           "endColumn": 63
         }
       },
@@ -10874,42 +10546,10 @@
     "input": "CallStaticMethods\\Ipsum::ipsumTest() calls parent::lorem() but CallStaticMethods\\Ipsum does not extend any class.",
     "tokens": [
       {
-        "type": "common_word",
-        "value": "CallStaticMethods",
+        "type": "method_name",
+        "value": "CallStaticMethods\\Ipsum::ipsumTest()",
         "location": {
           "startColumn": 0,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ipsumTest",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 34,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 35,
           "endColumn": 36
         }
       },
@@ -10922,34 +10562,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "parent",
+        "type": "method_name",
+        "value": "parent::lorem()",
         "location": {
           "startColumn": 43,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "lorem",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 57,
           "endColumn": 58
         }
       },
@@ -11039,34 +10655,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "parent",
+        "type": "method_name",
+        "value": "parent::someStaticMethod()",
         "location": {
           "startColumn": 8,
-          "endColumn": 14
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "someStaticMethod",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 33,
           "endColumn": 34
         }
       },
@@ -11124,34 +10716,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "self",
+        "type": "method_name",
+        "value": "self::someStaticMethod()",
         "location": {
           "startColumn": 8,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "someStaticMethod",
-        "location": {
-          "startColumn": 14,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 31,
           "endColumn": 32
         }
       },
@@ -11209,34 +10777,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "static",
+        "type": "method_name",
+        "value": "static::someStaticMethod()",
         "location": {
           "startColumn": 8,
-          "endColumn": 14
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "someStaticMethod",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 33,
           "endColumn": 34
         }
       },

--- a/test/__snapshots__/2.2.x/Properties.snap
+++ b/test/__snapshots__/2.2.x/Properties.snap
@@ -16620,34 +16620,10 @@
     "input": "IpsumAccessStaticProperties::ipsum() accesses parent::$lorem but IpsumAccessStaticProperties does not extend any class.",
     "tokens": [
       {
-        "type": "common_word",
-        "value": "IpsumAccessStaticProperties",
+        "type": "method_name",
+        "value": "IpsumAccessStaticProperties::ipsum()",
         "location": {
           "startColumn": 0,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ipsum",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "lparen",
-        "value": "(",
-        "location": {
-          "startColumn": 34,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "rparen",
-        "value": ")",
-        "location": {
-          "startColumn": 35,
           "endColumn": 36
         }
       },

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -78,6 +78,18 @@ describe('sample test', () => {
       ],
     },
     {
+      name: 'parse static method without method keyword',
+      m: 'Calling PHPStan\\Command\\CommandHelper::begin() is not covered.',
+      assertions: [
+        ['StaticMethodName:PHPStan\\Command\\CommandHelper::begin()', true],
+      ],
+    },
+    {
+      name: 'parse static method after constructor',
+      m: 'Cannot instantiate via constructor Test\\Foo::__construct().',
+      assertions: [['StaticMethodName:Test\\Foo::__construct()', true]],
+    },
+    {
       name: 'parse parameter number',
       m: 'Parameter #1 $bar of method Test\\ClassWithNullableProperty::doBar() is passed by reference, so it expects variables only.',
       assertions: [


### PR DESCRIPTION
## Summary

Remove lookbehind from `StaticMethodName` pattern so it matches `Class::method()` in any context, not just after "Method ".

### Problem

`StaticMethodName` had a `(?<=(M|m)ethod )` lookbehind, so it only matched after "Method " or "method ". This missed many real PHPStan error patterns:

- `Calling PHPStan\Command\CommandHelper::begin() is not covered.`
- `Cannot instantiate via constructor Test\Foo::__construct().`
- `Call to PHPStan\Type\ObjectType::getTemplateType() references unknown template type.`

### Fix

```diff
- pattern: /(?<!(T|t)he (M|m)ethod )(?<=(M|m)ethod )(\w+(\\[\w]+)*::\w+\(\))/
+ pattern: /[a-zA-Z]\w*(\\[a-zA-Z]\w*)*::\w+\(\)/
```

Now matches any `Class::method()` or `Namespace\Class::method()` regardless of preceding text.

### MethodName unchanged

`MethodName` keeps its `(?<=(M|m)ethod )` lookbehind since it matches patterns like `Method assert()` (without `::`) which would over-match without the constraint.

## Test plan

- [x] All 84 tests pass
- [x] Existing test: `method CallPrivateMethodThroughStatic\Foo::doBar()` still detected
- [x] New test: `Calling PHPStan\Command\CommandHelper::begin()` → `StaticMethodName`
- [x] New test: `constructor Test\Foo::__construct()` → `StaticMethodName`
- [x] 6 snapshot categories updated
- [x] Biome + tsc pass

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A