### PR TITLE
Add StaticProperty and StaticConstant tokens

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -23,6 +23,8 @@ export type Word = {
     | 'rbracket'
     | 'pipe'
     | 'ampersand'
+    | 'static_property'
+    | 'static_constant'
     | 'question'
     | 'ellipsis'
     | 'period';
@@ -92,6 +94,8 @@ const tokenTypeMap: Record<string, Word['type']> = {
   rbracket: 'rbracket',
   pipe: 'pipe',
   ampersand: 'ampersand',
+  StaticProperty: 'static_property',
+  StaticConstant: 'static_constant',
   question: 'question',
   ellipsis: 'ellipsis',
   period: 'period',

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,6 +20,16 @@ const tokens = {
     pattern: /[a-zA-Z]\w*(\\[a-zA-Z]\w*)*::\w+\(\)/,
     line_breaks: false,
   }),
+  STATIC_PROPERTY: createToken({
+    name: 'StaticProperty',
+    pattern: /[a-zA-Z]\w*(\\[a-zA-Z]\w*)*::\$\w+/,
+    line_breaks: false,
+  }),
+  STATIC_CONSTANT: createToken({
+    name: 'StaticConstant',
+    pattern: /[a-zA-Z]\w*(\\[a-zA-Z]\w*)*::[A-Z]\w*/,
+    line_breaks: false,
+  }),
   METHOD_NAME: createToken({
     name: 'MethodName',
     pattern: /(?<!(T|t)he (M|m)ethod )(?<=(M|m)ethod )([\w]+(\\[\w]+)*(\(\))?)/,
@@ -102,6 +112,8 @@ export class Parser extends CstParser {
         { ALT: () => this.CONSUME(tokens.DOUBLE_QUOTED_STRING) },
         { ALT: () => this.CONSUME(tokens.FUNCTION_NAME) },
         { ALT: () => this.CONSUME(tokens.STATIC_METHOD_NAME) },
+        { ALT: () => this.CONSUME(tokens.STATIC_PROPERTY) },
+        { ALT: () => this.CONSUME(tokens.STATIC_CONSTANT) },
         { ALT: () => this.CONSUME(tokens.METHOD_NAME) },
         { ALT: () => this.CONSUME(tokens.COMMON_WORD) },
         { ALT: () => this.CONSUME(tokens.DOC_TAG) },

--- a/test/__snapshots__/2.2.x/Api.snap
+++ b/test/__snapshots__/2.2.x/Api.snap
@@ -11,34 +11,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PHPStan",
+        "type": "static_constant",
+        "value": "PHPStan\\Analyser\\NodeScopeResolver::FOO",
         "location": {
           "startColumn": 10,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Analyser",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NodeScopeResolver",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 46,
           "endColumn": 49
         }
       },

--- a/test/__snapshots__/2.2.x/Arrays.snap
+++ b/test/__snapshots__/2.2.x/Arrays.snap
@@ -1200,18 +1200,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "self",
+        "type": "static_constant",
+        "value": "self::EQ",
         "location": {
           "startColumn": 43,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "EQ",
-        "location": {
-          "startColumn": 49,
           "endColumn": 51
         }
       },
@@ -1224,18 +1216,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "self",
+        "type": "static_constant",
+        "value": "self::IS",
         "location": {
           "startColumn": 53,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "IS",
-        "location": {
-          "startColumn": 59,
           "endColumn": 61
         }
       },
@@ -7414,34 +7398,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug6315\\FooEnum::A",
         "location": {
           "startColumn": 23,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "6315",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 40,
           "endColumn": 41
         }
       },
@@ -7491,34 +7451,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug6315\\FooEnum::B",
         "location": {
           "startColumn": 23,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "6315",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 40,
           "endColumn": 41
         }
       },
@@ -7621,26 +7557,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidKeyArrayItemEnum",
+        "type": "static_constant",
+        "value": "InvalidKeyArrayItemEnum\\FooEnum::A",
         "location": {
           "startColumn": 23,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 56,
           "endColumn": 57
         }
       },

--- a/test/__snapshots__/2.2.x/Classes.snap
+++ b/test/__snapshots__/2.2.x/Classes.snap
@@ -470,18 +470,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "parent",
+        "type": "static_constant",
+        "value": "parent::BAZ",
         "location": {
           "startColumn": 10,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 18,
           "endColumn": 21
         }
       },
@@ -959,26 +951,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstFetchDefined",
+        "type": "static_constant",
+        "value": "ClassConstFetchDefined\\Foo::TEST",
         "location": {
           "startColumn": 29,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TEST",
-        "location": {
-          "startColumn": 57,
           "endColumn": 61
         }
       },
@@ -1028,26 +1004,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantAttribute",
+        "type": "static_constant",
+        "value": "ClassConstantAttribute\\Foo::BAR",
         "location": {
           "startColumn": 29,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 57,
           "endColumn": 60
         }
       },
@@ -1097,26 +1057,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantDynamicAccess",
+        "type": "static_constant",
+        "value": "ClassConstantDynamicAccess\\Foo::BUZ",
         "location": {
           "startColumn": 29,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BUZ",
-        "location": {
-          "startColumn": 61,
           "endColumn": 64
         }
       },
@@ -1166,26 +1110,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantDynamicAccess",
+        "type": "static_constant",
+        "value": "ClassConstantDynamicAccess\\Foo::FOO",
         "location": {
           "startColumn": 29,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 61,
           "endColumn": 64
         }
       },
@@ -1235,26 +1163,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantDynamicAccess",
+        "type": "static_constant",
+        "value": "ClassConstantDynamicAccess\\Foo::QUX",
         "location": {
           "startColumn": 29,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "QUX",
-        "location": {
-          "startColumn": 61,
           "endColumn": 64
         }
       },
@@ -1304,26 +1216,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantNamespace",
+        "type": "static_constant",
+        "value": "ClassConstantNamespace\\Foo::DOLOR",
         "location": {
           "startColumn": 29,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DOLOR",
-        "location": {
-          "startColumn": 57,
           "endColumn": 62
         }
       },
@@ -1397,18 +1293,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "string",
+        "type": "static_constant",
+        "value": "string::DOLOR",
         "location": {
           "startColumn": 56,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DOLOR",
-        "location": {
-          "startColumn": 64,
           "endColumn": 69
         }
       },
@@ -1458,34 +1346,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantVisibility",
+        "type": "static_constant",
+        "value": "ClassConstantVisibility\\Bar::PRIVATE_FOO",
         "location": {
           "startColumn": 29,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PRIVATE",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 66,
           "endColumn": 69
         }
       },
@@ -1559,26 +1423,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantVisibility",
+        "type": "static_constant",
+        "value": "ClassConstantVisibility\\WithFooConstant::BAZ",
         "location": {
           "startColumn": 75,
-          "endColumn": 98
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithFooConstant",
-        "location": {
-          "startColumn": 99,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 116,
           "endColumn": 119
         }
       },
@@ -1652,26 +1500,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantVisibility",
+        "type": "static_constant",
+        "value": "ClassConstantVisibility\\WithFooConstant::BAR",
         "location": {
           "startColumn": 75,
-          "endColumn": 98
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithFooConstant",
-        "location": {
-          "startColumn": 99,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 116,
           "endColumn": 119
         }
       },
@@ -1721,18 +1553,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Foo",
+        "type": "static_constant",
+        "value": "Foo::TEST",
         "location": {
           "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TEST",
-        "location": {
-          "startColumn": 34,
           "endColumn": 38
         }
       },
@@ -7296,42 +7120,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug14250\\TraitWithDuplicateConstants::CONST1",
         "location": {
           "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "number",
-        "value": "14250",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TraitWithDuplicateConstants",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 64,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "number",
-        "value": "1",
-        "location": {
-          "startColumn": 69,
           "endColumn": 70
         }
       },
@@ -7373,42 +7165,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug14250\\TraitWithDuplicateConstants::CONST2",
         "location": {
           "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "number",
-        "value": "14250",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TraitWithDuplicateConstants",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 64,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 69,
           "endColumn": 70
         }
       },
@@ -7450,34 +7210,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicateDeclarations",
+        "type": "static_constant",
+        "value": "DuplicateDeclarations\\Foo::CONST1",
         "location": {
           "startColumn": 26,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "number",
-        "value": "1",
-        "location": {
-          "startColumn": 58,
           "endColumn": 59
         }
       },
@@ -7519,34 +7255,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicateDeclarations",
+        "type": "static_constant",
+        "value": "DuplicateDeclarations\\Foo::CONST2",
         "location": {
           "startColumn": 26,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 58,
           "endColumn": 59
         }
       },
@@ -7588,26 +7300,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicatedEnumCase",
+        "type": "static_constant",
+        "value": "DuplicatedEnumCase\\Hoo::BAR",
         "location": {
           "startColumn": 26,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Hoo",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 50,
           "endColumn": 53
         }
       },
@@ -7657,26 +7353,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicatedEnumCase",
+        "type": "static_constant",
+        "value": "DuplicatedEnumCase\\Boo::BAR",
         "location": {
           "startColumn": 27,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Boo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 51,
           "endColumn": 54
         }
       },
@@ -7726,26 +7406,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicatedEnumCase",
+        "type": "static_constant",
+        "value": "DuplicatedEnumCase\\Foo::BAR",
         "location": {
           "startColumn": 27,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 51,
           "endColumn": 54
         }
       },
@@ -8012,42 +7676,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14250PromotedProperties\\TraitWithDuplicatePromotedProperties::$bar",
         "location": {
           "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "number",
-        "value": "14250",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PromotedProperties",
-        "location": {
-          "startColumn": 34,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TraitWithDuplicatePromotedProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 89
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 91,
           "endColumn": 95
         }
       },
@@ -8089,42 +7721,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14250PromotedProperties\\TraitWithDuplicatePromotedProperties::$foo",
         "location": {
           "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "number",
-        "value": "14250",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PromotedProperties",
-        "location": {
-          "startColumn": 34,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TraitWithDuplicatePromotedProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 89
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 91,
           "endColumn": 95
         }
       },
@@ -8166,34 +7766,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14250\\TraitWithDuplicateProperties::$prop1",
         "location": {
           "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "number",
-        "value": "14250",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TraitWithDuplicateProperties",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop1",
-        "location": {
-          "startColumn": 65,
           "endColumn": 71
         }
       },
@@ -8235,34 +7811,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14250\\TraitWithDuplicateProperties::$prop2",
         "location": {
           "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "number",
-        "value": "14250",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TraitWithDuplicateProperties",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop2",
-        "location": {
-          "startColumn": 65,
           "endColumn": 71
         }
       },
@@ -8304,26 +7856,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicateDeclarations",
+        "type": "static_property",
+        "value": "DuplicateDeclarations\\Foo::$prop1",
         "location": {
           "startColumn": 26,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop1",
-        "location": {
-          "startColumn": 53,
           "endColumn": 59
         }
       },
@@ -8365,26 +7901,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicateDeclarations",
+        "type": "static_property",
+        "value": "DuplicateDeclarations\\Foo::$prop2",
         "location": {
           "startColumn": 26,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop2",
-        "location": {
-          "startColumn": 53,
           "endColumn": 59
         }
       },
@@ -8426,26 +7946,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicatedPromotedProperty",
+        "type": "static_property",
+        "value": "DuplicatedPromotedProperty\\Foo::$bar",
         "location": {
           "startColumn": 26,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 58,
           "endColumn": 62
         }
       },
@@ -8487,26 +7991,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DuplicatedPromotedProperty",
+        "type": "static_property",
+        "value": "DuplicatedPromotedProperty\\Foo::$foo",
         "location": {
           "startColumn": 26,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 58,
           "endColumn": 62
         }
       },
@@ -16251,18 +15739,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntlDateFormatter",
+        "type": "static_constant",
+        "value": "IntlDateFormatter::GREGORIAN",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "GREGORIAN",
-        "location": {
-          "startColumn": 28,
           "endColumn": 37
         }
       },
@@ -16376,26 +15856,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RecursiveIteratorIterator",
+        "type": "static_constant",
+        "value": "RecursiveIteratorIterator::CHILD_FIRST",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CHILD",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FIRST",
-        "location": {
-          "startColumn": 42,
           "endColumn": 47
         }
       },
@@ -19995,34 +19459,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug9402\\Foo::Two",
         "location": {
           "startColumn": 10,
-          "endColumn": 13
-        }
-      },
-      {
-        "type": "number",
-        "value": "9402",
-        "location": {
-          "startColumn": 13,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Two",
-        "location": {
-          "startColumn": 23,
           "endColumn": 26
         }
       },
@@ -20120,26 +19560,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "EnumSanity",
+        "type": "static_constant",
+        "value": "EnumSanity\\EnumInconsistentCaseType::BAR",
         "location": {
           "startColumn": 10,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "EnumInconsistentCaseType",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 47,
           "endColumn": 50
         }
       },
@@ -20285,26 +19709,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "EnumSanity",
+        "type": "static_constant",
+        "value": "EnumSanity\\EnumInconsistentCaseType::FOO",
         "location": {
           "startColumn": 10,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "EnumInconsistentCaseType",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 47,
           "endColumn": 50
         }
       },
@@ -20402,26 +19810,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "EnumSanity",
+        "type": "static_constant",
+        "value": "EnumSanity\\EnumInconsistentStringCaseType::BAR",
         "location": {
           "startColumn": 10,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "EnumInconsistentStringCaseType",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 53,
           "endColumn": 56
         }
       },
@@ -21539,26 +20931,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\TestGenerics::$c",
         "location": {
           "startColumn": 90,
-          "endColumn": 101
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestGenerics",
-        "location": {
-          "startColumn": 102,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 116,
           "endColumn": 118
         }
       },
@@ -21800,26 +21176,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\TestGenerics::$b",
         "location": {
           "startColumn": 75,
-          "endColumn": 86
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestGenerics",
-        "location": {
-          "startColumn": 87,
-          "endColumn": 99
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 101,
           "endColumn": 103
         }
       },
@@ -32984,26 +32344,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTagTrait",
+        "type": "static_property",
+        "value": "PropertyTagTrait\\Foo::$foo",
         "location": {
           "startColumn": 34,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 56,
           "endColumn": 60
         }
       },
@@ -33101,26 +32445,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Bar::$unresolvable",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unresolvable",
-        "location": {
-          "startColumn": 51,
           "endColumn": 64
         }
       },
@@ -33202,26 +32530,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$a",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -33319,26 +32631,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$b",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -33436,26 +32732,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$c",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -33553,26 +32833,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$c",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -33670,26 +32934,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$d",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -33787,26 +33035,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$e",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$e",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -33904,26 +33136,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$e",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$e",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -34021,26 +33237,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\MissingGenerics::$a",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MissingGenerics",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 63,
           "endColumn": 65
         }
       },
@@ -34210,26 +33410,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\NonexistentClasses::$a",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NonexistentClasses",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 66,
           "endColumn": 68
         }
       },
@@ -34327,26 +33511,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\NonexistentClasses::$b",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NonexistentClasses",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 66,
           "endColumn": 68
         }
       },
@@ -34444,26 +33612,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\TestGenerics::$a",
         "location": {
           "startColumn": 34,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestGenerics",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 60,
           "endColumn": 62
         }
       },
@@ -34633,26 +33785,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$f",
         "location": {
           "startColumn": 39,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$f",
-        "location": {
-          "startColumn": 56,
           "endColumn": 58
         }
       },
@@ -34758,26 +33894,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\Foo::$g",
         "location": {
           "startColumn": 40,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$g",
-        "location": {
-          "startColumn": 57,
           "endColumn": 59
         }
       },
@@ -45606,26 +44726,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTag",
+        "type": "static_property",
+        "value": "PropertyTag\\TestGenerics::$d",
         "location": {
           "startColumn": 101,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestGenerics",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 127,
           "endColumn": 129
         }
       },
@@ -46324,26 +45428,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessPrivateConstantThroughStatic",
+        "type": "static_constant",
+        "value": "AccessPrivateConstantThroughStatic\\Foo::FOO",
         "location": {
           "startColumn": 34,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 69,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 74,
           "endColumn": 77
         }
       },

--- a/test/__snapshots__/2.2.x/Comparison.snap
+++ b/test/__snapshots__/2.2.x/Comparison.snap
@@ -3085,26 +3085,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 33,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 74,
           "endColumn": 75
         }
       },
@@ -3149,26 +3133,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 96,
-          "endColumn": 123
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 135
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 137,
           "endColumn": 138
         }
       },
@@ -3290,26 +3258,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::B",
         "location": {
           "startColumn": 33,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 74,
           "endColumn": 75
         }
       },
@@ -3354,26 +3306,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 96,
-          "endColumn": 123
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 135
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 137,
           "endColumn": 138
         }
       },
@@ -7672,26 +7608,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 43,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 71,
-          "endColumn": 82
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 84,
           "endColumn": 85
         }
       },
@@ -7736,26 +7656,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 103,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 144,
           "endColumn": 145
         }
       },
@@ -7901,26 +7805,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 43,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 71,
-          "endColumn": 82
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 84,
           "endColumn": 85
         }
       },
@@ -7965,26 +7853,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 103,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 144,
           "endColumn": 145
         }
       },
@@ -8130,26 +8002,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::B",
         "location": {
           "startColumn": 43,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 71,
-          "endColumn": 82
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 84,
           "endColumn": 85
         }
       },
@@ -8194,26 +8050,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 103,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 144,
           "endColumn": 145
         }
       },
@@ -8359,26 +8199,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::B",
         "location": {
           "startColumn": 43,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 71,
-          "endColumn": 82
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 84,
           "endColumn": 85
         }
       },
@@ -8423,26 +8247,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LooseComparisonAgainstEnums",
+        "type": "static_constant",
+        "value": "LooseComparisonAgainstEnums\\FooUnitEnum::A",
         "location": {
           "startColumn": 103,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooUnitEnum",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 144,
           "endColumn": 145
         }
       },
@@ -24298,34 +24106,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::A",
         "location": {
           "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 46,
           "endColumn": 47
         }
       },
@@ -24338,34 +24122,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::B",
         "location": {
           "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 60,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 65,
           "endColumn": 66
         }
       },
@@ -24878,34 +24638,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::A",
         "location": {
           "startColumn": 34,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 47,
           "endColumn": 48
         }
       },
@@ -24918,34 +24654,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::B",
         "location": {
           "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 66,
           "endColumn": 67
         }
       },
@@ -25245,34 +24957,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::A",
         "location": {
           "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 46,
           "endColumn": 47
         }
       },
@@ -25285,34 +24973,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::B",
         "location": {
           "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 60,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 65,
           "endColumn": 66
         }
       },
@@ -25519,34 +25183,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::A",
         "location": {
           "startColumn": 34,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 47,
           "endColumn": 48
         }
       },
@@ -25559,34 +25199,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug7052\\Foo::B",
         "location": {
           "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "number",
-        "value": "7052",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 66,
           "endColumn": 67
         }
       },
@@ -30696,26 +30312,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LastMatchArmAlwaysTrue",
+        "type": "static_constant",
+        "value": "LastMatchArmAlwaysTrue\\Bar::ONE",
         "location": {
           "startColumn": 63,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 86,
-          "endColumn": 89
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ONE",
-        "location": {
-          "startColumn": 91,
           "endColumn": 94
         }
       },
@@ -30728,26 +30328,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LastMatchArmAlwaysTrue",
+        "type": "static_constant",
+        "value": "LastMatchArmAlwaysTrue\\Bar::ONE",
         "location": {
           "startColumn": 99,
-          "endColumn": 121
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 122,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ONE",
-        "location": {
-          "startColumn": 127,
           "endColumn": 130
         }
       },
@@ -30869,26 +30453,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LastMatchArmAlwaysTrue",
+        "type": "static_constant",
+        "value": "LastMatchArmAlwaysTrue\\Foo::TWO",
         "location": {
           "startColumn": 63,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 86,
-          "endColumn": 89
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TWO",
-        "location": {
-          "startColumn": 91,
           "endColumn": 94
         }
       },
@@ -30901,26 +30469,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "LastMatchArmAlwaysTrue",
+        "type": "static_constant",
+        "value": "LastMatchArmAlwaysTrue\\Foo::TWO",
         "location": {
           "startColumn": 99,
-          "endColumn": 121
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 122,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TWO",
-        "location": {
-          "startColumn": 127,
           "endColumn": 130
         }
       },
@@ -31042,26 +30594,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchAlwaysTrueLastArm",
+        "type": "static_constant",
+        "value": "MatchAlwaysTrueLastArm\\Foo::BAR",
         "location": {
           "startColumn": 63,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 86,
-          "endColumn": 89
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 91,
           "endColumn": 94
         }
       },
@@ -31074,26 +30610,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchAlwaysTrueLastArm",
+        "type": "static_constant",
+        "value": "MatchAlwaysTrueLastArm\\Foo::BAR",
         "location": {
           "startColumn": 99,
-          "endColumn": 121
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 122,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 127,
           "endColumn": 130
         }
       },
@@ -31978,42 +31498,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug8240\\Foo2::BAZ",
         "location": {
           "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "number",
-        "value": "8240",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 43,
           "endColumn": 46
         }
       },
@@ -32026,42 +31514,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug8240\\Foo2::BAZ",
         "location": {
           "startColumn": 51,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "number",
-        "value": "8240",
-        "location": {
-          "startColumn": 54,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 59,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 65,
           "endColumn": 68
         }
       },
@@ -32135,34 +31591,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug8240\\Foo::BAR",
         "location": {
           "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "number",
-        "value": "8240",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 42,
           "endColumn": 45
         }
       },
@@ -32175,34 +31607,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug8240\\Foo::BAR",
         "location": {
           "startColumn": 50,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "number",
-        "value": "8240",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 63,
           "endColumn": 66
         }
       },
@@ -32300,26 +31708,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::ONE",
         "location": {
           "startColumn": 48,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 59,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ONE",
-        "location": {
-          "startColumn": 64,
           "endColumn": 67
         }
       },
@@ -32393,26 +31785,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::THREE",
         "location": {
           "startColumn": 29,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "THREE",
-        "location": {
-          "startColumn": 45,
           "endColumn": 50
         }
       },
@@ -32425,26 +31801,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::THREE",
         "location": {
           "startColumn": 55,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 66,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "THREE",
-        "location": {
-          "startColumn": 71,
           "endColumn": 76
         }
       },
@@ -32518,26 +31878,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::THREE",
         "location": {
           "startColumn": 29,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "THREE",
-        "location": {
-          "startColumn": 45,
           "endColumn": 50
         }
       },
@@ -32550,26 +31894,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::TWO",
         "location": {
           "startColumn": 51,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TWO",
-        "location": {
-          "startColumn": 67,
           "endColumn": 70
         }
       },
@@ -32582,26 +31910,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\DifferentEnum::ONE",
         "location": {
           "startColumn": 75,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DifferentEnum",
-        "location": {
-          "startColumn": 86,
-          "endColumn": 99
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ONE",
-        "location": {
-          "startColumn": 101,
           "endColumn": 104
         }
       },
@@ -33276,26 +32588,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::THREE",
         "location": {
           "startColumn": 50,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "THREE",
-        "location": {
-          "startColumn": 66,
           "endColumn": 71
         }
       }
@@ -34231,26 +33527,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::THREE",
         "location": {
           "startColumn": 51,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "THREE",
-        "location": {
-          "startColumn": 67,
           "endColumn": 72
         }
       },
@@ -34263,26 +33543,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MatchEnums",
+        "type": "static_constant",
+        "value": "MatchEnums\\Foo::TWO",
         "location": {
           "startColumn": 73,
-          "endColumn": 83
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 84,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TWO",
-        "location": {
-          "startColumn": 89,
           "endColumn": 92
         }
       }
@@ -34486,26 +33750,10 @@
     "input": "MatchEnumPartialArmRegression\\MyEnum::A",
     "tokens": [
       {
-        "type": "common_word",
-        "value": "MatchEnumPartialArmRegression",
+        "type": "static_constant",
+        "value": "MatchEnumPartialArmRegression\\MyEnum::A",
         "location": {
           "startColumn": 0,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyEnum",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 38,
           "endColumn": 39
         }
       }
@@ -38345,34 +37593,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug9142\\MyEnum::Three",
         "location": {
           "startColumn": 62,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "number",
-        "value": "9142",
-        "location": {
-          "startColumn": 65,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyEnum",
-        "location": {
-          "startColumn": 70,
-          "endColumn": 76
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Three",
-        "location": {
-          "startColumn": 78,
           "endColumn": 83
         }
       },
@@ -43396,34 +42620,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug8485\\FooEnum::C",
         "location": {
           "startColumn": 36,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "number",
-        "value": "8485",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 53,
           "endColumn": 54
         }
       },
@@ -43436,34 +42636,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug8485\\FooEnum::C",
         "location": {
           "startColumn": 59,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "number",
-        "value": "8485",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 66
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 67,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 76,
           "endColumn": 77
         }
       },
@@ -43585,34 +42761,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug9142\\MyEnum::Three",
         "location": {
           "startColumn": 55,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "number",
-        "value": "9142",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyEnum",
-        "location": {
-          "startColumn": 63,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Three",
-        "location": {
-          "startColumn": 71,
           "endColumn": 76
         }
       },
@@ -43920,26 +43072,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "StrictComparisonEnumTips",
+        "type": "static_constant",
+        "value": "StrictComparisonEnumTips\\SomeEnum::Two",
         "location": {
           "startColumn": 36,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeEnum",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Two",
-        "location": {
-          "startColumn": 71,
           "endColumn": 74
         }
       },
@@ -43952,26 +43088,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "StrictComparisonEnumTips",
+        "type": "static_constant",
+        "value": "StrictComparisonEnumTips\\SomeEnum::Two",
         "location": {
           "startColumn": 79,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeEnum",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Two",
-        "location": {
-          "startColumn": 114,
           "endColumn": 117
         }
       },

--- a/test/__snapshots__/2.2.x/Constants.snap
+++ b/test/__snapshots__/2.2.x/Constants.snap
@@ -660,34 +660,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug10212\\HelloWorld::B",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "10212",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 30,
           "endColumn": 31
         }
       },
@@ -772,34 +748,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug10212\\Foo::Bar",
         "location": {
           "startColumn": 71,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "number",
-        "value": "10212",
-        "location": {
-          "startColumn": 74,
-          "endColumn": 79
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 80,
-          "endColumn": 83
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 85,
           "endColumn": 88
         }
       },
@@ -825,26 +777,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantNativeTypeForMissingTypehintRule",
+        "type": "static_constant",
+        "value": "ClassConstantNativeTypeForMissingTypehintRule\\Foo::B",
         "location": {
           "startColumn": 9,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 60,
           "endColumn": 61
         }
       },
@@ -950,26 +886,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantNativeTypeForMissingTypehintRule",
+        "type": "static_constant",
+        "value": "ClassConstantNativeTypeForMissingTypehintRule\\Foo::D",
         "location": {
           "startColumn": 9,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "D",
-        "location": {
-          "startColumn": 60,
           "endColumn": 61
         }
       },
@@ -1144,26 +1064,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingClassConstantTypehint",
+        "type": "static_constant",
+        "value": "MissingClassConstantTypehint\\Foo::BAR",
         "location": {
           "startColumn": 9,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 43,
           "endColumn": 46
         }
       },
@@ -1269,26 +1173,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingClassConstantTypehint",
+        "type": "static_constant",
+        "value": "MissingClassConstantTypehint\\Foo::BAZ",
         "location": {
           "startColumn": 9,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 43,
           "endColumn": 46
         }
       },
@@ -1402,26 +1290,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingClassConstantTypehint",
+        "type": "static_constant",
+        "value": "MissingClassConstantTypehint\\Foo::LOREM",
         "location": {
           "startColumn": 9,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "LOREM",
-        "location": {
-          "startColumn": 43,
           "endColumn": 48
         }
       },
@@ -1556,26 +1428,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstantNativeTypes",
+        "type": "static_constant",
+        "value": "OverridingConstantNativeTypes\\Ipsum::B",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 46,
           "endColumn": 47
         }
       },
@@ -1596,26 +1452,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstantNativeTypes",
+        "type": "static_constant",
+        "value": "OverridingConstantNativeTypes\\Lorem::B",
         "location": {
           "startColumn": 68,
-          "endColumn": 97
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Lorem",
-        "location": {
-          "startColumn": 98,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 105,
           "endColumn": 106
         }
       },
@@ -1713,34 +1553,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstantNativeTypes",
+        "type": "static_constant",
+        "value": "OverridingConstantNativeTypes\\PharChild::BZ2",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PharChild",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BZ",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 52,
           "endColumn": 53
         }
       },
@@ -1761,26 +1577,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Phar",
+        "type": "static_constant",
+        "value": "Phar::BZ2",
         "location": {
           "startColumn": 74,
-          "endColumn": 78
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BZ",
-        "location": {
-          "startColumn": 80,
-          "endColumn": 82
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 82,
           "endColumn": 83
         }
       },
@@ -1878,26 +1678,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Bar::BAR",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 38,
           "endColumn": 41
         }
       },
@@ -1926,26 +1710,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Foo::BAR",
         "location": {
           "startColumn": 67,
-          "endColumn": 90
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 91,
-          "endColumn": 94
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 96,
           "endColumn": 99
         }
       },
@@ -1971,26 +1739,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Bar::FOO",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 38,
           "endColumn": 41
         }
       },
@@ -2019,26 +1771,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Foo::FOO",
         "location": {
           "startColumn": 67,
-          "endColumn": 90
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 91,
-          "endColumn": 94
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 96,
           "endColumn": 99
         }
       },
@@ -2064,26 +1800,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Baz::BAR",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 38,
           "endColumn": 41
         }
       },
@@ -2112,26 +1832,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\FooInterface::BAR",
         "location": {
           "startColumn": 67,
-          "endColumn": 90
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooInterface",
-        "location": {
-          "startColumn": 91,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 105,
           "endColumn": 108
         }
       },
@@ -2255,26 +1959,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstantNativeType",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstantNativeType\\Bar::BAR",
         "location": {
           "startColumn": 9,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 53,
           "endColumn": 56
         }
       },
@@ -2404,26 +2092,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstantNativeType",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstantNativeType\\Floats::BAR",
         "location": {
           "startColumn": 9,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Floats",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 56,
           "endColumn": 59
         }
       },
@@ -2513,26 +2185,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstantNativeType",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstantNativeType\\Foo::BAR",
         "location": {
           "startColumn": 9,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 53,
           "endColumn": 56
         }
       },
@@ -3493,26 +3149,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstantNativeTypes",
+        "type": "static_constant",
+        "value": "OverridingConstantNativeTypes\\Bar::D",
         "location": {
           "startColumn": 35,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 65,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "D",
-        "location": {
-          "startColumn": 70,
           "endColumn": 71
         }
       },
@@ -3589,26 +3229,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstantNativeTypes",
+        "type": "static_constant",
+        "value": "OverridingConstantNativeTypes\\Foo::D",
         "location": {
           "startColumn": 122,
-          "endColumn": 151
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 152,
-          "endColumn": 155
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "D",
-        "location": {
-          "startColumn": 157,
           "endColumn": 158
         }
       },
@@ -3682,26 +3306,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstantNativeTypes",
+        "type": "static_constant",
+        "value": "OverridingConstantNativeTypes\\PharChild::NONE",
         "location": {
           "startColumn": 35,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PharChild",
-        "location": {
-          "startColumn": 65,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NONE",
-        "location": {
-          "startColumn": 76,
           "endColumn": 80
         }
       },
@@ -3778,18 +3386,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Phar",
+        "type": "static_constant",
+        "value": "Phar::NONE",
         "location": {
           "startColumn": 131,
-          "endColumn": 135
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NONE",
-        "location": {
-          "startColumn": 137,
           "endColumn": 141
         }
       },
@@ -3847,26 +3447,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstantNativeType",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstantNativeType\\Floats::BAZ",
         "location": {
           "startColumn": 29,
-          "endColumn": 67
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Floats",
-        "location": {
-          "startColumn": 68,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 76,
           "endColumn": 79
         }
       },
@@ -3988,26 +3572,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstant",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstant\\Bar::BAZ",
         "location": {
           "startColumn": 29,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 63,
           "endColumn": 66
         }
       },
@@ -4129,26 +3697,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstant",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstant\\Foo::BAZ",
         "location": {
           "startColumn": 29,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 63,
           "endColumn": 66
         }
       },
@@ -4270,26 +3822,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ValueAssignedToClassConstant",
+        "type": "static_constant",
+        "value": "ValueAssignedToClassConstant\\Foo::DOLOR",
         "location": {
           "startColumn": 29,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DOLOR",
-        "location": {
-          "startColumn": 63,
           "endColumn": 68
         }
       },
@@ -4544,42 +4080,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\PrivateDolor::ANOTHER_PUBLIC_CONST",
         "location": {
           "startColumn": 17,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateDolor",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ANOTHER",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 63,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 70,
           "endColumn": 75
         }
       },
@@ -4608,42 +4112,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Dolor::ANOTHER_PUBLIC_CONST",
         "location": {
           "startColumn": 103,
-          "endColumn": 126
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 127,
-          "endColumn": 132
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ANOTHER",
-        "location": {
-          "startColumn": 134,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 142,
-          "endColumn": 148
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 149,
           "endColumn": 154
         }
       },
@@ -4709,34 +4181,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\PrivateDolor::PROTECTED_CONST",
         "location": {
           "startColumn": 17,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateDolor",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PROTECTED",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 65,
           "endColumn": 70
         }
       },
@@ -4765,34 +4213,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Dolor::PROTECTED_CONST",
         "location": {
           "startColumn": 101,
-          "endColumn": 124
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 125,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PROTECTED",
-        "location": {
-          "startColumn": 132,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 142,
           "endColumn": 147
         }
       },
@@ -4866,34 +4290,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\PrivateDolor::PUBLIC_CONST",
         "location": {
           "startColumn": 17,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateDolor",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 62,
           "endColumn": 67
         }
       },
@@ -4922,34 +4322,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Dolor::PUBLIC_CONST",
         "location": {
           "startColumn": 95,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 119,
-          "endColumn": 124
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 126,
-          "endColumn": 132
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 133,
           "endColumn": 138
         }
       },
@@ -5015,42 +4391,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\ProtectedDolor::ANOTHER_PUBLIC_CONST",
         "location": {
           "startColumn": 19,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ProtectedDolor",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ANOTHER",
-        "location": {
-          "startColumn": 59,
-          "endColumn": 66
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 67,
-          "endColumn": 73
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 74,
           "endColumn": 79
         }
       },
@@ -5079,42 +4423,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Dolor::ANOTHER_PUBLIC_CONST",
         "location": {
           "startColumn": 107,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ANOTHER",
-        "location": {
-          "startColumn": 138,
-          "endColumn": 145
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 146,
-          "endColumn": 152
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 153,
           "endColumn": 158
         }
       },
@@ -5180,34 +4492,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\ProtectedDolor::PUBLIC_CONST",
         "location": {
           "startColumn": 19,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ProtectedDolor",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 59,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 66,
           "endColumn": 71
         }
       },
@@ -5236,34 +4524,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Dolor::PUBLIC_CONST",
         "location": {
           "startColumn": 99,
-          "endColumn": 122
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 123,
-          "endColumn": 128
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 130,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 137,
           "endColumn": 142
         }
       },
@@ -5361,26 +4625,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstant",
+        "type": "static_constant",
+        "value": "OverridingConstant\\Bar::IPSUM",
         "location": {
           "startColumn": 28,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "IPSUM",
-        "location": {
-          "startColumn": 52,
           "endColumn": 57
         }
       },
@@ -5449,26 +4697,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstant",
+        "type": "static_constant",
+        "value": "OverridingConstant\\Foo::IPSUM",
         "location": {
           "startColumn": 101,
-          "endColumn": 119
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 120,
-          "endColumn": 123
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "IPSUM",
-        "location": {
-          "startColumn": 125,
           "endColumn": 130
         }
       },
@@ -5518,26 +4750,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstant",
+        "type": "static_constant",
+        "value": "OverridingConstant\\Bar::BAR",
         "location": {
           "startColumn": 24,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 48,
           "endColumn": 51
         }
       },
@@ -5606,26 +4822,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingConstant",
+        "type": "static_constant",
+        "value": "OverridingConstant\\Foo::BAR",
         "location": {
           "startColumn": 95,
-          "endColumn": 113
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 114,
-          "endColumn": 117
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 119,
           "endColumn": 122
         }
       },
@@ -5675,26 +4875,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\Lorem::FOO",
         "location": {
           "startColumn": 24,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Lorem",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 55,
           "endColumn": 58
         }
       },
@@ -5763,26 +4947,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingFinalConstant",
+        "type": "static_constant",
+        "value": "OverridingFinalConstant\\BarInterface::FOO",
         "location": {
           "startColumn": 102,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BarInterface",
-        "location": {
-          "startColumn": 126,
-          "endColumn": 138
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 140,
           "endColumn": 143
         }
       },

--- a/test/__snapshots__/2.2.x/DeadCode.snap
+++ b/test/__snapshots__/2.2.x/DeadCode.snap
@@ -1361,26 +1361,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateConstantDynamicFetch",
+        "type": "static_constant",
+        "value": "UnusedPrivateConstantDynamicFetch\\Baz::FOO",
         "location": {
           "startColumn": 9,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 48,
           "endColumn": 51
         }
       },
@@ -1422,34 +1406,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateConstantEnum",
+        "type": "static_constant",
+        "value": "UnusedPrivateConstantEnum\\Foo::TEST_2",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TEST",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 45,
           "endColumn": 46
         }
       },
@@ -1491,34 +1451,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateConstant",
+        "type": "static_constant",
+        "value": "UnusedPrivateConstant\\Foo::BAR_CONST",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 40,
           "endColumn": 45
         }
       },
@@ -1560,26 +1496,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateConstant",
+        "type": "static_constant",
+        "value": "UnusedPrivateConstant\\TestExtension::UNUSED",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestExtension",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "UNUSED",
-        "location": {
-          "startColumn": 46,
           "endColumn": 52
         }
       },
@@ -3721,34 +3641,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11802\\HelloWorld::$isFinal",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "11802",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$isFinal",
-        "location": {
-          "startColumn": 30,
           "endColumn": 38
         }
       },
@@ -3822,34 +3718,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3636\\Bar::$date",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3636",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$date",
-        "location": {
-          "startColumn": 22,
           "endColumn": 27
         }
       },
@@ -3923,26 +3795,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PrivatePropertyWithTags",
+        "type": "static_property",
+        "value": "PrivatePropertyWithTags\\Foo::$text",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$text",
-        "location": {
-          "startColumn": 38,
           "endColumn": 43
         }
       },
@@ -4016,26 +3872,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PrivatePropertyWithTags",
+        "type": "static_property",
+        "value": "PrivatePropertyWithTags\\Foo::$title",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$title",
-        "location": {
-          "startColumn": 38,
           "endColumn": 44
         }
       },
@@ -4109,26 +3949,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivatePromotedProperty",
+        "type": "static_property",
+        "value": "UnusedPrivatePromotedProperty\\Foo::$lorem",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem",
-        "location": {
-          "startColumn": 44,
           "endColumn": 50
         }
       },
@@ -4202,26 +4026,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\ArrayAssign::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ArrayAssign",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 44,
           "endColumn": 48
         }
       },
@@ -4295,26 +4103,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Bar::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -4388,26 +4180,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\DolorWithAnonymous::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DolorWithAnonymous",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 51,
           "endColumn": 55
         }
       },
@@ -4449,26 +4225,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -4542,26 +4302,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Foo::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -4603,26 +4347,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Foo::$lorem",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem",
-        "location": {
-          "startColumn": 36,
           "endColumn": 42
         }
       },
@@ -4696,26 +4424,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\ListAssign::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ListAssign",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 43,
           "endColumn": 47
         }
       },
@@ -4789,26 +4501,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Lorem::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Lorem",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 38,
           "endColumn": 42
         }
       },
@@ -4882,26 +4578,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\TestExtension::$read",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestExtension",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$read",
-        "location": {
-          "startColumn": 46,
           "endColumn": 51
         }
       },
@@ -4975,26 +4655,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\TestExtension::$unused",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestExtension",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unused",
-        "location": {
-          "startColumn": 46,
           "endColumn": 53
         }
       },
@@ -5036,26 +4700,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\TestExtension::$written",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestExtension",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$written",
-        "location": {
-          "startColumn": 46,
           "endColumn": 54
         }
       },
@@ -5291,26 +4939,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Baz::$bar",
         "location": {
           "startColumn": 16,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 43,
           "endColumn": 47
         }
       },
@@ -5392,26 +5024,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Baz::$baz",
         "location": {
           "startColumn": 16,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 43,
           "endColumn": 47
         }
       },
@@ -5461,26 +5077,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnusedPrivateProperty",
+        "type": "static_property",
+        "value": "UnusedPrivateProperty\\Baz::$lorem",
         "location": {
           "startColumn": 16,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem",
-        "location": {
-          "startColumn": 43,
           "endColumn": 49
         }
       },

--- a/test/__snapshots__/2.2.x/Functions.snap
+++ b/test/__snapshots__/2.2.x/Functions.snap
@@ -35749,34 +35749,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12676\\A::$a",
         "location": {
           "startColumn": 84,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "number",
-        "value": "12676",
-        "location": {
-          "startColumn": 87,
-          "endColumn": 92
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 93,
-          "endColumn": 94
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 96,
           "endColumn": 98
         }
       },
@@ -35906,34 +35882,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12676\\B::$readonlyArr",
         "location": {
           "startColumn": 84,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "number",
-        "value": "12676",
-        "location": {
-          "startColumn": 87,
-          "endColumn": 92
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 93,
-          "endColumn": 94
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readonlyArr",
-        "location": {
-          "startColumn": 96,
           "endColumn": 108
         }
       },
@@ -36071,34 +36023,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12676\\C::$readonlyArr",
         "location": {
           "startColumn": 91,
-          "endColumn": 94
-        }
-      },
-      {
-        "type": "number",
-        "value": "12676",
-        "location": {
-          "startColumn": 94,
-          "endColumn": 99
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 100,
-          "endColumn": 101
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readonlyArr",
-        "location": {
-          "startColumn": 103,
           "endColumn": 115
         }
       },
@@ -36747,26 +36675,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 109,
-          "endColumn": 143
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 144,
-          "endColumn": 151
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 153,
           "endColumn": 154
         }
       },
@@ -37181,34 +37093,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11141\\Language::DAN",
         "location": {
           "startColumn": 101,
-          "endColumn": 104
-        }
-      },
-      {
-        "type": "number",
-        "value": "11141",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Language",
-        "location": {
-          "startColumn": 110,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DAN",
-        "location": {
-          "startColumn": 120,
           "endColumn": 123
         }
       },
@@ -37221,34 +37109,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11141\\Language::ENG",
         "location": {
           "startColumn": 124,
-          "endColumn": 127
-        }
-      },
-      {
-        "type": "number",
-        "value": "11141",
-        "location": {
-          "startColumn": 127,
-          "endColumn": 132
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Language",
-        "location": {
-          "startColumn": 133,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ENG",
-        "location": {
-          "startColumn": 143,
           "endColumn": 146
         }
       },
@@ -37261,34 +37125,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11141\\Language::GER",
         "location": {
           "startColumn": 147,
-          "endColumn": 150
-        }
-      },
-      {
-        "type": "number",
-        "value": "11141",
-        "location": {
-          "startColumn": 150,
-          "endColumn": 155
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Language",
-        "location": {
-          "startColumn": 156,
-          "endColumn": 164
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "GER",
-        "location": {
-          "startColumn": 166,
           "endColumn": 169
         }
       },
@@ -37663,26 +37503,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 106,
-          "endColumn": 140
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 141,
-          "endColumn": 148
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 150,
           "endColumn": 151
         }
       },
@@ -38246,34 +38070,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11883\\SomeEnum::A",
         "location": {
           "startColumn": 104,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "number",
-        "value": "11883",
-        "location": {
-          "startColumn": 107,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeEnum",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 121
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 123,
           "endColumn": 124
         }
       },
@@ -38286,34 +38086,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11883\\SomeEnum::B",
         "location": {
           "startColumn": 125,
-          "endColumn": 128
-        }
-      },
-      {
-        "type": "number",
-        "value": "11883",
-        "location": {
-          "startColumn": 128,
-          "endColumn": 133
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeEnum",
-        "location": {
-          "startColumn": 134,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 144,
           "endColumn": 145
         }
       },
@@ -38893,26 +38669,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToNumberFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToNumberFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 104,
-          "endColumn": 138
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 139,
-          "endColumn": 146
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 148,
           "endColumn": 149
         }
       },
@@ -41052,34 +40812,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11883\\SomeEnum::A",
         "location": {
           "startColumn": 100,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "number",
-        "value": "11883",
-        "location": {
-          "startColumn": 103,
-          "endColumn": 108
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeEnum",
-        "location": {
-          "startColumn": 109,
-          "endColumn": 117
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 119,
           "endColumn": 120
         }
       },
@@ -41092,34 +40828,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11883\\SomeEnum::B",
         "location": {
           "startColumn": 121,
-          "endColumn": 124
-        }
-      },
-      {
-        "type": "number",
-        "value": "11883",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 129
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeEnum",
-        "location": {
-          "startColumn": 130,
-          "endColumn": 138
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 140,
           "endColumn": 141
         }
       },
@@ -41699,26 +41411,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToNumberFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToNumberFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 100,
-          "endColumn": 134
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 135,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 144,
           "endColumn": 145
         }
       },
@@ -43858,26 +43554,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "SortParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "SortParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 103,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 142,
-          "endColumn": 149
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 151,
           "endColumn": 152
         }
       },
@@ -45285,26 +44965,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "SortParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "SortParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 90,
-          "endColumn": 128
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 129,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 138,
           "endColumn": 139
         }
       },
@@ -46334,26 +45998,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 102,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 137,
-          "endColumn": 144
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 146,
           "endColumn": 147
         }
       },
@@ -46768,26 +46416,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 98,
-          "endColumn": 132
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 133,
-          "endColumn": 140
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 142,
           "endColumn": 143
         }
       },
@@ -47303,26 +46935,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "SortParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "SortParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 90,
-          "endColumn": 128
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 129,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 138,
           "endColumn": 139
         }
       },
@@ -47950,26 +47566,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "SortParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "SortParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 95,
-          "endColumn": 133
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 134,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 143,
           "endColumn": 144
         }
       },
@@ -54039,26 +53639,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 103,
-          "endColumn": 137
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 138,
-          "endColumn": 145
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 147,
           "endColumn": 148
         }
       },
@@ -54662,34 +54246,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11111\\Language::DUT",
         "location": {
           "startColumn": 105,
-          "endColumn": 108
-        }
-      },
-      {
-        "type": "number",
-        "value": "11111",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 113
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Language",
-        "location": {
-          "startColumn": 114,
-          "endColumn": 122
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DUT",
-        "location": {
-          "startColumn": 124,
           "endColumn": 127
         }
       },
@@ -54702,34 +54262,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11111\\Language::ITA",
         "location": {
           "startColumn": 128,
-          "endColumn": 131
-        }
-      },
-      {
-        "type": "number",
-        "value": "11111",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Language",
-        "location": {
-          "startColumn": 137,
-          "endColumn": 145
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ITA",
-        "location": {
-          "startColumn": 147,
           "endColumn": 150
         }
       },
@@ -54915,26 +54451,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 105,
-          "endColumn": 139
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 140,
-          "endColumn": 147
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 149,
           "endColumn": 150
         }
       },
@@ -65171,26 +64691,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ImplodeParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ImplodeParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 74,
-          "endColumn": 115
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 116,
-          "endColumn": 123
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 125,
           "endColumn": 126
         }
       },
@@ -66438,34 +65942,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_constant",
+        "value": "Bug11141\\Language::DAN",
         "location": {
           "startColumn": 102,
-          "endColumn": 105
-        }
-      },
-      {
-        "type": "number",
-        "value": "11141",
-        "location": {
-          "startColumn": 105,
-          "endColumn": 110
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Language",
-        "location": {
-          "startColumn": 111,
-          "endColumn": 119
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DAN",
-        "location": {
-          "startColumn": 121,
           "endColumn": 124
         }
       },
@@ -66651,26 +66131,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 102,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 137,
-          "endColumn": 144
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 146,
           "endColumn": 147
         }
       },
@@ -67242,26 +66706,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 108,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 143,
-          "endColumn": 150
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 152,
           "endColumn": 153
         }
       },
@@ -67644,26 +67092,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 107,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 142,
-          "endColumn": 149
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 151,
           "endColumn": 152
         }
       },
@@ -76911,26 +76343,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CurlSetOptArray",
+        "type": "static_constant",
+        "value": "CurlSetOptArray\\BackedRequestMethod::POST",
         "location": {
           "startColumn": 212,
-          "endColumn": 227
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BackedRequestMethod",
-        "location": {
-          "startColumn": 228,
-          "endColumn": 247
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "POST",
-        "location": {
-          "startColumn": 249,
           "endColumn": 253
         }
       },
@@ -77460,26 +76876,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CurlSetOptArray",
+        "type": "static_constant",
+        "value": "CurlSetOptArray\\RequestMethod::POST",
         "location": {
           "startColumn": 212,
-          "endColumn": 227
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "RequestMethod",
-        "location": {
-          "startColumn": 228,
-          "endColumn": 241
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "POST",
-        "location": {
-          "startColumn": 243,
           "endColumn": 247
         }
       },
@@ -95515,26 +94915,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParamCastableToStringFunctionsEnum",
+        "type": "static_constant",
+        "value": "ParamCastableToStringFunctionsEnum\\FooEnum::A",
         "location": {
           "startColumn": 99,
-          "endColumn": 133
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooEnum",
-        "location": {
-          "startColumn": 134,
-          "endColumn": 141
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 143,
           "endColumn": 144
         }
       },

--- a/test/__snapshots__/2.2.x/Generics.snap
+++ b/test/__snapshots__/2.2.x/Generics.snap
@@ -24928,34 +24928,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\ReadOnly\\C::$a",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadOnly",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -25093,34 +25069,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\ReadOnly\\C::$c",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadOnly",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -25258,34 +25210,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\ReadOnly\\D::$a",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadOnly",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "D",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -27238,26 +27166,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\C::$a",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 111,
           "endColumn": 113
         }
       },
@@ -27395,26 +27307,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\C::$b",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 111,
           "endColumn": 113
         }
       },
@@ -27552,26 +27448,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\C::$c",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 111,
           "endColumn": 113
         }
       },
@@ -27709,26 +27589,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\C::$d",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 111,
           "endColumn": 113
         }
       },
@@ -27866,34 +27730,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\C::$a",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -28031,34 +27871,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\C::$b",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -28196,34 +28012,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\C::$c",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -28361,34 +28153,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\C::$d",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -28526,34 +28294,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\ReadOnly\\C::$d",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadOnly",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -30506,34 +30250,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\ReadOnly\\B::$b",
         "location": {
           "startColumn": 91,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadOnly",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 120,
           "endColumn": 122
         }
       },
@@ -32156,26 +31876,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\B::$a",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 105
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 107,
           "endColumn": 109
         }
       },
@@ -32313,26 +32017,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\B::$b",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 105
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 107,
           "endColumn": 109
         }
       },
@@ -32470,26 +32158,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\B::$c",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 105
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 107,
           "endColumn": 109
         }
       },
@@ -32627,26 +32299,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\B::$d",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 105
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 107,
           "endColumn": 109
         }
       },
@@ -32784,34 +32440,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\B::$a",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 116,
           "endColumn": 118
         }
       },
@@ -32949,34 +32581,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\B::$b",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 116,
           "endColumn": 118
         }
       },
@@ -33114,34 +32722,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\B::$c",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 116,
           "endColumn": 118
         }
       },
@@ -33279,34 +32863,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\Promoted\\B::$d",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Promoted",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 116,
           "endColumn": 118
         }
       },
@@ -33444,34 +33004,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyVariance",
+        "type": "static_property",
+        "value": "PropertyVariance\\ReadOnly\\B::$d",
         "location": {
           "startColumn": 87,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadOnly",
-        "location": {
-          "startColumn": 104,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 116,
           "endColumn": 118
         }
       },

--- a/test/__snapshots__/2.2.x/InternalTag.snap
+++ b/test/__snapshots__/2.2.x/InternalTag.snap
@@ -551,26 +551,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassConstantInternalTagOne",
+        "type": "static_constant",
+        "value": "ClassConstantInternalTagOne\\Foo::INTERNAL",
         "location": {
           "startColumn": 28,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 56,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "INTERNAL",
-        "location": {
-          "startColumn": 61,
           "endColumn": 69
         }
       },
@@ -668,26 +652,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassInternal",
+        "type": "static_constant",
+        "value": "ClassInternal::INTERNAL_CONSTANT",
         "location": {
           "startColumn": 28,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "INTERNAL",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 52,
           "endColumn": 60
         }
       },
@@ -737,18 +705,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooWithInternalClassConstantWithoutNamespace",
+        "type": "static_constant",
+        "value": "FooWithInternalClassConstantWithoutNamespace::INTERNAL",
         "location": {
           "startColumn": 28,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "INTERNAL",
-        "location": {
-          "startColumn": 74,
           "endColumn": 82
         }
       },
@@ -798,18 +758,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooWithInternalPropertyWithoutNamespace",
+        "type": "static_property",
+        "value": "FooWithInternalPropertyWithoutNamespace::$internal",
         "location": {
           "startColumn": 28,
-          "endColumn": 67
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$internal",
-        "location": {
-          "startColumn": 69,
           "endColumn": 78
         }
       },
@@ -859,26 +811,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyInternalTagOne",
+        "type": "static_property",
+        "value": "PropertyInternalTagOne\\Foo::$internal",
         "location": {
           "startColumn": 28,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$internal",
-        "location": {
-          "startColumn": 56,
           "endColumn": 65
         }
       },
@@ -984,18 +920,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooWithInternalStaticPropertyWithoutNamespace",
+        "type": "static_property",
+        "value": "FooWithInternalStaticPropertyWithoutNamespace::$internal",
         "location": {
           "startColumn": 35,
-          "endColumn": 80
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$internal",
-        "location": {
-          "startColumn": 82,
           "endColumn": 91
         }
       },
@@ -1053,26 +981,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "StaticPropertyInternalTagOne",
+        "type": "static_property",
+        "value": "StaticPropertyInternalTagOne\\Foo::$internal",
         "location": {
           "startColumn": 35,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 64,
-          "endColumn": 67
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$internal",
-        "location": {
-          "startColumn": 69,
           "endColumn": 78
         }
       },

--- a/test/__snapshots__/2.2.x/Methods.snap
+++ b/test/__snapshots__/2.2.x/Methods.snap
@@ -14601,26 +14601,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Collator",
+        "type": "static_constant",
+        "value": "Collator::FRENCH_COLLATION",
         "location": {
           "startColumn": 9,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FRENCH",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "COLLATION",
-        "location": {
-          "startColumn": 26,
           "endColumn": 35
         }
       },
@@ -14726,18 +14710,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntlDateFormatter",
+        "type": "static_constant",
+        "value": "IntlDateFormatter::GREGORIAN",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "GREGORIAN",
-        "location": {
-          "startColumn": 28,
           "endColumn": 37
         }
       },
@@ -14851,34 +14827,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "NumberFormatter",
+        "type": "static_constant",
+        "value": "NumberFormatter::TYPE_INT32",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TYPE",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "INT",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "number",
-        "value": "32",
-        "location": {
-          "startColumn": 34,
           "endColumn": 36
         }
       },
@@ -14992,26 +14944,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PDO",
+        "type": "static_constant",
+        "value": "PDO::ATTR_ERRMODE",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ATTR",
-        "location": {
-          "startColumn": 14,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ERRMODE",
-        "location": {
-          "startColumn": 19,
           "endColumn": 26
         }
       },
@@ -72438,26 +72374,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CallMethodInEnum",
+        "type": "static_constant",
+        "value": "CallMethodInEnum\\CountryNo::NL",
         "location": {
           "startColumn": 113,
-          "endColumn": 129
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CountryNo",
-        "location": {
-          "startColumn": 130,
-          "endColumn": 139
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NL",
-        "location": {
-          "startColumn": 141,
           "endColumn": 143
         }
       },
@@ -88676,26 +88596,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CallMethodInEnum",
+        "type": "static_constant",
+        "value": "CallMethodInEnum\\TestPassingEnums::ONE",
         "location": {
           "startColumn": 84,
-          "endColumn": 100
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TestPassingEnums",
-        "location": {
-          "startColumn": 101,
-          "endColumn": 117
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ONE",
-        "location": {
-          "startColumn": 119,
           "endColumn": 122
         }
       },
@@ -89163,26 +89067,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyPassedByRef",
+        "type": "static_property",
+        "value": "ReadonlyPropertyPassedByRef\\Foo::$bar",
         "location": {
           "startColumn": 83,
-          "endColumn": 110
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 111,
-          "endColumn": 114
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 116,
           "endColumn": 120
         }
       },
@@ -106472,26 +106360,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyPassedByRef",
+        "type": "static_property",
+        "value": "ReadonlyPropertyPassedByRef\\Foo::$bar",
         "location": {
           "startColumn": 80,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 111
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 113,
           "endColumn": 117
         }
       },

--- a/test/__snapshots__/2.2.x/PhpDoc.snap
+++ b/test/__snapshots__/2.2.x/PhpDoc.snap
@@ -1722,26 +1722,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$genericIncompatibleTypeProjection",
         "location": {
           "startColumn": 152,
-          "endColumn": 165
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 166,
-          "endColumn": 181
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$genericIncompatibleTypeProjection",
-        "location": {
-          "startColumn": 183,
           "endColumn": 217
         }
       },
@@ -2886,26 +2870,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$genericRedundantTypeProjection",
         "location": {
           "startColumn": 144,
-          "endColumn": 157
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 158,
-          "endColumn": 173
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$genericRedundantTypeProjection",
-        "location": {
-          "startColumn": 175,
           "endColumn": 206
         }
       },
@@ -5616,26 +5584,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$tooManyTypesGenericfoo",
         "location": {
           "startColumn": 120,
-          "endColumn": 133
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 134,
-          "endColumn": 149
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$tooManyTypesGenericfoo",
-        "location": {
-          "startColumn": 151,
           "endColumn": 174
         }
       },
@@ -6178,26 +6130,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$tooManyTypesGenericfoo",
         "location": {
           "startColumn": 116,
-          "endColumn": 147
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 148,
-          "endColumn": 163
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$tooManyTypesGenericfoo",
-        "location": {
-          "startColumn": 165,
           "endColumn": 188
         }
       },
@@ -6873,26 +6809,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$notEnoughTypesGenericfoo",
         "location": {
           "startColumn": 86,
-          "endColumn": 99
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 100,
-          "endColumn": 115
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$notEnoughTypesGenericfoo",
-        "location": {
-          "startColumn": 117,
           "endColumn": 142
         }
       },
@@ -7339,26 +7259,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$notEnoughTypesGenericfoo",
         "location": {
           "startColumn": 82,
-          "endColumn": 113
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 114,
-          "endColumn": 129
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$notEnoughTypesGenericfoo",
-        "location": {
-          "startColumn": 131,
           "endColumn": 156
         }
       },
@@ -27699,26 +27603,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatibleClassConstantPhpDocNativeType",
+        "type": "static_constant",
+        "value": "IncompatibleClassConstantPhpDocNativeType\\Foo::BAZ",
         "location": {
           "startColumn": 29,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 71,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAZ",
-        "location": {
-          "startColumn": 76,
           "endColumn": 79
         }
       },
@@ -27848,26 +27736,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatibleClassConstantPhpDocNativeType",
+        "type": "static_constant",
+        "value": "IncompatibleClassConstantPhpDocNativeType\\Foo::LOREM",
         "location": {
           "startColumn": 29,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 71,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "LOREM",
-        "location": {
-          "startColumn": 76,
           "endColumn": 81
         }
       },
@@ -28021,26 +27893,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatibleClassConstantPhpDoc",
+        "type": "static_constant",
+        "value": "IncompatibleClassConstantPhpDoc\\Foo::DOLOR",
         "location": {
           "startColumn": 29,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DOLOR",
-        "location": {
-          "startColumn": 66,
           "endColumn": 71
         }
       },
@@ -28218,26 +28074,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatibleClassConstantPhpDoc",
+        "type": "static_constant",
+        "value": "IncompatibleClassConstantPhpDoc\\Foo::FOO",
         "location": {
           "startColumn": 29,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 61,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 66,
           "endColumn": 69
         }
       },
@@ -28319,26 +28159,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatiblePhpDocPropertyNativeType",
+        "type": "static_property",
+        "value": "IncompatiblePhpDocPropertyNativeType\\Foo::$foo",
         "location": {
           "startColumn": 29,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 66,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 71,
           "endColumn": 75
         }
       },
@@ -28484,26 +28308,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatiblePhpDocPropertyNativeType",
+        "type": "static_property",
+        "value": "IncompatiblePhpDocPropertyNativeType\\Foo::$selfTwo",
         "location": {
           "startColumn": 29,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 66,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$selfTwo",
-        "location": {
-          "startColumn": 71,
           "endColumn": 79
         }
       },
@@ -28649,26 +28457,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatiblePhpDocPropertyNativeType",
+        "type": "static_property",
+        "value": "IncompatiblePhpDocPropertyNativeType\\Foo::$stringOrInt",
         "location": {
           "startColumn": 29,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 66,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$stringOrInt",
-        "location": {
-          "startColumn": 71,
           "endColumn": 83
         }
       },
@@ -28822,26 +28614,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IncompatiblePhpDocPropertyNativeType",
+        "type": "static_property",
+        "value": "IncompatiblePhpDocPropertyNativeType\\Lorem::$string",
         "location": {
           "startColumn": 29,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Lorem",
-        "location": {
-          "startColumn": 66,
-          "endColumn": 71
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 73,
           "endColumn": 80
         }
       },
@@ -28979,26 +28755,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$bar",
         "location": {
           "startColumn": 29,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 60,
           "endColumn": 64
         }
       },
@@ -29080,26 +28840,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$classStringInt",
         "location": {
           "startColumn": 29,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$classStringInt",
-        "location": {
-          "startColumn": 60,
           "endColumn": 75
         }
       },
@@ -29181,26 +28925,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$fooGeneric",
         "location": {
           "startColumn": 29,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$fooGeneric",
-        "location": {
-          "startColumn": 60,
           "endColumn": 71
         }
       },
@@ -29378,26 +29106,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$unknownClassConstant",
         "location": {
           "startColumn": 29,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unknownClassConstant",
-        "location": {
-          "startColumn": 60,
           "endColumn": 81
         }
       },
@@ -29479,26 +29191,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$unknownClassConstant2",
         "location": {
           "startColumn": 29,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unknownClassConstant2",
-        "location": {
-          "startColumn": 60,
           "endColumn": 82
         }
       },
@@ -40324,26 +40020,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\BazWithProperty::$bar",
         "location": {
           "startColumn": 25,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BazWithProperty",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 74,
           "endColumn": 78
         }
       },
@@ -40465,26 +40145,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$bar",
         "location": {
           "startColumn": 25,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 74,
           "endColumn": 78
         }
       },
@@ -40558,26 +40222,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$classStringInt",
         "location": {
           "startColumn": 25,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$classStringInt",
-        "location": {
-          "startColumn": 74,
           "endColumn": 89
         }
       },
@@ -40651,26 +40299,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$fooGeneric",
         "location": {
           "startColumn": 25,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$fooGeneric",
-        "location": {
-          "startColumn": 74,
           "endColumn": 85
         }
       },
@@ -40840,26 +40472,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$unknownClassConstant",
         "location": {
           "startColumn": 25,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unknownClassConstant",
-        "location": {
-          "startColumn": 74,
           "endColumn": 95
         }
       },
@@ -40933,26 +40549,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$unknownClassConstant2",
         "location": {
           "startColumn": 25,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unknownClassConstant2",
-        "location": {
-          "startColumn": 74,
           "endColumn": 96
         }
       },
@@ -42304,26 +41904,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$invalidTypeGenericfoo",
         "location": {
           "startColumn": 115,
-          "endColumn": 128
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 129,
-          "endColumn": 144
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$invalidTypeGenericfoo",
-        "location": {
-          "startColumn": 146,
           "endColumn": 168
         }
       },
@@ -42850,26 +42434,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$invalidTypeGenericfoo",
         "location": {
           "startColumn": 111,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 143,
-          "endColumn": 158
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$invalidTypeGenericfoo",
-        "location": {
-          "startColumn": 160,
           "endColumn": 182
         }
       },
@@ -44970,26 +44538,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDoc",
+        "type": "static_property",
+        "value": "InvalidPhpDoc\\FooWithProperty::$anotherInvalidTypeGenericfoo",
         "location": {
           "startColumn": 113,
-          "endColumn": 126
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 127,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherInvalidTypeGenericfoo",
-        "location": {
-          "startColumn": 144,
           "endColumn": 173
         }
       },
@@ -45516,26 +45068,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidPhpDocPromotedProperties",
+        "type": "static_property",
+        "value": "InvalidPhpDocPromotedProperties\\FooWithProperty::$anotherInvalidTypeGenericfoo",
         "location": {
           "startColumn": 109,
-          "endColumn": 140
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooWithProperty",
-        "location": {
-          "startColumn": 141,
-          "endColumn": 156
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherInvalidTypeGenericfoo",
-        "location": {
-          "startColumn": 158,
           "endColumn": 187
         }
       },

--- a/test/__snapshots__/2.2.x/Properties.snap
+++ b/test/__snapshots__/2.2.x/Properties.snap
@@ -19,34 +19,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug7361\\Example::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "number",
-        "value": "7361",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Example",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -128,34 +104,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Feature",
+        "type": "static_property",
+        "value": "Feature11775\\FooImmutable::$i",
         "location": {
           "startColumn": 19,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "11775",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooImmutable",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 46,
           "endColumn": 48
         }
       },
@@ -237,34 +189,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Feature",
+        "type": "static_property",
+        "value": "Feature11775\\FooReadonly::$i",
         "location": {
           "startColumn": 19,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "11775",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooReadonly",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 45,
           "endColumn": 47
         }
       },
@@ -346,26 +274,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\C::$c",
         "location": {
           "startColumn": 19,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 58,
           "endColumn": 60
         }
       },
@@ -423,26 +335,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\Foo::$doubleAssigned",
         "location": {
           "startColumn": 19,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$doubleAssigned",
-        "location": {
-          "startColumn": 60,
           "endColumn": 75
         }
       },
@@ -500,26 +396,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\FooTraitClass::$doubleAssigned",
         "location": {
           "startColumn": 19,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooTraitClass",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$doubleAssigned",
-        "location": {
-          "startColumn": 70,
           "endColumn": 85
         }
       },
@@ -577,26 +457,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\Immutable::$doubleAssigned",
         "location": {
           "startColumn": 19,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Immutable",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$doubleAssigned",
-        "location": {
-          "startColumn": 66,
           "endColumn": 81
         }
       },
@@ -654,26 +518,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\A::$a",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 54,
           "endColumn": 56
         }
       },
@@ -739,26 +587,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\B::$b",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 54,
           "endColumn": 56
         }
       },
@@ -824,26 +656,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\C::$c",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 54,
           "endColumn": 56
         }
       },
@@ -909,26 +725,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\Foo::$bar",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 56,
           "endColumn": 60
         }
       },
@@ -994,26 +794,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\Foo::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 56,
           "endColumn": 60
         }
       },
@@ -1079,26 +863,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\Immutable::$bar",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Immutable",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 62,
           "endColumn": 66
         }
       },
@@ -1164,26 +932,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRefPhpDoc",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRefPhpDoc\\Immutable::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Immutable",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 62,
           "endColumn": 66
         }
       },
@@ -1249,26 +1001,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\A::$a",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -1358,26 +1094,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\ArrayAccessPropertyFetch::$storage",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ArrayAccessPropertyFetch",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$storage",
-        "location": {
-          "startColumn": 74,
           "endColumn": 82
         }
       },
@@ -1459,26 +1179,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\B::$b",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -1560,26 +1264,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\C::$c",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "C",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 51,
           "endColumn": 53
         }
       },
@@ -1661,26 +1349,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Foo::$bar",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 53,
           "endColumn": 57
         }
       },
@@ -1770,26 +1442,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Foo::$baz",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 53,
           "endColumn": 57
         }
       },
@@ -1879,26 +1535,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Foo::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 53,
           "endColumn": 57
         }
       },
@@ -1980,26 +1620,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Foo::$phan",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$phan",
-        "location": {
-          "startColumn": 53,
           "endColumn": 58
         }
       },
@@ -2089,26 +1713,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Foo::$phan",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$phan",
-        "location": {
-          "startColumn": 53,
           "endColumn": 58
         }
       },
@@ -2190,26 +1798,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Foo::$psalm",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$psalm",
-        "location": {
-          "startColumn": 53,
           "endColumn": 59
         }
       },
@@ -2299,26 +1891,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\FooArrays::$details",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooArrays",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$details",
-        "location": {
-          "startColumn": 59,
           "endColumn": 67
         }
       },
@@ -2400,26 +1976,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\Immutable::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Immutable",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 59,
           "endColumn": 63
         }
       },
@@ -2501,26 +2061,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\ListAssign::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ListAssign",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 60,
           "endColumn": 64
         }
       },
@@ -2602,26 +2146,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\NotThis::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NotThis",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 57,
           "endColumn": 61
         }
       },
@@ -2695,26 +2223,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssignPhpDoc\\PostInc::$foo",
         "location": {
           "startColumn": 19,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PostInc",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 57,
           "endColumn": 61
         }
       },
@@ -2889,26 +2401,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessPropertiesAfterIsNull",
+        "type": "static_property",
+        "value": "AccessPropertiesAfterIsNull\\Foo::$barProperty",
         "location": {
           "startColumn": 32,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 60,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$barProperty",
-        "location": {
-          "startColumn": 65,
           "endColumn": 77
         }
       },
@@ -2966,26 +2462,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessPropertiesDateIntervalChild",
+        "type": "static_property",
+        "value": "AccessPropertiesDateIntervalChild\\DateIntervalChild::$nonexistent",
         "location": {
           "startColumn": 32,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DateIntervalChild",
-        "location": {
-          "startColumn": 66,
-          "endColumn": 83
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonexistent",
-        "location": {
-          "startColumn": 85,
           "endColumn": 97
         }
       },
@@ -3075,34 +2555,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11424\\Foo::$i",
         "location": {
           "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "number",
-        "value": "11424",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 54,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 59,
           "endColumn": 61
         }
       },
@@ -3160,34 +2616,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6385\\ActualUnitEnum::$value",
         "location": {
           "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "6385",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ActualUnitEnum",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$value",
-        "location": {
-          "startColumn": 56,
           "endColumn": 62
         }
       },
@@ -3245,26 +2677,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DynamicProperties",
+        "type": "static_property",
+        "value": "DynamicProperties\\Bar::$dynamicProperty",
         "location": {
           "startColumn": 32,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dynamicProperty",
-        "location": {
-          "startColumn": 55,
           "endColumn": 71
         }
       },
@@ -3322,26 +2738,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DynamicProperties",
+        "type": "static_property",
+        "value": "DynamicProperties\\Baz::$dynamicProperty",
         "location": {
           "startColumn": 32,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dynamicProperty",
-        "location": {
-          "startColumn": 55,
           "endColumn": 71
         }
       },
@@ -3399,26 +2799,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DynamicProperties",
+        "type": "static_property",
+        "value": "DynamicProperties\\FinalBar::$dynamicProperty",
         "location": {
           "startColumn": 32,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FinalBar",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dynamicProperty",
-        "location": {
-          "startColumn": 60,
           "endColumn": 76
         }
       },
@@ -3476,26 +2860,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DynamicProperties",
+        "type": "static_property",
+        "value": "DynamicProperties\\FinalFoo::$dynamicProperty",
         "location": {
           "startColumn": 32,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FinalFoo",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dynamicProperty",
-        "location": {
-          "startColumn": 60,
           "endColumn": 76
         }
       },
@@ -3553,26 +2921,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DynamicProperties",
+        "type": "static_property",
+        "value": "DynamicProperties\\Foo::$dynamicProperty",
         "location": {
           "startColumn": 32,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dynamicProperty",
-        "location": {
-          "startColumn": 55,
           "endColumn": 71
         }
       },
@@ -3731,26 +3083,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "NullCoalesceIsAlwaysFinal",
+        "type": "static_property",
+        "value": "NullCoalesceIsAlwaysFinal\\Foo::$bar",
         "location": {
           "startColumn": 32,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 63,
           "endColumn": 67
         }
       },
@@ -3808,26 +3144,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "NullsafePropertyFetch",
+        "type": "static_property",
+        "value": "NullsafePropertyFetch\\Foo::$baz",
         "location": {
           "startColumn": 32,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 54,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 59,
           "endColumn": 63
         }
       },
@@ -3885,42 +3205,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Php",
+        "type": "static_property",
+        "value": "Php82DynamicPropertiesAllow\\HelloWorld::$world",
         "location": {
           "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "82",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DynamicPropertiesAllow",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 60,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$world",
-        "location": {
-          "startColumn": 72,
           "endColumn": 78
         }
       },
@@ -3978,42 +3266,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Php",
+        "type": "static_property",
+        "value": "Php82DynamicProperties\\ClassA::$properties",
         "location": {
           "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "82",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DynamicProperties",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ClassA",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$properties",
-        "location": {
-          "startColumn": 63,
           "endColumn": 74
         }
       },
@@ -4071,42 +3327,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Php",
+        "type": "static_property",
+        "value": "Php82DynamicProperties\\FinalHelloWorld::$world",
         "location": {
           "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "82",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DynamicProperties",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FinalHelloWorld",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$world",
-        "location": {
-          "startColumn": 72,
           "endColumn": 78
         }
       },
@@ -4164,42 +3388,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Php",
+        "type": "static_property",
+        "value": "Php82DynamicProperties\\HelloWorld::$world",
         "location": {
           "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "82",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DynamicProperties",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$world",
-        "location": {
-          "startColumn": 67,
           "endColumn": 73
         }
       },
@@ -4257,42 +3449,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Php",
+        "type": "static_property",
+        "value": "Php82DynamicProperties\\ReadonlyWithMagic::$foo",
         "location": {
           "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "82",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "DynamicProperties",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyWithMagic",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 74,
           "endColumn": 78
         }
       },
@@ -4350,26 +3510,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoObject\\Foo::$noop",
         "location": {
           "startColumn": 32,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$noop",
-        "location": {
-          "startColumn": 67,
           "endColumn": 72
         }
       },
@@ -4427,26 +3571,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromVariableIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromVariableIntoObject\\Foo::$noop",
         "location": {
           "startColumn": 32,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 65,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$noop",
-        "location": {
-          "startColumn": 70,
           "endColumn": 75
         }
       },
@@ -4504,26 +3632,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RequireExtends",
+        "type": "static_property",
+        "value": "RequireExtends\\MyInterface::$bar",
         "location": {
           "startColumn": 32,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyInterface",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 60,
           "endColumn": 64
         }
       },
@@ -4581,26 +3693,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessPropertiesAssign",
+        "type": "static_property",
+        "value": "TestAccessPropertiesAssign\\AccessPropertyWithDimFetch::$foo",
         "location": {
           "startColumn": 32,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AccessPropertyWithDimFetch",
-        "location": {
-          "startColumn": 59,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 87,
           "endColumn": 91
         }
       },
@@ -4658,26 +3754,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\AssignOpNonexistentProperty::$flags",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignOpNonexistentProperty",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 80
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$flags",
-        "location": {
-          "startColumn": 82,
           "endColumn": 88
         }
       },
@@ -4735,26 +3815,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\BarAccessProperties::$loremipsum",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BarAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$loremipsum",
-        "location": {
-          "startColumn": 74,
           "endColumn": 85
         }
       },
@@ -4812,26 +3876,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$anotherEmptyNonexistent",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherEmptyNonexistent",
-        "location": {
-          "startColumn": 74,
           "endColumn": 98
         }
       },
@@ -4889,26 +3937,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$anotherNonexistent",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherNonexistent",
-        "location": {
-          "startColumn": 74,
           "endColumn": 93
         }
       },
@@ -4966,26 +3998,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$baz",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 74,
           "endColumn": 78
         }
       },
@@ -5043,26 +4059,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$dolor",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dolor",
-        "location": {
-          "startColumn": 74,
           "endColumn": 80
         }
       },
@@ -5120,26 +4120,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$emptyBaz",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$emptyBaz",
-        "location": {
-          "startColumn": 74,
           "endColumn": 83
         }
       },
@@ -5197,26 +4181,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$emptyNonexistent",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$emptyNonexistent",
-        "location": {
-          "startColumn": 74,
           "endColumn": 91
         }
       },
@@ -5274,26 +4242,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$lorem",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem",
-        "location": {
-          "startColumn": 74,
           "endColumn": 80
         }
       },
@@ -5351,26 +4303,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$nonexistent",
         "location": {
           "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonexistent",
-        "location": {
-          "startColumn": 74,
           "endColumn": 86
         }
       },
@@ -5452,26 +4388,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\WithFooProperty::$bar",
         "location": {
           "startColumn": 67,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithFooProperty",
-        "location": {
-          "startColumn": 88,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 105,
           "endColumn": 109
         }
       },
@@ -5553,26 +4473,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\WithFooProperty::$bar",
         "location": {
           "startColumn": 75,
-          "endColumn": 95
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithFooProperty",
-        "location": {
-          "startColumn": 96,
-          "endColumn": 111
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 113,
           "endColumn": 117
         }
       },
@@ -5630,18 +4534,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UnitEnum",
+        "type": "static_property",
+        "value": "UnitEnum::$value",
         "location": {
           "startColumn": 32,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$value",
-        "location": {
-          "startColumn": 42,
           "endColumn": 48
         }
       },
@@ -5824,18 +4720,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "object",
+        "type": "static_property",
+        "value": "object::$baz",
         "location": {
           "startColumn": 32,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 40,
           "endColumn": 44
         }
       },
@@ -6316,18 +5204,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessInIsset",
+        "type": "static_property",
+        "value": "AccessInIsset::$foo",
         "location": {
           "startColumn": 39,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 54,
           "endColumn": 58
         }
       },
@@ -6393,26 +5273,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessStaticProperties",
+        "type": "static_property",
+        "value": "AccessStaticProperties\\AssignOpNonexistentProperty::$flags",
         "location": {
           "startColumn": 39,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignOpNonexistentProperty",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 89
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$flags",
-        "location": {
-          "startColumn": 91,
           "endColumn": 97
         }
       },
@@ -6478,18 +5342,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AllowsDynamicProperties",
+        "type": "static_property",
+        "value": "AllowsDynamicProperties::$foo",
         "location": {
           "startColumn": 39,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 64,
           "endColumn": 68
         }
       },
@@ -6555,18 +5411,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "BarAccessStaticProperties",
+        "type": "static_property",
+        "value": "BarAccessStaticProperties::$bar",
         "location": {
           "startColumn": 39,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 66,
           "endColumn": 70
         }
       },
@@ -6648,18 +5496,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "string",
+        "type": "static_property",
+        "value": "string::$unknownProperty",
         "location": {
           "startColumn": 53,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unknownProperty",
-        "location": {
-          "startColumn": 61,
           "endColumn": 77
         }
       },
@@ -6725,18 +5565,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DoesNotAllowDynamicProperties",
+        "type": "static_property",
+        "value": "DoesNotAllowDynamicProperties::$foo",
         "location": {
           "startColumn": 39,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 70,
           "endColumn": 74
         }
       },
@@ -6818,18 +5650,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "SomeInterface",
+        "type": "static_property",
+        "value": "SomeInterface::$nonexistent",
         "location": {
           "startColumn": 65,
-          "endColumn": 78
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonexistent",
-        "location": {
-          "startColumn": 80,
           "endColumn": 92
         }
       },
@@ -6895,18 +5719,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooAccessStaticProperties",
+        "type": "static_property",
+        "value": "FooAccessStaticProperties::$bar",
         "location": {
           "startColumn": 39,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 66,
           "endColumn": 70
         }
       },
@@ -6972,18 +5788,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooAccessStaticProperties",
+        "type": "static_property",
+        "value": "FooAccessStaticProperties::$nonexistent",
         "location": {
           "startColumn": 39,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonexistent",
-        "location": {
-          "startColumn": 66,
           "endColumn": 78
         }
       },
@@ -7049,18 +5857,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooAccessStaticProperties",
+        "type": "static_property",
+        "value": "FooAccessStaticProperties::$unknownProperties",
         "location": {
           "startColumn": 39,
-          "endColumn": 64
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unknownProperties",
-        "location": {
-          "startColumn": 66,
           "endColumn": 84
         }
       },
@@ -7126,18 +5926,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParentClassWithInstanceProperty",
+        "type": "static_property",
+        "value": "ParentClassWithInstanceProperty::$j",
         "location": {
           "startColumn": 39,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$j",
-        "location": {
-          "startColumn": 72,
           "endColumn": 74
         }
       },
@@ -7203,26 +5995,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoStaticObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoStaticObject\\Foo::$noop",
         "location": {
           "startColumn": 39,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 75,
-          "endColumn": 78
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$noop",
-        "location": {
-          "startColumn": 80,
           "endColumn": 85
         }
       },
@@ -7288,26 +6064,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessStaticPropertiesAssign",
+        "type": "static_property",
+        "value": "TestAccessStaticPropertiesAssign\\AccessStaticPropertyWithDimFetch::$foo",
         "location": {
           "startColumn": 39,
-          "endColumn": 71
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AccessStaticPropertyWithDimFetch",
-        "location": {
-          "startColumn": 72,
-          "endColumn": 104
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 106,
           "endColumn": 110
         }
       },
@@ -8314,26 +7074,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\AssignOp::$bar",
         "location": {
           "startColumn": 46,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignOp",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 90
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 92,
           "endColumn": 96
         }
       },
@@ -8399,26 +7143,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\AssignOp::$foo",
         "location": {
           "startColumn": 46,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignOp",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 90
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 92,
           "endColumn": 96
         }
       },
@@ -8484,26 +7212,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\B::$b",
         "location": {
           "startColumn": 46,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 83
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 85,
           "endColumn": 87
         }
       },
@@ -8569,26 +7281,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\Foo::$readBeforeAssigned",
         "location": {
           "startColumn": 46,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readBeforeAssigned",
-        "location": {
-          "startColumn": 87,
           "endColumn": 106
         }
       },
@@ -8654,26 +7350,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\FooTraitClass::$readBeforeAssigned",
         "location": {
           "startColumn": 46,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooTraitClass",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 95
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readBeforeAssigned",
-        "location": {
-          "startColumn": 97,
           "endColumn": 116
         }
       },
@@ -8739,26 +7419,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssignPhpDoc",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssignPhpDoc\\Immutable::$readBeforeAssigned",
         "location": {
           "startColumn": 46,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Immutable",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 91
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readBeforeAssigned",
-        "location": {
-          "startColumn": 93,
           "endColumn": 112
         }
       },
@@ -8816,42 +7480,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug9619\\AdminPresenter3::$user",
         "location": {
           "startColumn": 36,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "number",
-        "value": "9619",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AdminPresenter",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "number",
-        "value": "3",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 59
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$user",
-        "location": {
-          "startColumn": 61,
           "endColumn": 66
         }
       },
@@ -8909,34 +7541,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug9831\\Foo::$bar",
         "location": {
           "startColumn": 36,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "number",
-        "value": "9831",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 49,
           "endColumn": 53
         }
       },
@@ -8994,34 +7602,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RedeclareReadonlyProperty",
+        "type": "static_property",
+        "value": "RedeclareReadonlyProperty\\B19::$prop2",
         "location": {
           "startColumn": 36,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "number",
-        "value": "19",
-        "location": {
-          "startColumn": 63,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop2",
-        "location": {
-          "startColumn": 67,
           "endColumn": 73
         }
       },
@@ -9079,26 +7663,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UninitializedProperty",
+        "type": "static_property",
+        "value": "UninitializedProperty\\Bar::$foo",
         "location": {
           "startColumn": 36,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 63,
           "endColumn": 67
         }
       },
@@ -9156,26 +7724,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "UninitializedProperty",
+        "type": "static_property",
+        "value": "UninitializedProperty\\SometimesInitializedInPrivateSetter::$foo",
         "location": {
           "startColumn": 36,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SometimesInitializedInPrivateSetter",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 93
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 95,
           "endColumn": 99
         }
       },
@@ -9241,42 +7793,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6402\\SomeModel2::$views",
         "location": {
           "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "number",
-        "value": "6402",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeModel",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 62
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 62,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$views",
-        "location": {
-          "startColumn": 65,
           "endColumn": 71
         }
       },
@@ -9342,34 +7862,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug9863\\ReadonlyParentWithIsset::$foo",
         "location": {
           "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "number",
-        "value": "9863",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyParentWithIsset",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 76
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 78,
           "endColumn": 82
         }
       },
@@ -9435,26 +7931,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\AssignOp::$bar",
         "location": {
           "startColumn": 45,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignOp",
-        "location": {
-          "startColumn": 75,
-          "endColumn": 83
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 85,
           "endColumn": 89
         }
       },
@@ -9520,26 +8000,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\AssignOp::$foo",
         "location": {
           "startColumn": 45,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignOp",
-        "location": {
-          "startColumn": 75,
-          "endColumn": 83
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 85,
           "endColumn": 89
         }
       },
@@ -9605,26 +8069,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\Foo::$readBeforeAssigned",
         "location": {
           "startColumn": 45,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 75,
-          "endColumn": 78
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readBeforeAssigned",
-        "location": {
-          "startColumn": 80,
           "endColumn": 99
         }
       },
@@ -9690,26 +8138,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\FooTraitClass::$readBeforeAssigned",
         "location": {
           "startColumn": 45,
-          "endColumn": 74
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooTraitClass",
-        "location": {
-          "startColumn": 75,
-          "endColumn": 88
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readBeforeAssigned",
-        "location": {
-          "startColumn": 90,
           "endColumn": 109
         }
       },
@@ -9852,34 +8284,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12645\\Foo::$id",
         "location": {
           "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "number",
-        "value": "12645",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$id",
-        "location": {
-          "startColumn": 41,
           "endColumn": 44
         }
       },
@@ -9929,26 +8337,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingAnnotationProperty",
+        "type": "static_property",
+        "value": "ConflictingAnnotationProperty\\PropertyWithAnnotation::$test",
         "location": {
           "startColumn": 27,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PropertyWithAnnotation",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 79
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$test",
-        "location": {
-          "startColumn": 81,
           "endColumn": 86
         }
       },
@@ -9998,26 +8390,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$foo",
         "location": {
           "startColumn": 27,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 67
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 69,
           "endColumn": 73
         }
       },
@@ -10718,34 +9094,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13537\\Bar::$test",
         "location": {
           "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "number",
-        "value": "13537",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$test",
-        "location": {
-          "startColumn": 43,
           "endColumn": 48
         }
       },
@@ -10795,26 +9147,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TestAccessProperties",
+        "type": "static_property",
+        "value": "TestAccessProperties\\FooAccessProperties::$bar",
         "location": {
           "startColumn": 29,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooAccessProperties",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 69
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 71,
           "endColumn": 75
         }
       },
@@ -11119,18 +9455,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "parent",
+        "type": "static_property",
+        "value": "parent::$staticFooProperty",
         "location": {
           "startColumn": 10,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticFooProperty",
-        "location": {
-          "startColumn": 18,
           "endColumn": 36
         }
       },
@@ -11188,18 +9516,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "self",
+        "type": "static_property",
+        "value": "self::$staticFooProperty",
         "location": {
           "startColumn": 10,
-          "endColumn": 14
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticFooProperty",
-        "location": {
-          "startColumn": 16,
           "endColumn": 34
         }
       },
@@ -11257,18 +9577,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "static",
+        "type": "static_property",
+        "value": "static::$staticFooProperty",
         "location": {
           "startColumn": 10,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticFooProperty",
-        "location": {
-          "startColumn": 18,
           "endColumn": 36
         }
       },
@@ -16636,18 +14948,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "parent",
+        "type": "static_property",
+        "value": "parent::$lorem",
         "location": {
           "startColumn": 46,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem",
-        "location": {
-          "startColumn": 54,
           "endColumn": 60
         }
       },
@@ -16769,34 +15073,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12692\\Foo::$static",
         "location": {
           "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "number",
-        "value": "12692",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$static",
-        "location": {
-          "startColumn": 51,
           "endColumn": 58
         }
       },
@@ -16862,42 +15142,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug8668\\Sample2::$sample",
         "location": {
           "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "number",
-        "value": "8668",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Sample",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$sample",
-        "location": {
-          "startColumn": 54,
           "endColumn": 61
         }
       },
@@ -16963,34 +15211,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug8668\\Sample::$sample",
         "location": {
           "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "number",
-        "value": "8668",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Sample",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$sample",
-        "location": {
-          "startColumn": 53,
           "endColumn": 60
         }
       },
@@ -17032,26 +15256,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Bar::$protectedStaticFoo",
         "location": {
           "startColumn": 20,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$protectedStaticFoo",
-        "location": {
-          "startColumn": 44,
           "endColumn": 63
         }
       },
@@ -17080,26 +15288,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Foo::$protectedStaticFoo",
         "location": {
           "startColumn": 90,
-          "endColumn": 108
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 109,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$protectedStaticFoo",
-        "location": {
-          "startColumn": 114,
           "endColumn": 133
         }
       },
@@ -17141,26 +15333,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Bar::$publicStaticFoo",
         "location": {
           "startColumn": 20,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicStaticFoo",
-        "location": {
-          "startColumn": 44,
           "endColumn": 60
         }
       },
@@ -17189,26 +15365,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Foo::$publicStaticFoo",
         "location": {
           "startColumn": 87,
-          "endColumn": 105
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 106,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicStaticFoo",
-        "location": {
-          "startColumn": 111,
           "endColumn": 127
         }
       },
@@ -17303,42 +15463,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Typed2WithPhpDoc::$foo",
         "location": {
           "startColumn": 26,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Typed",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WithPhpDoc",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 63,
           "endColumn": 67
         }
       },
@@ -17463,26 +15591,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\TypedWithPhpDoc::$foo",
         "location": {
           "startColumn": 128,
-          "endColumn": 146
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TypedWithPhpDoc",
-        "location": {
-          "startColumn": 147,
-          "endColumn": 162
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 164,
           "endColumn": 168
         }
       },
@@ -17540,26 +15652,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Bar::$arrayClassStrings",
         "location": {
           "startColumn": 30,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$arrayClassStrings",
-        "location": {
-          "startColumn": 60,
           "endColumn": 78
         }
       },
@@ -17676,26 +15772,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Foo::$arrayClassStrings",
         "location": {
           "startColumn": 156,
-          "endColumn": 180
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 181,
-          "endColumn": 184
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$arrayClassStrings",
-        "location": {
-          "startColumn": 186,
           "endColumn": 204
         }
       },
@@ -17753,26 +15833,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Bar::$arrayClassStrings",
         "location": {
           "startColumn": 30,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 55,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$arrayClassStrings",
-        "location": {
-          "startColumn": 60,
           "endColumn": 78
         }
       },
@@ -17897,26 +15961,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Foo::$arrayClassStrings",
         "location": {
           "startColumn": 153,
-          "endColumn": 177
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 178,
-          "endColumn": 181
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$arrayClassStrings",
-        "location": {
-          "startColumn": 183,
           "endColumn": 201
         }
       },
@@ -18006,26 +16054,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Bar::$array",
         "location": {
           "startColumn": 44,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 69,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$array",
-        "location": {
-          "startColumn": 74,
           "endColumn": 80
         }
       },
@@ -18118,26 +16150,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Foo::$array",
         "location": {
           "startColumn": 141,
-          "endColumn": 165
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 166,
-          "endColumn": 169
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$array",
-        "location": {
-          "startColumn": 171,
           "endColumn": 177
         }
       },
@@ -18195,26 +16211,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Bar::$string",
         "location": {
           "startColumn": 28,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 58,
           "endColumn": 65
         }
       },
@@ -18299,26 +16299,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Foo::$string",
         "location": {
           "startColumn": 130,
-          "endColumn": 154
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 155,
-          "endColumn": 158
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 160,
           "endColumn": 167
         }
       },
@@ -18376,26 +16360,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Bar::$string",
         "location": {
           "startColumn": 28,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 58,
           "endColumn": 65
         }
       },
@@ -18488,26 +16456,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingPropertyPhpDoc",
+        "type": "static_property",
+        "value": "OverridingPropertyPhpDoc\\Foo::$string",
         "location": {
           "startColumn": 127,
-          "endColumn": 151
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 152,
-          "endColumn": 155
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 157,
           "endColumn": 164
         }
       },
@@ -18541,26 +16493,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\PrivateDolor::$anotherPublicFoo",
         "location": {
           "startColumn": 17,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateDolor",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherPublicFoo",
-        "location": {
-          "startColumn": 50,
           "endColumn": 67
         }
       },
@@ -18589,26 +16525,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Dolor::$anotherPublicFoo",
         "location": {
           "startColumn": 95,
-          "endColumn": 113
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 114,
-          "endColumn": 119
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherPublicFoo",
-        "location": {
-          "startColumn": 121,
           "endColumn": 138
         }
       },
@@ -18674,26 +16594,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\PrivateDolor::$protectedFoo",
         "location": {
           "startColumn": 17,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateDolor",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$protectedFoo",
-        "location": {
-          "startColumn": 50,
           "endColumn": 63
         }
       },
@@ -18722,26 +16626,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Dolor::$protectedFoo",
         "location": {
           "startColumn": 94,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$protectedFoo",
-        "location": {
-          "startColumn": 120,
           "endColumn": 133
         }
       },
@@ -18815,26 +16703,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\PrivateDolor::$publicFoo",
         "location": {
           "startColumn": 17,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PrivateDolor",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicFoo",
-        "location": {
-          "startColumn": 50,
           "endColumn": 60
         }
       },
@@ -18863,26 +16735,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Dolor::$publicFoo",
         "location": {
           "startColumn": 88,
-          "endColumn": 106
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 107,
-          "endColumn": 112
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicFoo",
-        "location": {
-          "startColumn": 114,
           "endColumn": 124
         }
       },
@@ -18940,26 +16796,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayItem",
+        "type": "static_property",
+        "value": "AppendedArrayItem\\Bar::$stringCallables",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$stringCallables",
-        "location": {
-          "startColumn": 32,
           "endColumn": 48
         }
       },
@@ -19249,26 +17089,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayItem",
+        "type": "static_property",
+        "value": "AppendedArrayItem\\Baz::$staticProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticProperty",
-        "location": {
-          "startColumn": 32,
           "endColumn": 47
         }
       },
@@ -19438,26 +17262,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayItem",
+        "type": "static_property",
+        "value": "AppendedArrayItem\\Foo::$callables",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$callables",
-        "location": {
-          "startColumn": 32,
           "endColumn": 42
         }
       },
@@ -19739,26 +17547,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayItem",
+        "type": "static_property",
+        "value": "AppendedArrayItem\\Foo::$callables",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$callables",
-        "location": {
-          "startColumn": 32,
           "endColumn": 42
         }
       },
@@ -20040,26 +17832,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayItem",
+        "type": "static_property",
+        "value": "AppendedArrayItem\\Foo::$callables",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$callables",
-        "location": {
-          "startColumn": 32,
           "endColumn": 42
         }
       },
@@ -20357,26 +18133,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayItem",
+        "type": "static_property",
+        "value": "AppendedArrayItem\\Foo::$integers",
         "location": {
           "startColumn": 9,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$integers",
-        "location": {
-          "startColumn": 32,
           "endColumn": 41
         }
       },
@@ -20522,26 +18282,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayKey",
+        "type": "static_property",
+        "value": "AppendedArrayKey\\Foo::$intArray",
         "location": {
           "startColumn": 9,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$intArray",
-        "location": {
-          "startColumn": 31,
           "endColumn": 40
         }
       },
@@ -20719,26 +18463,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayKey",
+        "type": "static_property",
+        "value": "AppendedArrayKey\\Foo::$stringArray",
         "location": {
           "startColumn": 9,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$stringArray",
-        "location": {
-          "startColumn": 31,
           "endColumn": 43
         }
       },
@@ -20916,26 +18644,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayKey",
+        "type": "static_property",
+        "value": "AppendedArrayKey\\MorePreciseKey::$test",
         "location": {
           "startColumn": 9,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MorePreciseKey",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$test",
-        "location": {
-          "startColumn": 42,
           "endColumn": 47
         }
       },
@@ -21193,26 +18905,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AppendedArrayKey",
+        "type": "static_property",
+        "value": "AppendedArrayKey\\MorePreciseKey::$test",
         "location": {
           "startColumn": 9,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MorePreciseKey",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$test",
-        "location": {
-          "startColumn": 42,
           "endColumn": 47
         }
       },
@@ -21422,34 +19118,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11241\\ActualProp::$id",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "11241",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ActualProp",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$id",
-        "location": {
-          "startColumn": 30,
           "endColumn": 33
         }
       },
@@ -21499,34 +19171,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11241\\MagicProp::$id",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "11241",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MagicProp",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$id",
-        "location": {
-          "startColumn": 29,
           "endColumn": 32
         }
       },
@@ -21576,42 +19224,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11241b\\HelloWorld::$property1",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "11241",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "b",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$property1",
-        "location": {
-          "startColumn": 31,
           "endColumn": 41
         }
       },
@@ -21693,34 +19309,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11275\\D::$b",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "11275",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "D",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 21,
           "endColumn": 23
         }
       },
@@ -21914,34 +19506,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug11617\\HelloWorld::$params",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "11617",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$params",
-        "location": {
-          "startColumn": 30,
           "endColumn": 37
         }
       },
@@ -22159,34 +19727,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12131\\Test::$array",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "12131",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$array",
-        "location": {
-          "startColumn": 24,
           "endColumn": 30
         }
       },
@@ -22404,42 +19948,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug1216PropertyTest\\Baz::$untypedBar",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "1216",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PropertyTest",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$untypedBar",
-        "location": {
-          "startColumn": 34,
           "endColumn": 45
         }
       },
@@ -22521,42 +20033,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug1216PropertyTest\\Dummy::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "1216",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PropertyTest",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dummy",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -22638,34 +20118,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13438\\Test::$queue",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "13438",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$queue",
-        "location": {
-          "startColumn": 24,
           "endColumn": 30
         }
       },
@@ -22811,42 +20267,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13438b\\Test::$queue",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "13438",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "b",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$queue",
-        "location": {
-          "startColumn": 25,
           "endColumn": 31
         }
       },
@@ -22992,42 +20416,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13438d\\Test::$queue",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "13438",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "d",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$queue",
-        "location": {
-          "startColumn": 25,
           "endColumn": 31
         }
       },
@@ -23149,42 +20541,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13438e\\Test::$queue",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "13438",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "e",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$queue",
-        "location": {
-          "startColumn": 25,
           "endColumn": 31
         }
       },
@@ -23306,42 +20666,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13438f\\Test::$queue",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "13438",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "f",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$queue",
-        "location": {
-          "startColumn": 25,
           "endColumn": 31
         }
       },
@@ -23583,42 +20911,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14150Properties\\HelloWorld::$x",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "14150",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Properties",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$x",
-        "location": {
-          "startColumn": 40,
           "endColumn": 42
         }
       },
@@ -23700,34 +20996,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug2888\\MyClass::$prop",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "2888",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClass",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop",
-        "location": {
-          "startColumn": 26,
           "endColumn": 31
         }
       },
@@ -23873,42 +21145,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3311b\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3311",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "b",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 23,
           "endColumn": 27
         }
       },
@@ -24110,34 +21350,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3703\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3703",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 22,
           "endColumn": 26
         }
       },
@@ -24443,34 +21659,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3703\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3703",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 22,
           "endColumn": 26
         }
       },
@@ -24776,34 +21968,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3703\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3703",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 22,
           "endColumn": 26
         }
       },
@@ -25125,34 +22293,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777\\Bar::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 22,
           "endColumn": 26
         }
       },
@@ -25314,42 +22458,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777\\Ipsum2::$ipsum2",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum2",
-        "location": {
-          "startColumn": 25,
           "endColumn": 32
         }
       },
@@ -25559,42 +22671,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777\\Ipsum2::$lorem2",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem2",
-        "location": {
-          "startColumn": 25,
           "endColumn": 32
         }
       },
@@ -25804,42 +22884,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777\\Ipsum3::$ipsum3",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "number",
-        "value": "3",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum3",
-        "location": {
-          "startColumn": 25,
           "endColumn": 32
         }
       },
@@ -26049,34 +23097,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777\\Ipsum::$ipsum",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 22
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum",
-        "location": {
-          "startColumn": 24,
           "endColumn": 30
         }
       },
@@ -26270,34 +23294,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug5298\\WorldProviderManager::$providers",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "5298",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "WorldProviderManager",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$providers",
-        "location": {
-          "startColumn": 39,
           "endColumn": 49
         }
       },
@@ -26675,34 +23675,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug5607\\Cl::$u",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "5607",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Cl",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$u",
-        "location": {
-          "startColumn": 21,
           "endColumn": 23
         }
       },
@@ -26904,34 +23880,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug5804\\Blah::$value",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "5804",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Blah",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$value",
-        "location": {
-          "startColumn": 23,
           "endColumn": 29
         }
       },
@@ -27109,34 +24061,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug5804\\Blah::$value",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "5804",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Blah",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$value",
-        "location": {
-          "startColumn": 23,
           "endColumn": 29
         }
       },
@@ -27298,34 +24226,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6286\\HelloWorld::$details",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "6286",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$details",
-        "location": {
-          "startColumn": 29,
           "endColumn": 37
         }
       },
@@ -27551,34 +24455,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6286\\HelloWorld::$nestedDetails",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "6286",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nestedDetails",
-        "location": {
-          "startColumn": 29,
           "endColumn": 43
         }
       },
@@ -27884,50 +24764,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6356b\\HelloWorld2::$details",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "6356",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "b",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$details",
-        "location": {
-          "startColumn": 31,
           "endColumn": 39
         }
       },
@@ -28153,50 +24993,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6356b\\HelloWorld2::$nestedDetails",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "6356",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "b",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nestedDetails",
-        "location": {
-          "startColumn": 31,
           "endColumn": 45
         }
       },
@@ -28502,50 +25302,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6356b\\HelloWorld2::$nestedDetails",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "6356",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "b",
-        "location": {
-          "startColumn": 16,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nestedDetails",
-        "location": {
-          "startColumn": 31,
           "endColumn": 45
         }
       },
@@ -28851,42 +25611,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug7074\\SomeModel2::$primaryKey",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "7074",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "SomeModel",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$primaryKey",
-        "location": {
-          "startColumn": 29,
           "endColumn": 40
         }
       },
@@ -29096,34 +25824,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug7912\\A::$has",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "7912",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "A",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$has",
-        "location": {
-          "startColumn": 20,
           "endColumn": 24
         }
       },
@@ -29245,26 +25949,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "DefaultValueForNativePropertyType",
+        "type": "static_property",
+        "value": "DefaultValueForNativePropertyType\\Foo::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 48,
           "endColumn": 52
         }
       },
@@ -29378,26 +26066,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "GenericObjectUnspecifiedTemplateTypes",
+        "type": "static_property",
+        "value": "GenericObjectUnspecifiedTemplateTypes\\Bar::$ints",
         "location": {
           "startColumn": 9,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ints",
-        "location": {
-          "startColumn": 52,
           "endColumn": 57
         }
       },
@@ -29575,26 +26247,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "GenericObjectUnspecifiedTemplateTypes",
+        "type": "static_property",
+        "value": "GenericObjectUnspecifiedTemplateTypes\\Foo::$obj",
         "location": {
           "startColumn": 9,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$obj",
-        "location": {
-          "startColumn": 52,
           "endColumn": 56
         }
       },
@@ -29804,26 +26460,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntegerRangesAndConstants",
+        "type": "static_property",
+        "value": "IntegerRangesAndConstants\\HelloWorld::$i",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 47,
           "endColumn": 49
         }
       },
@@ -29977,26 +26617,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntegerRangesAndConstants",
+        "type": "static_property",
+        "value": "IntegerRangesAndConstants\\HelloWorld::$x",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$x",
-        "location": {
-          "startColumn": 47,
           "endColumn": 49
         }
       },
@@ -30182,26 +26806,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntegerRangesAndConstants",
+        "type": "static_property",
+        "value": "IntegerRangesAndConstants\\HelloWorld::$x",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$x",
-        "location": {
-          "startColumn": 47,
           "endColumn": 49
         }
       },
@@ -30387,26 +26995,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntegerRangesAndConstants",
+        "type": "static_property",
+        "value": "IntegerRangesAndConstants\\HelloWorld::$x",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$x",
-        "location": {
-          "startColumn": 47,
           "endColumn": 49
         }
       },
@@ -30576,26 +27168,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IntegerRangesAndConstants",
+        "type": "static_property",
+        "value": "IntegerRangesAndConstants\\HelloWorld::$x",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$x",
-        "location": {
-          "startColumn": 47,
           "endColumn": 49
         }
       },
@@ -30765,26 +27341,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidCallablePropertyType",
+        "type": "static_property",
+        "value": "InvalidCallablePropertyType\\HelloWorld::$a",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 49,
           "endColumn": 51
         }
       },
@@ -30866,26 +27426,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidCallablePropertyType",
+        "type": "static_property",
+        "value": "InvalidCallablePropertyType\\HelloWorld::$b",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$b",
-        "location": {
-          "startColumn": 49,
           "endColumn": 51
         }
       },
@@ -30967,26 +27511,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidCallablePropertyType",
+        "type": "static_property",
+        "value": "InvalidCallablePropertyType\\HelloWorld::$c",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 49,
           "endColumn": 51
         }
       },
@@ -31068,26 +27596,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "InvalidCallablePropertyType",
+        "type": "static_property",
+        "value": "InvalidCallablePropertyType\\HelloWorld::$callback",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "HelloWorld",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$callback",
-        "location": {
-          "startColumn": 49,
           "endColumn": 58
         }
       },
@@ -31169,26 +27681,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\Bar::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 38,
           "endColumn": 42
         }
       },
@@ -31318,26 +27814,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\Bar::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 38,
           "endColumn": 42
         }
       },
@@ -31467,26 +27947,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\Baz::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 38,
           "endColumn": 42
         }
       },
@@ -31656,26 +28120,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\CallableSignature::$cb",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CallableSignature",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$cb",
-        "location": {
-          "startColumn": 52,
           "endColumn": 55
         }
       },
@@ -31757,26 +28205,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\ChildClass::$unionProp",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ChildClass",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unionProp",
-        "location": {
-          "startColumn": 45,
           "endColumn": 55
         }
       },
@@ -31882,26 +28314,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\MyClass::$prop1",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClass",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop1",
-        "location": {
-          "startColumn": 42,
           "endColumn": 48
         }
       },
@@ -31959,26 +28375,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\MyClass::$prop2",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClass",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop2",
-        "location": {
-          "startColumn": 42,
           "endColumn": 48
         }
       },
@@ -32036,26 +28436,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\MyClass::$prop3",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClass",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop3",
-        "location": {
-          "startColumn": 42,
           "endColumn": 48
         }
       },
@@ -32113,26 +28497,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingPropertyTypehint",
+        "type": "static_property",
+        "value": "MissingPropertyTypehint\\NestedArrayInProperty::$args",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NestedArrayInProperty",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$args",
-        "location": {
-          "startColumn": 56,
           "endColumn": 61
         }
       },
@@ -32238,26 +28606,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\TypeChild::$withType",
         "location": {
           "startColumn": 9,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TypeChild",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$withType",
-        "location": {
-          "startColumn": 39,
           "endColumn": 48
         }
       },
@@ -32278,26 +28630,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Typed::$withType",
         "location": {
           "startColumn": 69,
-          "endColumn": 87
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Typed",
-        "location": {
-          "startColumn": 88,
-          "endColumn": 93
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$withType",
-        "location": {
-          "startColumn": 95,
           "endColumn": 104
         }
       },
@@ -32395,26 +28731,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\TypeChild::$withoutType",
         "location": {
           "startColumn": 9,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "TypeChild",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$withoutType",
-        "location": {
-          "startColumn": 39,
           "endColumn": 51
         }
       },
@@ -32459,26 +28779,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Typed::$withoutType",
         "location": {
           "startColumn": 78,
-          "endColumn": 96
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Typed",
-        "location": {
-          "startColumn": 97,
-          "endColumn": 102
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$withoutType",
-        "location": {
-          "startColumn": 104,
           "endColumn": 116
         }
       },
@@ -32552,26 +28856,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PrivatePropertyTagRead",
+        "type": "static_property",
+        "value": "PrivatePropertyTagRead\\Foo::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 37,
           "endColumn": 41
         }
       },
@@ -32621,26 +28909,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PrivatePropertyTagWrite",
+        "type": "static_property",
+        "value": "PrivatePropertyTagWrite\\Foo::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 38,
           "endColumn": 42
         }
       },
@@ -32690,26 +28962,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PromotedPropertiesExistingClasses",
+        "type": "static_property",
+        "value": "PromotedPropertiesExistingClasses\\Foo::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 48,
           "endColumn": 52
         }
       },
@@ -32775,26 +29031,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PromotedPropertiesExistingClasses",
+        "type": "static_property",
+        "value": "PromotedPropertiesExistingClasses\\Foo::$dolor",
         "location": {
           "startColumn": 9,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dolor",
-        "location": {
-          "startColumn": 48,
           "endColumn": 54
         }
       },
@@ -32884,26 +29124,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PromotedPropertiesExistingClasses",
+        "type": "static_property",
+        "value": "PromotedPropertiesExistingClasses\\Foo::$ipsum",
         "location": {
           "startColumn": 9,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum",
-        "location": {
-          "startColumn": 48,
           "endColumn": 54
         }
       },
@@ -32993,26 +29217,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PromotedPropertiesExistingClasses",
+        "type": "static_property",
+        "value": "PromotedPropertiesExistingClasses\\Foo::$lorem",
         "location": {
           "startColumn": 9,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem",
-        "location": {
-          "startColumn": 48,
           "endColumn": 54
         }
       },
@@ -33078,26 +29286,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedDefaultValuesTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedDefaultValuesTypes\\Foo::$stringPropertyWithWrongDefaultValue",
         "location": {
           "startColumn": 9,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$stringPropertyWithWrongDefaultValue",
-        "location": {
-          "startColumn": 51,
           "endColumn": 87
         }
       },
@@ -33211,26 +29403,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\AppendToArrayAccess::$collection2",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AppendToArrayAccess",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$collection2",
-        "location": {
-          "startColumn": 54,
           "endColumn": 66
         }
       },
@@ -33368,26 +29544,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\AssignRefFoo::$stringProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AssignRefFoo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$stringProperty",
-        "location": {
-          "startColumn": 47,
           "endColumn": 62
         }
       },
@@ -33469,26 +29629,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$fooProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$fooProperty",
-        "location": {
-          "startColumn": 38,
           "endColumn": 50
         }
       },
@@ -33586,26 +29730,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$intProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$intProperty",
-        "location": {
-          "startColumn": 38,
           "endColumn": 50
         }
       },
@@ -33687,26 +29815,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$stringProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$stringProperty",
-        "location": {
-          "startColumn": 38,
           "endColumn": 53
         }
       },
@@ -33788,26 +29900,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$unionPropertySelf",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unionPropertySelf",
-        "location": {
-          "startColumn": 38,
           "endColumn": 56
         }
       },
@@ -34017,26 +30113,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$unionPropertySelf",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unionPropertySelf",
-        "location": {
-          "startColumn": 38,
           "endColumn": 56
         }
       },
@@ -34246,26 +30326,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$unionPropertySelf",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$unionPropertySelf",
-        "location": {
-          "startColumn": 38,
           "endColumn": 56
         }
       },
@@ -34515,26 +30579,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Ipsum::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 40,
           "endColumn": 44
         }
       },
@@ -34632,26 +30680,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Ipsum::$parentStringProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$parentStringProperty",
-        "location": {
-          "startColumn": 40,
           "endColumn": 61
         }
       },
@@ -34733,26 +30765,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\ListAssign::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ListAssign",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 45,
           "endColumn": 49
         }
       },
@@ -34834,26 +30850,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\ParamOutAssign::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ParamOutAssign",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 49,
           "endColumn": 53
         }
       },
@@ -34959,26 +30959,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\ParamOutAssign::$foo2",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ParamOutAssign",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo2",
-        "location": {
-          "startColumn": 49,
           "endColumn": 54
         }
       },
@@ -35188,26 +31172,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\ParamOutAssign::$foo2",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ParamOutAssign",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo2",
-        "location": {
-          "startColumn": 49,
           "endColumn": 54
         }
       },
@@ -35337,26 +31305,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\PostInc::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PostInc",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 42,
           "endColumn": 46
         }
       },
@@ -35518,26 +31470,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\PostInc::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PostInc",
-        "location": {
-          "startColumn": 33,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 42,
           "endColumn": 46
         }
       },
@@ -35699,26 +31635,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoObject\\Foo::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 44,
           "endColumn": 48
         }
       },
@@ -35800,26 +31720,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoObject\\Foo::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 44,
           "endColumn": 48
         }
       },
@@ -35933,26 +31837,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoObject\\Foo::$lall",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lall",
-        "location": {
-          "startColumn": 44,
           "endColumn": 49
         }
       },
@@ -36034,26 +31922,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoObject\\Foo::$test",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$test",
-        "location": {
-          "startColumn": 44,
           "endColumn": 49
         }
       },
@@ -36151,26 +32023,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoObject\\FooBar::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooBar",
-        "location": {
-          "startColumn": 39,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 47,
           "endColumn": 51
         }
       },
@@ -36252,26 +32108,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesNativeTypes",
+        "type": "static_property",
+        "value": "PropertiesNativeTypes\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -36361,26 +32201,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesNativeTypes",
+        "type": "static_property",
+        "value": "PropertiesNativeTypes\\Foo::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -36470,26 +32294,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 30,
           "endColumn": 34
         }
       },
@@ -36579,26 +32387,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$bars",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bars",
-        "location": {
-          "startColumn": 30,
           "endColumn": 35
         }
       },
@@ -36688,26 +32480,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$dolors",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dolors",
-        "location": {
-          "startColumn": 30,
           "endColumn": 37
         }
       },
@@ -36797,26 +32573,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$dolors",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$dolors",
-        "location": {
-          "startColumn": 30,
           "endColumn": 37
         }
       },
@@ -36906,26 +32666,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$fooWithWrongCase",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$fooWithWrongCase",
-        "location": {
-          "startColumn": 30,
           "endColumn": 47
         }
       },
@@ -37015,26 +32759,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$fooWithWrongCase",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$fooWithWrongCase",
-        "location": {
-          "startColumn": 30,
           "endColumn": 47
         }
       },
@@ -37124,26 +32852,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$nonexistentClassInGenericObjectType",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonexistentClassInGenericObjectType",
-        "location": {
-          "startColumn": 30,
           "endColumn": 66
         }
       },
@@ -37233,26 +32945,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$nonexistentClassInGenericObjectType",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonexistentClassInGenericObjectType",
-        "location": {
-          "startColumn": 30,
           "endColumn": 66
         }
       },
@@ -37342,26 +33038,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesTypes",
+        "type": "static_property",
+        "value": "PropertiesTypes\\Foo::$withTrait",
         "location": {
           "startColumn": 9,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$withTrait",
-        "location": {
-          "startColumn": 30,
           "endColumn": 40
         }
       },
@@ -37427,26 +33107,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyIntersectionTypes",
+        "type": "static_property",
+        "value": "PropertyIntersectionTypes\\Test::$prop2",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop2",
-        "location": {
-          "startColumn": 41,
           "endColumn": 47
         }
       },
@@ -37504,26 +33168,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyIntersectionTypes",
+        "type": "static_property",
+        "value": "PropertyIntersectionTypes\\Test::$prop3",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Test",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$prop3",
-        "location": {
-          "startColumn": 41,
           "endColumn": 47
         }
       },
@@ -37581,26 +33229,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyOverrideAttr",
+        "type": "static_property",
+        "value": "PropertyOverrideAttr\\Bar::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 35,
           "endColumn": 39
         }
       },
@@ -37714,26 +33346,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyOverrideAttr",
+        "type": "static_property",
+        "value": "PropertyOverrideAttr\\Baz::$bar",
         "location": {
           "startColumn": 9,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 35,
           "endColumn": 39
         }
       },
@@ -37847,26 +33463,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyOverrideAttr",
+        "type": "static_property",
+        "value": "PropertyOverrideAttr\\Lorem::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Lorem",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 37,
           "endColumn": 41
         }
       },
@@ -37887,26 +33487,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyOverrideAttr",
+        "type": "static_property",
+        "value": "PropertyOverrideAttr\\Foo::$foo",
         "location": {
           "startColumn": 61,
-          "endColumn": 81
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 82,
-          "endColumn": 85
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 87,
           "endColumn": 91
         }
       },
@@ -37996,26 +33580,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTypeAfterUnset",
+        "type": "static_property",
+        "value": "PropertyTypeAfterUnset\\Foo::$listProp",
         "location": {
           "startColumn": 9,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$listProp",
-        "location": {
-          "startColumn": 37,
           "endColumn": 46
         }
       },
@@ -38201,26 +33769,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTypeAfterUnset",
+        "type": "static_property",
+        "value": "PropertyTypeAfterUnset\\Foo::$nestedListProp",
         "location": {
           "startColumn": 9,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nestedListProp",
-        "location": {
-          "startColumn": 37,
           "endColumn": 52
         }
       },
@@ -38454,26 +34006,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertyTypeAfterUnset",
+        "type": "static_property",
+        "value": "PropertyTypeAfterUnset\\Foo::$nonEmpty",
         "location": {
           "startColumn": 9,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$nonEmpty",
-        "location": {
-          "startColumn": 37,
           "endColumn": 46
         }
       },
@@ -38619,26 +34155,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadingWriteOnlyProperties",
+        "type": "static_property",
+        "value": "ReadingWriteOnlyProperties\\Foo::$writeOnlyProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 36,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$writeOnlyProperty",
-        "location": {
-          "startColumn": 41,
           "endColumn": 59
         }
       },
@@ -38688,26 +34208,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "WritingToReadOnlyProperties",
+        "type": "static_property",
+        "value": "WritingToReadOnlyProperties\\Foo::$readOnlyProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readOnlyProperty",
-        "location": {
-          "startColumn": 42,
           "endColumn": 59
         }
       },
@@ -38757,26 +34261,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "WritingToReadOnlyProperties",
+        "type": "static_property",
+        "value": "WritingToReadOnlyProperties\\Foo::$usualProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$usualProperty",
-        "location": {
-          "startColumn": 42,
           "endColumn": 56
         }
       },
@@ -38858,26 +34346,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "WritingToReadOnlyProperties",
+        "type": "static_property",
+        "value": "WritingToReadOnlyProperties\\Foo::$writeOnlyProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$writeOnlyProperty",
-        "location": {
-          "startColumn": 42,
           "endColumn": 60
         }
       },
@@ -38959,26 +34431,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "WritingToReadOnlyProperties",
+        "type": "static_property",
+        "value": "WritingToReadOnlyProperties\\Foo::$writeOnlyProperty",
         "location": {
           "startColumn": 9,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$writeOnlyProperty",
-        "location": {
-          "startColumn": 42,
           "endColumn": 60
         }
       },
@@ -40143,18 +35599,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "stdClass",
+        "type": "static_property",
+        "value": "stdClass::$foo",
         "location": {
           "startColumn": 26,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 36,
           "endColumn": 40
         }
       },
@@ -40212,26 +35660,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ProtectedDolor::$anotherPublicFoo",
         "location": {
           "startColumn": 19,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ProtectedDolor",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherPublicFoo",
-        "location": {
-          "startColumn": 54,
           "endColumn": 71
         }
       },
@@ -40260,26 +35692,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Dolor::$anotherPublicFoo",
         "location": {
           "startColumn": 99,
-          "endColumn": 117
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 118,
-          "endColumn": 123
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$anotherPublicFoo",
-        "location": {
-          "startColumn": 125,
           "endColumn": 142
         }
       },
@@ -40345,26 +35761,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ProtectedDolor::$publicFoo",
         "location": {
           "startColumn": 19,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ProtectedDolor",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicFoo",
-        "location": {
-          "startColumn": 54,
           "endColumn": 64
         }
       },
@@ -40393,26 +35793,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Dolor::$publicFoo",
         "location": {
           "startColumn": 92,
-          "endColumn": 110
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Dolor",
-        "location": {
-          "startColumn": 111,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicFoo",
-        "location": {
-          "startColumn": 118,
           "endColumn": 128
         }
       },
@@ -40571,34 +35955,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug10523\\MultipleWrites::$userAccount",
         "location": {
           "startColumn": 18,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "number",
-        "value": "10523",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MultipleWrites",
-        "location": {
-          "startColumn": 27,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$userAccount",
-        "location": {
-          "startColumn": 43,
           "endColumn": 55
         }
       },
@@ -40656,34 +36016,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug6773\\Repository::$data",
         "location": {
           "startColumn": 18,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "number",
-        "value": "6773",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Repository",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$data",
-        "location": {
-          "startColumn": 38,
           "endColumn": 43
         }
       },
@@ -40765,34 +36101,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug8101\\B::$myProp",
         "location": {
           "startColumn": 18,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "number",
-        "value": "8101",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$myProp",
-        "location": {
-          "startColumn": 29,
           "endColumn": 36
         }
       },
@@ -40850,34 +36162,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug9863\\ReadonlyChildWithoutIsset::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "number",
-        "value": "9863",
-        "location": {
-          "startColumn": 21,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyChildWithoutIsset",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 53,
           "endColumn": 57
         }
       },
@@ -40935,34 +36223,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Feature",
+        "type": "static_property",
+        "value": "Feature7648\\Request::$offset",
         "location": {
           "startColumn": 18,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "number",
-        "value": "7648",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Request",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$offset",
-        "location": {
-          "startColumn": 39,
           "endColumn": 46
         }
       },
@@ -41044,26 +36308,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\AdditionalAssignOfReadonlyPromotedProperty::$x",
         "location": {
           "startColumn": 18,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "AdditionalAssignOfReadonlyPromotedProperty",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 90
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$x",
-        "location": {
-          "startColumn": 92,
           "endColumn": 94
         }
       },
@@ -41121,26 +36369,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\Foo::$doubleAssigned",
         "location": {
           "startColumn": 18,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$doubleAssigned",
-        "location": {
-          "startColumn": 53,
           "endColumn": 68
         }
       },
@@ -41198,26 +36430,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "MissingReadOnlyPropertyAssign",
+        "type": "static_property",
+        "value": "MissingReadOnlyPropertyAssign\\FooTraitClass::$doubleAssigned",
         "location": {
           "startColumn": 18,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooTraitClass",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$doubleAssigned",
-        "location": {
-          "startColumn": 63,
           "endColumn": 78
         }
       },
@@ -41275,34 +36491,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyChild2::$readWrite",
         "location": {
           "startColumn": 18,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyChild",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readWrite",
-        "location": {
-          "startColumn": 53,
           "endColumn": 63
         }
       },
@@ -41331,26 +36523,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyParent::$readWrite",
         "location": {
           "startColumn": 93,
-          "endColumn": 111
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyParent",
-        "location": {
-          "startColumn": 112,
-          "endColumn": 126
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readWrite",
-        "location": {
-          "startColumn": 128,
           "endColumn": 138
         }
       },
@@ -41384,26 +36560,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyChild::$readWrite",
         "location": {
           "startColumn": 18,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyChild",
-        "location": {
-          "startColumn": 37,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readWrite",
-        "location": {
-          "startColumn": 52,
           "endColumn": 62
         }
       },
@@ -41432,26 +36592,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyParent::$readWrite",
         "location": {
           "startColumn": 92,
-          "endColumn": 110
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyParent",
-        "location": {
-          "startColumn": 111,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readWrite",
-        "location": {
-          "startColumn": 127,
           "endColumn": 137
         }
       },
@@ -41485,26 +36629,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRef",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRef\\Foo::$bar",
         "location": {
           "startColumn": 18,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 49,
           "endColumn": 53
         }
       },
@@ -41570,26 +36698,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadOnlyPropertyAssignRef",
+        "type": "static_property",
+        "value": "ReadOnlyPropertyAssignRef\\Foo::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 49,
           "endColumn": 53
         }
       },
@@ -41655,26 +36767,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyClassPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyClassPropertyAssign\\Foo::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 51,
           "endColumn": 55
         }
       },
@@ -41756,26 +36852,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\ArrayAccessPropertyFetch::$storage",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ArrayAccessPropertyFetch",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 65
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$storage",
-        "location": {
-          "startColumn": 67,
           "endColumn": 75
         }
       },
@@ -41857,26 +36937,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\Foo::$bar",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 46,
           "endColumn": 50
         }
       },
@@ -41966,26 +37030,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\Foo::$baz",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 46,
           "endColumn": 50
         }
       },
@@ -42075,26 +37123,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\Foo::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 46,
           "endColumn": 50
         }
       },
@@ -42176,26 +37208,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\FooArrays::$details",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooArrays",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$details",
-        "location": {
-          "startColumn": 52,
           "endColumn": 60
         }
       },
@@ -42277,26 +37293,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\ListAssign::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ListAssign",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 53,
           "endColumn": 57
         }
       },
@@ -42378,26 +37378,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\NotThis::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NotThis",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 50,
           "endColumn": 54
         }
       },
@@ -42471,26 +37455,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ReadonlyPropertyAssign",
+        "type": "static_property",
+        "value": "ReadonlyPropertyAssign\\PostInc::$foo",
         "location": {
           "startColumn": 18,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PostInc",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 50,
           "endColumn": 54
         }
       },
@@ -42572,34 +37540,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RedeclarePropertyOfReadonlyClass",
+        "type": "static_property",
+        "value": "RedeclarePropertyOfReadonlyClass\\B1::$promotedProp",
         "location": {
           "startColumn": 18,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "number",
-        "value": "1",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$promotedProp",
-        "location": {
-          "startColumn": 55,
           "endColumn": 68
         }
       },
@@ -42774,34 +37718,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RedeclareReadonlyProperty",
+        "type": "static_property",
+        "value": "RedeclareReadonlyProperty\\B1::$myProp",
         "location": {
           "startColumn": 18,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "number",
-        "value": "1",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$myProp",
-        "location": {
-          "startColumn": 48,
           "endColumn": 55
         }
       },
@@ -42859,34 +37779,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RedeclareReadonlyProperty",
+        "type": "static_property",
+        "value": "RedeclareReadonlyProperty\\B5::$myProp",
         "location": {
           "startColumn": 18,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "number",
-        "value": "5",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$myProp",
-        "location": {
-          "startColumn": 48,
           "endColumn": 55
         }
       },
@@ -42944,34 +37840,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "RedeclareReadonlyProperty",
+        "type": "static_property",
+        "value": "RedeclareReadonlyProperty\\B7::$myProp",
         "location": {
           "startColumn": 18,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "B",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "number",
-        "value": "7",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$myProp",
-        "location": {
-          "startColumn": 48,
           "endColumn": 55
         }
       },
@@ -43220,34 +38092,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyChild2::$readOnly",
         "location": {
           "startColumn": 19,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyChild",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readOnly",
-        "location": {
-          "startColumn": 54,
           "endColumn": 63
         }
       },
@@ -43276,26 +38124,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyParent::$readOnly",
         "location": {
           "startColumn": 92,
-          "endColumn": 110
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyParent",
-        "location": {
-          "startColumn": 111,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readOnly",
-        "location": {
-          "startColumn": 127,
           "endColumn": 136
         }
       },
@@ -43329,26 +38161,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyChild::$readOnly",
         "location": {
           "startColumn": 19,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyChild",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readOnly",
-        "location": {
-          "startColumn": 53,
           "endColumn": 62
         }
       },
@@ -43377,26 +38193,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\ReadonlyParent::$readOnly",
         "location": {
           "startColumn": 91,
-          "endColumn": 109
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ReadonlyParent",
-        "location": {
-          "startColumn": 110,
-          "endColumn": 124
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$readOnly",
-        "location": {
-          "startColumn": 126,
           "endColumn": 135
         }
       },
@@ -43491,18 +38291,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessWithStatic",
+        "type": "static_property",
+        "value": "AccessWithStatic::$bar",
         "location": {
           "startColumn": 35,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$bar",
-        "location": {
-          "startColumn": 53,
           "endColumn": 57
         }
       },
@@ -43560,50 +38352,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug8668Bis\\Sample2::$sample",
         "location": {
           "startColumn": 35,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "number",
-        "value": "8668",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bis",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Sample",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$sample",
-        "location": {
-          "startColumn": 55,
           "endColumn": 62
         }
       },
@@ -43661,42 +38413,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug8668Bis\\Sample::$sample",
         "location": {
           "startColumn": 35,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "number",
-        "value": "8668",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bis",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Sample",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$sample",
-        "location": {
-          "startColumn": 54,
           "endColumn": 61
         }
       },
@@ -43754,18 +38474,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ClassOrString",
+        "type": "static_property",
+        "value": "ClassOrString::$instanceProperty",
         "location": {
           "startColumn": 35,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$instanceProperty",
-        "location": {
-          "startColumn": 50,
           "endColumn": 67
         }
       },
@@ -43823,18 +38535,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "FooAccessStaticProperties",
+        "type": "static_property",
+        "value": "FooAccessStaticProperties::$loremIpsum",
         "location": {
           "startColumn": 35,
-          "endColumn": 60
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$loremIpsum",
-        "location": {
-          "startColumn": 62,
           "endColumn": 73
         }
       },
@@ -43892,18 +38596,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ParentClassWithInstanceProperty",
+        "type": "static_property",
+        "value": "ParentClassWithInstanceProperty::$i",
         "location": {
           "startColumn": 35,
-          "endColumn": 66
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 68,
           "endColumn": 70
         }
       },
@@ -43937,42 +38633,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777Static\\Bar::$foo",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Static",
-        "location": {
-          "startColumn": 23,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 35,
           "endColumn": 39
         }
       },
@@ -44158,50 +38822,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777Static\\Ipsum2::$ipsum2",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Static",
-        "location": {
-          "startColumn": 23,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum2",
-        "location": {
-          "startColumn": 38,
           "endColumn": 45
         }
       },
@@ -44435,50 +39059,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777Static\\Ipsum2::$lorem2",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Static",
-        "location": {
-          "startColumn": 23,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lorem2",
-        "location": {
-          "startColumn": 38,
           "endColumn": 45
         }
       },
@@ -44712,50 +39296,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777Static\\Ipsum3::$ipsum3",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Static",
-        "location": {
-          "startColumn": 23,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "number",
-        "value": "3",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 36
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum3",
-        "location": {
-          "startColumn": 38,
           "endColumn": 45
         }
       },
@@ -44989,42 +39533,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug3777Static\\Ipsum::$ipsum",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "3777",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Static",
-        "location": {
-          "startColumn": 23,
-          "endColumn": 29
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 30,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$ipsum",
-        "location": {
-          "startColumn": 37,
           "endColumn": 43
         }
       },
@@ -45242,34 +39754,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug9384\\Deprecation::$type",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "9384",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 23
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Deprecation",
-        "location": {
-          "startColumn": 24,
-          "endColumn": 35
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$type",
-        "location": {
-          "startColumn": 37,
           "endColumn": 42
         }
       },
@@ -45415,26 +39903,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Bar::$protectedFoo",
         "location": {
           "startColumn": 16,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$protectedFoo",
-        "location": {
-          "startColumn": 40,
           "endColumn": 53
         }
       },
@@ -45471,26 +39943,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Foo::$protectedFoo",
         "location": {
           "startColumn": 84,
-          "endColumn": 102
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 103,
-          "endColumn": 106
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$protectedFoo",
-        "location": {
-          "startColumn": 108,
           "endColumn": 121
         }
       },
@@ -45524,26 +39980,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Bar::$publicFoo",
         "location": {
           "startColumn": 16,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicFoo",
-        "location": {
-          "startColumn": 40,
           "endColumn": 50
         }
       },
@@ -45580,26 +40020,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Foo::$publicFoo",
         "location": {
           "startColumn": 81,
-          "endColumn": 99
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 100,
-          "endColumn": 103
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$publicFoo",
-        "location": {
-          "startColumn": 105,
           "endColumn": 115
         }
       },
@@ -45633,26 +40057,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedDefaultValuesTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedDefaultValuesTypes\\Foo::$staticStringPropertyWithWrongDefaultValue",
         "location": {
           "startColumn": 16,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticStringPropertyWithWrongDefaultValue",
-        "location": {
-          "startColumn": 58,
           "endColumn": 100
         }
       },
@@ -45774,26 +40182,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedDefaultValuesTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedDefaultValuesTypes\\Foo::$windowsNtVersions",
         "location": {
           "startColumn": 16,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 53,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$windowsNtVersions",
-        "location": {
-          "startColumn": 58,
           "endColumn": 76
         }
       },
@@ -46011,26 +40403,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Foo::$staticStringProperty",
         "location": {
           "startColumn": 16,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticStringProperty",
-        "location": {
-          "startColumn": 45,
           "endColumn": 66
         }
       },
@@ -46120,26 +40496,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Ipsum::$fooStatic",
         "location": {
           "startColumn": 16,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$fooStatic",
-        "location": {
-          "startColumn": 47,
           "endColumn": 57
         }
       },
@@ -46245,26 +40605,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesAssignedTypes",
+        "type": "static_property",
+        "value": "PropertiesAssignedTypes\\Ipsum::$parentStaticStringProperty",
         "location": {
           "startColumn": 16,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Ipsum",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$parentStaticStringProperty",
-        "location": {
-          "startColumn": 47,
           "endColumn": 74
         }
       },
@@ -46354,26 +40698,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoStaticObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoStaticObject\\Foo::$foo",
         "location": {
           "startColumn": 16,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 57,
           "endColumn": 61
         }
       },
@@ -46463,26 +40791,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoStaticObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoStaticObject\\Foo::$lall",
         "location": {
           "startColumn": 16,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$lall",
-        "location": {
-          "startColumn": 57,
           "endColumn": 62
         }
       },
@@ -46588,26 +40900,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "PropertiesFromArrayIntoStaticObject",
+        "type": "static_property",
+        "value": "PropertiesFromArrayIntoStaticObject\\FooBar::$foo",
         "location": {
           "startColumn": 16,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooBar",
-        "location": {
-          "startColumn": 52,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 60,
           "endColumn": 64
         }
       },
@@ -46713,42 +41009,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Typed2Child::$foo",
         "location": {
           "startColumn": 24,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Typed",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Child",
-        "location": {
-          "startColumn": 49,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 56,
           "endColumn": 60
         }
       },
@@ -46833,34 +41097,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "OverridingProperty",
+        "type": "static_property",
+        "value": "OverridingProperty\\Typed2::$foo",
         "location": {
           "startColumn": 112,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Typed",
-        "location": {
-          "startColumn": 131,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 136,
-          "endColumn": 137
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 139,
           "endColumn": 143
         }
       },
@@ -46918,26 +41158,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "AccessPrivatePropertyThroughStatic",
+        "type": "static_property",
+        "value": "AccessPrivatePropertyThroughStatic\\Foo::$foo",
         "location": {
           "startColumn": 34,
-          "endColumn": 68
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 69,
-          "endColumn": 72
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 74,
           "endColumn": 78
         }
       },

--- a/test/__snapshots__/2.2.x/TooWideTypehints.snap
+++ b/test/__snapshots__/2.2.x/TooWideTypehints.snap
@@ -8128,26 +8128,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TooWidePropertyType",
+        "type": "static_property",
+        "value": "TooWidePropertyType\\Bar::$c",
         "location": {
           "startColumn": 9,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$c",
-        "location": {
-          "startColumn": 34,
           "endColumn": 36
         }
       },
@@ -8317,26 +8301,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TooWidePropertyType",
+        "type": "static_property",
+        "value": "TooWidePropertyType\\Bar::$d",
         "location": {
           "startColumn": 9,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$d",
-        "location": {
-          "startColumn": 34,
           "endColumn": 36
         }
       },
@@ -8506,26 +8474,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TooWidePropertyType",
+        "type": "static_property",
+        "value": "TooWidePropertyType\\Foo::$barr",
         "location": {
           "startColumn": 9,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$barr",
-        "location": {
-          "startColumn": 34,
           "endColumn": 39
         }
       },
@@ -8695,26 +8647,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TooWidePropertyType",
+        "type": "static_property",
+        "value": "TooWidePropertyType\\Foo::$baz",
         "location": {
           "startColumn": 9,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$baz",
-        "location": {
-          "startColumn": 34,
           "endColumn": 38
         }
       },
@@ -8884,26 +8820,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "TooWidePropertyType",
+        "type": "static_property",
+        "value": "TooWidePropertyType\\Foo::$foo",
         "location": {
           "startColumn": 9,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 32
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$foo",
-        "location": {
-          "startColumn": 34,
           "endColumn": 38
         }
       },
@@ -10013,42 +9933,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13384Phpdoc\\ShutdownHandlerPhpdocTypes::$registered",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "13384",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Phpdoc",
-        "location": {
-          "startColumn": 24,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ShutdownHandlerPhpdocTypes",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$registered",
-        "location": {
-          "startColumn": 59,
           "endColumn": 70
         }
       },
@@ -10210,34 +10098,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13384\\ShutdownHandlerFalseDefault::$registered",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "13384",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ShutdownHandlerFalseDefault",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$registered",
-        "location": {
-          "startColumn": 54,
           "endColumn": 65
         }
       },
@@ -10399,34 +10263,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug13384\\ShutdownHandlerTrueDefault::$registered",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "13384",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "ShutdownHandlerTrueDefault",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$registered",
-        "location": {
-          "startColumn": 53,
           "endColumn": 64
         }
       },
@@ -10668,26 +10508,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "NestedTooWidePropertyType",
+        "type": "static_property",
+        "value": "NestedTooWidePropertyType\\Foo::$a",
         "location": {
           "startColumn": 41,
-          "endColumn": 66
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 67,
-          "endColumn": 70
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$a",
-        "location": {
-          "startColumn": 72,
           "endColumn": 74
         }
       },

--- a/test/__snapshots__/2.2.x/Traits.snap
+++ b/test/__snapshots__/2.2.x/Traits.snap
@@ -367,34 +367,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstantsTypes",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstantsTypes\\Baz::BAR_CONST",
         "location": {
           "startColumn": 9,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 49,
           "endColumn": 54
         }
       },
@@ -439,34 +415,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstantsTypes",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstantsTypes\\Foo::BAR_CONST",
         "location": {
           "startColumn": 81,
-          "endColumn": 111
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 112,
-          "endColumn": 115
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "BAR",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 120
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 121,
           "endColumn": 126
         }
       },
@@ -540,34 +492,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstantsTypes",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstantsTypes\\Baz::FOO_CONST",
         "location": {
           "startColumn": 9,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Baz",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 43
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 49,
           "endColumn": 54
         }
       },
@@ -612,34 +540,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstantsTypes",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstantsTypes\\Foo::FOO_CONST",
         "location": {
           "startColumn": 81,
-          "endColumn": 111
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 112,
-          "endColumn": 115
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 117,
-          "endColumn": 120
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 121,
           "endColumn": 126
         }
       },
@@ -777,34 +681,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstantsTypes",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstantsTypes\\Lorem::FOO_CONST",
         "location": {
           "startColumn": 9,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Lorem",
-        "location": {
-          "startColumn": 40,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 51,
           "endColumn": 56
         }
       },
@@ -825,34 +705,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstantsTypes",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstantsTypes\\Foo::FOO_CONST",
         "location": {
           "startColumn": 77,
-          "endColumn": 107
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 108,
-          "endColumn": 111
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FOO",
-        "location": {
-          "startColumn": 113,
-          "endColumn": 116
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONST",
-        "location": {
-          "startColumn": 117,
           "endColumn": 122
         }
       },
@@ -982,42 +838,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar9::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 9,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "number",
-        "value": "9",
-        "location": {
-          "startColumn": 38,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 48,
           "endColumn": 56
         }
       },
@@ -1062,34 +886,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 90,
-          "endColumn": 115
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 116,
-          "endColumn": 119
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 121,
-          "endColumn": 127
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 128,
           "endColumn": 136
         }
       },
@@ -1328,42 +1128,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar8::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 15,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 41,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "number",
-        "value": "8",
-        "location": {
-          "startColumn": 44,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 47,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 54,
           "endColumn": 62
         }
       },
@@ -1400,34 +1168,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 93,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 119,
-          "endColumn": 122
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 131,
           "endColumn": 139
         }
       },
@@ -1509,50 +1253,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar7::PUBLIC_FINAL_CONSTANT",
         "location": {
           "startColumn": 19,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "number",
-        "value": "7",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FINAL",
-        "location": {
-          "startColumn": 58,
-          "endColumn": 63
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 64,
           "endColumn": 72
         }
       },
@@ -1581,42 +1285,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PUBLIC_FINAL_CONSTANT",
         "location": {
           "startColumn": 99,
-          "endColumn": 124
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 125,
-          "endColumn": 128
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 130,
-          "endColumn": 136
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FINAL",
-        "location": {
-          "startColumn": 137,
-          "endColumn": 142
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 143,
           "endColumn": 151
         }
       },
@@ -1839,42 +1511,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar2::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 17,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "number",
-        "value": "2",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 49,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 56,
           "endColumn": 64
         }
       },
@@ -1903,34 +1543,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 92,
-          "endColumn": 117
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 118,
-          "endColumn": 121
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 123,
-          "endColumn": 129
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 130,
           "endColumn": 138
         }
       },
@@ -1996,42 +1612,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar4::PROTECTED_CONSTANT",
         "location": {
           "startColumn": 17,
-          "endColumn": 42
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 43,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "number",
-        "value": "4",
-        "location": {
-          "startColumn": 46,
-          "endColumn": 47
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PROTECTED",
-        "location": {
-          "startColumn": 49,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 59,
           "endColumn": 67
         }
       },
@@ -2060,34 +1644,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PROTECTED_CONSTANT",
         "location": {
           "startColumn": 98,
-          "endColumn": 123
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 127
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PROTECTED",
-        "location": {
-          "startColumn": 129,
-          "endColumn": 138
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 139,
           "endColumn": 147
         }
       },
@@ -2153,42 +1713,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar5::PRIVATE_CONSTANT",
         "location": {
           "startColumn": 19,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "number",
-        "value": "5",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 49
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PRIVATE",
-        "location": {
-          "startColumn": 51,
-          "endColumn": 58
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 59,
           "endColumn": 67
         }
       },
@@ -2217,34 +1745,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PRIVATE_CONSTANT",
         "location": {
           "startColumn": 96,
-          "endColumn": 121
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 122,
-          "endColumn": 125
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PRIVATE",
-        "location": {
-          "startColumn": 127,
-          "endColumn": 134
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 135,
           "endColumn": 143
         }
       },
@@ -2310,34 +1814,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 19,
-          "endColumn": 44
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 48
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 50,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 57,
           "endColumn": 65
         }
       },
@@ -2366,34 +1846,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PUBLIC_CONSTANT",
         "location": {
           "startColumn": 93,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 119,
-          "endColumn": 122
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PUBLIC",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 130
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 131,
           "endColumn": 139
         }
       },
@@ -2459,42 +1915,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar3::PROTECTED_CONSTANT",
         "location": {
           "startColumn": 16,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "number",
-        "value": "3",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PROTECTED",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 57
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 58,
           "endColumn": 66
         }
       },
@@ -2523,34 +1947,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PROTECTED_CONSTANT",
         "location": {
           "startColumn": 97,
-          "endColumn": 122
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 123,
-          "endColumn": 126
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PROTECTED",
-        "location": {
-          "startColumn": 128,
-          "endColumn": 137
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 138,
           "endColumn": 146
         }
       },
@@ -2616,42 +2016,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Bar6::PRIVATE_CONSTANT",
         "location": {
           "startColumn": 16,
-          "endColumn": 41
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Bar",
-        "location": {
-          "startColumn": 42,
-          "endColumn": 45
-        }
-      },
-      {
-        "type": "number",
-        "value": "6",
-        "location": {
-          "startColumn": 45,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PRIVATE",
-        "location": {
-          "startColumn": 48,
-          "endColumn": 55
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 56,
           "endColumn": 64
         }
       },
@@ -2680,34 +2048,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "ConflictingTraitConstants",
+        "type": "static_constant",
+        "value": "ConflictingTraitConstants\\Foo::PRIVATE_CONSTANT",
         "location": {
           "startColumn": 93,
-          "endColumn": 118
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 119,
-          "endColumn": 122
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PRIVATE",
-        "location": {
-          "startColumn": 124,
-          "endColumn": 131
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "CONSTANT",
-        "location": {
-          "startColumn": 132,
           "endColumn": 140
         }
       },

--- a/test/__snapshots__/2.2.x/Variables.snap
+++ b/test/__snapshots__/2.2.x/Variables.snap
@@ -1007,34 +1007,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12421\\PhpdocImmutableClass::$y",
         "location": {
           "startColumn": 23,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "12421",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PhpdocImmutableClass",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 52
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$y",
-        "location": {
-          "startColumn": 54,
           "endColumn": 56
         }
       },
@@ -1084,34 +1060,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12421\\PhpdocReadonlyClass::$y",
         "location": {
           "startColumn": 23,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "12421",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PhpdocReadonlyClass",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 51
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$y",
-        "location": {
-          "startColumn": 53,
           "endColumn": 55
         }
       },
@@ -1161,34 +1113,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12421\\PhpdocReadonlyProperty::$y",
         "location": {
           "startColumn": 23,
-          "endColumn": 26
-        }
-      },
-      {
-        "type": "number",
-        "value": "12421",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "PhpdocReadonlyProperty",
-        "location": {
-          "startColumn": 32,
-          "endColumn": 54
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$y",
-        "location": {
-          "startColumn": 56,
           "endColumn": 58
         }
       },
@@ -1884,34 +1812,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12421\\NativeReadonlyClass::$y",
         "location": {
           "startColumn": 22,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "number",
-        "value": "12421",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NativeReadonlyClass",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 50
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$y",
-        "location": {
-          "startColumn": 52,
           "endColumn": 54
         }
       },
@@ -1961,34 +1865,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug12421\\NativeReadonlyProperty::$y",
         "location": {
           "startColumn": 22,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "number",
-        "value": "12421",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "NativeReadonlyProperty",
-        "location": {
-          "startColumn": 31,
-          "endColumn": 53
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$y",
-        "location": {
-          "startColumn": 55,
           "endColumn": 57
         }
       },
@@ -12122,34 +12002,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14393\\MyClass::$i",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "14393",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClass",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 27,
           "endColumn": 29
         }
       },
@@ -12255,34 +12111,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14393\\MyClass::$i",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "14393",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClass",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 27,
           "endColumn": 29
         }
       },
@@ -12404,34 +12236,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14393\\MyClassPhpDoc::$i",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "14393",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClassPhpDoc",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 33,
           "endColumn": 35
         }
       },
@@ -12537,34 +12345,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14393\\MyClassPhpDoc::$i",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "14393",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 17
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClassPhpDoc",
-        "location": {
-          "startColumn": 18,
-          "endColumn": 31
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 33,
           "endColumn": 35
         }
       },
@@ -12686,34 +12470,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug4846\\Foo::$alwaysString",
         "location": {
           "startColumn": 9,
-          "endColumn": 12
-        }
-      },
-      {
-        "type": "number",
-        "value": "4846",
-        "location": {
-          "startColumn": 12,
-          "endColumn": 16
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 17,
-          "endColumn": 20
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$alwaysString",
-        "location": {
-          "startColumn": 22,
           "endColumn": 35
         }
       },
@@ -12835,26 +12595,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceAssignRule",
+        "type": "static_property",
+        "value": "CoalesceAssignRule\\FooCoalesce::$alwaysNull",
         "location": {
           "startColumn": 9,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$alwaysNull",
-        "location": {
-          "startColumn": 41,
           "endColumn": 52
         }
       },
@@ -12976,26 +12720,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceAssignRule",
+        "type": "static_property",
+        "value": "CoalesceAssignRule\\FooCoalesce::$string",
         "location": {
           "startColumn": 9,
-          "endColumn": 27
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 28,
-          "endColumn": 39
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 41,
           "endColumn": 48
         }
       },
@@ -13117,26 +12845,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceRule",
+        "type": "static_property",
+        "value": "CoalesceRule\\FooCoalesce::$alwaysNull",
         "location": {
           "startColumn": 9,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$alwaysNull",
-        "location": {
-          "startColumn": 35,
           "endColumn": 46
         }
       },
@@ -13258,26 +12970,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceRule",
+        "type": "static_property",
+        "value": "CoalesceRule\\FooCoalesce::$string",
         "location": {
           "startColumn": 9,
-          "endColumn": 21
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 22,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 35,
           "endColumn": 42
         }
       },
@@ -13399,26 +13095,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetNativePropertyTypes",
+        "type": "static_property",
+        "value": "IssetNativePropertyTypes\\Foo::$hasDefaultValue",
         "location": {
           "startColumn": 9,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 34,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$hasDefaultValue",
-        "location": {
-          "startColumn": 39,
           "endColumn": 55
         }
       },
@@ -13524,26 +13204,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetNativePropertyTypes",
+        "type": "static_property",
+        "value": "IssetNativePropertyTypes\\Foo::$isAssignedBefore",
         "location": {
           "startColumn": 9,
-          "endColumn": 33
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "Foo",
-        "location": {
-          "startColumn": 34,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$isAssignedBefore",
-        "location": {
-          "startColumn": 39,
           "endColumn": 56
         }
       },
@@ -13649,26 +13313,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetOrCoalesceOnNonNullableInitializedProperty",
+        "type": "static_property",
+        "value": "IssetOrCoalesceOnNonNullableInitializedProperty\\MoreEmptyCases::$false",
         "location": {
           "startColumn": 9,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MoreEmptyCases",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 71
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$false",
-        "location": {
-          "startColumn": 73,
           "endColumn": 79
         }
       },
@@ -13766,26 +13414,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetOrCoalesceOnNonNullableInitializedProperty",
+        "type": "static_property",
+        "value": "IssetOrCoalesceOnNonNullableInitializedProperty\\MoreEmptyCases::$true",
         "location": {
           "startColumn": 9,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MoreEmptyCases",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 71
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$true",
-        "location": {
-          "startColumn": 73,
           "endColumn": 78
         }
       },
@@ -13883,26 +13515,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetOrCoalesceOnNonNullableInitializedProperty",
+        "type": "static_property",
+        "value": "IssetOrCoalesceOnNonNullableInitializedProperty\\User::$string",
         "location": {
           "startColumn": 9,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "User",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 63,
           "endColumn": 70
         }
       },
@@ -14000,26 +13616,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetOrCoalesceOnNonNullableInitializedProperty",
+        "type": "static_property",
+        "value": "IssetOrCoalesceOnNonNullableInitializedProperty\\User::$string",
         "location": {
           "startColumn": 9,
-          "endColumn": 56
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "User",
-        "location": {
-          "startColumn": 57,
-          "endColumn": 61
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 63,
           "endColumn": 70
         }
       },
@@ -14133,26 +13733,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetRule",
+        "type": "static_property",
+        "value": "IssetRule\\FooCoalesce::$alwaysNull",
         "location": {
           "startColumn": 9,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$alwaysNull",
-        "location": {
-          "startColumn": 32,
           "endColumn": 43
         }
       },
@@ -14258,26 +13842,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetRule",
+        "type": "static_property",
+        "value": "IssetRule\\FooCoalesce::$string",
         "location": {
           "startColumn": 9,
-          "endColumn": 18
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 30
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$string",
-        "location": {
-          "startColumn": 32,
           "endColumn": 39
         }
       },
@@ -14391,34 +13959,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14393\\MyClassStatic::$i",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "14393",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClassStatic",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 40,
           "endColumn": 42
         }
       },
@@ -14532,34 +14076,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "Bug",
+        "type": "static_property",
+        "value": "Bug14393\\MyClassStatic::$i",
         "location": {
           "startColumn": 16,
-          "endColumn": 19
-        }
-      },
-      {
-        "type": "number",
-        "value": "14393",
-        "location": {
-          "startColumn": 19,
-          "endColumn": 24
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "MyClassStatic",
-        "location": {
-          "startColumn": 25,
-          "endColumn": 38
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$i",
-        "location": {
-          "startColumn": 40,
           "endColumn": 42
         }
       },
@@ -14689,26 +14209,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceAssignRule",
+        "type": "static_property",
+        "value": "CoalesceAssignRule\\FooCoalesce::$staticAlwaysNull",
         "location": {
           "startColumn": 16,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticAlwaysNull",
-        "location": {
-          "startColumn": 48,
           "endColumn": 65
         }
       },
@@ -14838,26 +14342,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceAssignRule",
+        "type": "static_property",
+        "value": "CoalesceAssignRule\\FooCoalesce::$staticString",
         "location": {
           "startColumn": 16,
-          "endColumn": 34
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 35,
-          "endColumn": 46
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticString",
-        "location": {
-          "startColumn": 48,
           "endColumn": 61
         }
       },
@@ -14987,26 +14475,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceRule",
+        "type": "static_property",
+        "value": "CoalesceRule\\FooCoalesce::$staticAlwaysNull",
         "location": {
           "startColumn": 16,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticAlwaysNull",
-        "location": {
-          "startColumn": 42,
           "endColumn": 59
         }
       },
@@ -15136,26 +14608,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "CoalesceRule",
+        "type": "static_property",
+        "value": "CoalesceRule\\FooCoalesce::$staticString",
         "location": {
           "startColumn": 16,
-          "endColumn": 28
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 29,
-          "endColumn": 40
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticString",
-        "location": {
-          "startColumn": 42,
           "endColumn": 55
         }
       },
@@ -15285,26 +14741,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetRule",
+        "type": "static_property",
+        "value": "IssetRule\\FooCoalesce::$staticAlwaysNull",
         "location": {
           "startColumn": 16,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticAlwaysNull",
-        "location": {
-          "startColumn": 39,
           "endColumn": 56
         }
       },
@@ -15418,26 +14858,10 @@
         }
       },
       {
-        "type": "common_word",
-        "value": "IssetRule",
+        "type": "static_property",
+        "value": "IssetRule\\FooCoalesce::$staticString",
         "location": {
           "startColumn": 16,
-          "endColumn": 25
-        }
-      },
-      {
-        "type": "common_word",
-        "value": "FooCoalesce",
-        "location": {
-          "startColumn": 26,
-          "endColumn": 37
-        }
-      },
-      {
-        "type": "variable_name",
-        "value": "$staticString",
-        "location": {
-          "startColumn": 39,
           "endColumn": 52
         }
       },

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -228,6 +228,16 @@ describe('sample test', () => {
       m: 'Parameter #1 ...$arg1 of function max expects non-empty-array, array{} given.',
       assertions: [['ellipsis:...', true]],
     },
+    {
+      name: 'parse static property',
+      m: 'Access to property Bug3703\\Foo::$bar.',
+      assertions: [['StaticProperty:Bug3703\\Foo::$bar', true]],
+    },
+    {
+      name: 'parse static constant',
+      m: 'Access to constant MatchEnums\\Foo::THREE.',
+      assertions: [['StaticConstant:MatchEnums\\Foo::THREE', true]],
+    },
   ] satisfies DataSet[];
 
   test.each(dataSet)('$name', ({ m, assertions }) => {


### PR DESCRIPTION
## Summary

Add tokens for static property access (`Foo::$bar`) and class constants (`Foo::BAR`), with namespace support.

### New tokens

| Token | Pattern | Example |
|-------|---------|---------|
| `StaticProperty` | `Class::\$prop` | `Bug3703\Foo::$bar` |
| `StaticConstant` | `Class::CONST` | `MatchEnums\Foo::THREE` |

### Priority

Defined after `StaticMethodName` in the lexer, so `::method()` (with parentheses) takes priority:
1. `StaticMethodName`: `Foo::bar()` — has `()`
2. `StaticProperty`: `Foo::$bar` — has `$`
3. `StaticConstant`: `Foo::BAR` — uppercase identifier

### Coverage

612 occurrences across fixtures (306 in Properties, 58 in Classes, 57 in Methods, etc.)

## Test plan

- [x] All 86 tests pass
- [x] Parser test: `Bug3703\Foo::$bar` → `StaticProperty`
- [x] Parser test: `MatchEnums\Foo::THREE` → `StaticConstant`
- [x] 15 snapshot categories updated
- [x] Biome + tsc pass

https://claude.ai/code/session_01JG7frv8KfH7XD53F6N1z3A