### PR TITLE
Add issue template for wrong parse results

### DIFF
--- a/.github/ISSUE_TEMPLATE/wrong-parse.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-parse.yml
@@ -1,0 +1,62 @@
+name: Wrong parse result
+description: パース結果が期待と異なる場合に報告する
+title: "[wrong-parse] "
+labels: ["wrong-parse"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        パーサーが誤ったトークン列を出力しているケースを報告するためのテンプレートです。
+        `test/__snapshots__/` から該当のトークン列をコピーして貼り付けてください。
+
+  - type: input
+    id: input
+    attributes:
+      label: Input (エラー原文)
+      description: PHPStan が出力したエラーメッセージの原文（1 行）
+      placeholder: 'Method Foo::bar() has parameter $baz with no type specified.'
+    validations:
+      required: true
+
+  - type: input
+    id: snapshot-file
+    attributes:
+      label: Snapshot file
+      description: 該当スナップショットのパス（任意）
+      placeholder: 'test/__snapshots__/2.2.x/Methods.snap'
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual tokens (現状のパース結果)
+      description: スナップショット（または `parse()` の戻り値）をそのまま貼り付けてください
+      render: json
+      placeholder: |
+        [
+          { "type": "common_word", "value": "Method", "location": { "startColumn": 0, "endColumn": 6 } }
+        ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected tokens (期待するパース結果)
+      description: 正しくパースされた場合に得られるべきトークン列。差分が明確な箇所だけでも可
+      render: json
+      placeholder: |
+        [
+          { "type": "method_name", "value": "Foo::bar()", "location": { "startColumn": 7, "endColumn": 17 } }
+        ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 補足（関連する未対応トークン、再現手順、参照先 Issue/PR など）
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ The parser can identify:
 - **Common words**: Regular words in the error message
 - **Punctuation**: Commas and periods
 
+## Reporting Wrong Parse Results
+
+If you find an input that the parser tokenizes incorrectly, please file an issue using the **Wrong parse result** template:
+
+[Open a wrong-parse issue](https://github.com/natsuki-engr/phpstan-error-parser/issues/new?template=wrong-parse.yml)
+
+The form asks for:
+
+- **Input**: the original PHPStan error message
+- **Actual tokens**: the current parse result (you can copy it from `test/__snapshots__/`)
+- **Expected tokens**: what the parse result should look like
+- **Snapshot file** (optional): the relevant file under `test/__snapshots__/`
+
 ## Development
 
 ### Setup


### PR DESCRIPTION
## Summary
This PR adds an issue template and documentation for reporting incorrect parser tokenization results.

## Changes
- **New issue template** (`.github/ISSUE_TEMPLATE/wrong-parse.yml`): Created a structured form for reporting cases where the parser produces incorrect token output
  - Collects the original PHPStan error message
  - Requests actual tokens from the parser (with snapshot file reference)
  - Requests expected tokens for comparison
  - Includes optional notes field for additional context
  - Labeled with "wrong-parse" for easy categorization

- **Updated README.md**: Added a new "Reporting Wrong Parse Results" section
  - Explains when and how to report parsing issues
  - Provides a direct link to open a new wrong-parse issue
  - Documents what information should be included in the report
  - References the snapshot files location for users to find actual output

## Details
The issue template uses Japanese descriptions alongside English to match the project's bilingual documentation style. The form guides users to provide the necessary information (input, actual vs. expected tokens) to help maintainers quickly identify and fix parsing bugs.

https://claude.ai/code/session_01VWkHyryBcMtznz9XniduGy